### PR TITLE
Fix #127 P1: Rate-limit /device/authorize OAuth init endpoint

### DIFF
--- a/core/mcp/src/commonMain/kotlin/com/rousecontext/mcp/core/McpRouting.kt
+++ b/core/mcp/src/commonMain/kotlin/com/rousecontext/mcp/core/McpRouting.kt
@@ -304,9 +304,14 @@ internal class McpRoutes(
 
     // Device code authorize -- no auth required
     suspend fun RoutingCall.handleDeviceAuthorize() {
+        if (rejectIfSecurityAlert()) return
         val ri = resolveIntegration()
         if (registry.providerForPath(ri) == null) {
             respond(HttpStatusCode.NotFound)
+            return
+        }
+        if (rateLimiter != null && !rateLimiter.tryAcquire("$ri/device_authorize")) {
+            respond(HttpStatusCode.TooManyRequests)
             return
         }
 

--- a/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/core/RateLimiterTest.kt
+++ b/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/core/RateLimiterTest.kt
@@ -140,6 +140,42 @@ class RateLimiterTest {
     }
 
     @Test
+    fun `device authorize endpoint returns 429 when rate limited`() = testApplication {
+        val registry = InMemoryProviderRegistry()
+        registry.register("health", stubProvider())
+        registry.setEnabled("health", true)
+        val tokenStore = InMemoryTokenStore()
+        val deviceCodeManager = DeviceCodeManager(tokenStore = tokenStore)
+        val clock = FakeClock()
+        val rateLimiter = RateLimiter(maxRequests = 2, windowMs = 60_000L, clock = clock)
+
+        application {
+            configureMcpRouting(
+                registry = registry,
+                tokenStore = tokenStore,
+                deviceCodeManager = deviceCodeManager,
+                hostname = "test.rousecontext.com",
+                integration = "health",
+                clock = clock,
+                rateLimiter = rateLimiter
+            )
+        }
+
+        // First two requests should succeed (not 429)
+        repeat(2) {
+            val response = client.post("/device/authorize")
+            assertTrue(
+                "Request ${it + 1} should not be 429, was ${response.status}",
+                response.status != HttpStatusCode.TooManyRequests
+            )
+        }
+
+        // Third request should be rate limited
+        val response = client.post("/device/authorize")
+        assertEquals(HttpStatusCode.TooManyRequests, response.status)
+    }
+
+    @Test
     fun `token endpoint returns 429 when rate limited`() = testApplication {
         val registry = InMemoryProviderRegistry()
         registry.register("health", stubProvider())


### PR DESCRIPTION
## Summary
- Adds rate-limiting and security-alert gating to `POST /device/authorize`, the one OAuth-init endpoint that was unprotected after #127 P0 (loopback bind).
- `/register` and `/authorize` already had identical gates; this change brings `/device/authorize` in line.
- Uses existing `RateLimiter` wired via `configureMcpRouting(rateLimiter=...)` -- no new config.

## Endpoints audit (before/after)
| Endpoint | Before | After |
| --- | --- | --- |
| POST /register | rate-limited, security-alert-gated | unchanged |
| GET /authorize | rate-limited, security-alert-gated | unchanged |
| POST /device/authorize | **unprotected** | **rate-limited, security-alert-gated** |
| POST /token | rate-limited, security-alert-gated | unchanged |
| GET /authorize/status | not gated (intentional -- polling) | unchanged |
| POST /mcp | Bearer + `mcpRateLimiter` | unchanged |

## Out of scope (tracked in #127)
- P2: internal shared-secret header between McpSessionBridge and Ktor
- P3: AF_UNIX socket replacement for loopback TCP

## Test plan
- [x] New test `device authorize endpoint returns 429 when rate limited` passes; fails before the fix
- [x] Existing `/register`, `/authorize`, `/token` rate-limit tests still pass
- [x] `:core:mcp:jvmTest :core:tunnel:jvmTest :app:testDebugUnitTest ktlintCheck` all green
- [x] detekt: 74 weighted issues -- matches pre-existing baseline

Do not merge; P2/P3 remain open in #127.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>