### PR TITLE
Add Android CI and Relay CI workflows

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,31 @@
+name: Android CI
+
+on:
+  push:
+    branches: [main]
+    paths-ignore: ['relay/**', 'docs/**', 'deploy/**']
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ hashFiles('**/*.gradle.kts', 'gradle/libs.versions.toml') }}
+      - name: Build
+        run: ./gradlew assemble
+      - name: Test
+        run: ./gradlew :core:tunnel:jvmTest :core:mcp:jvmTest :api:testDebugUnitTest :notifications:testDebugUnitTest :work:testDebugUnitTest :app:testDebugUnitTest
+      - name: Lint
+        run: ./gradlew ktlintCheck

--- a/.github/workflows/relay-ci.yml
+++ b/.github/workflows/relay-ci.yml
@@ -1,0 +1,32 @@
+name: Relay CI
+
+on:
+  push:
+    branches: [main]
+    paths: ['relay/**']
+  pull_request:
+    paths: ['relay/**']
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            relay/target
+          key: relay-ci-${{ hashFiles('relay/Cargo.lock') }}
+      - name: Test
+        working-directory: relay
+        run: cargo test
+      - name: Clippy
+        working-directory: relay
+        run: cargo clippy -- -D warnings
+      - name: Format check
+        working-directory: relay
+        run: cargo fmt -- --check


### PR DESCRIPTION
## Summary
- Adds `android-ci.yml` workflow: builds all modules, runs Kotlin unit tests (`:core:tunnel:jvmTest`, `:core:mcp:jvmTest`, plus `testDebugUnitTest` for `:api`, `:notifications`, `:work`, `:app`), and runs ktlint. Triggers on pushes to main (excluding relay/docs/deploy changes) and on PRs.
- Adds `relay-ci.yml` workflow: runs `cargo test`, `cargo clippy`, and `cargo fmt --check` on relay changes only.

## Test plan
- [ ] Verify Android CI workflow appears in Actions tab after merge
- [ ] Verify Relay CI workflow appears in Actions tab after merge
- [ ] Confirm Android CI triggers on a subsequent PR touching Kotlin code
- [ ] Confirm Relay CI triggers on a PR touching relay/ code

🤖 Generated with [Claude Code](https://claude.com/claude-code)