### PR TITLE
Fix #123: McpTool DSL + migrate :integrations/outreach

### DIFF
--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/McpTool.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/McpTool.kt
@@ -1,0 +1,139 @@
+package com.rousecontext.mcp.tool
+
+import com.rousecontext.mcp.tool.params.BoolParam
+import com.rousecontext.mcp.tool.params.EnumParam
+import com.rousecontext.mcp.tool.params.InstantParam
+import com.rousecontext.mcp.tool.params.IntParam
+import com.rousecontext.mcp.tool.params.ListParam
+import com.rousecontext.mcp.tool.params.MapParam
+import com.rousecontext.mcp.tool.params.ParamDef
+import com.rousecontext.mcp.tool.params.ParamExtract
+import com.rousecontext.mcp.tool.params.StringParam
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+
+/**
+ * Base class for tools. A tool authored against [McpTool] declares its name,
+ * description, and typed parameters via delegate helpers, then overrides
+ * [execute] with the business logic.
+ *
+ * Instances are cheap — the framework creates a fresh one per call, so it is
+ * safe to hold request-scoped state as regular fields. Do not share instances
+ * across calls.
+ *
+ * See `core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/README.md` for
+ * the full authoring guide.
+ */
+abstract class McpTool {
+    abstract val name: String
+    abstract val description: String
+
+    private val params = mutableListOf<ParamBinding<*>>()
+
+    /** Set by [invoke] before [execute] runs, so param delegates can read it. */
+    private var boundArgs: JsonObject? = null
+
+    /** Raw JSON arguments for tools that need to reach beyond the typed params. */
+    protected val rawArgs: JsonObject?
+        get() = boundArgs
+
+    // ---------- param declarations ----------
+
+    protected fun stringParam(name: String, description: String): StringParam =
+        StringParam(name, description)
+
+    protected fun intParam(name: String, description: String): IntParam =
+        IntParam(name, description)
+
+    protected fun boolParam(name: String, description: String): BoolParam =
+        BoolParam(name, description)
+
+    protected fun <T : Enum<T>> enumParam(
+        name: String,
+        description: String,
+        kClass: KClass<T>
+    ): EnumParam<T> = EnumParam(name, description, kClass)
+
+    protected fun mapParam(name: String, description: String): MapParam =
+        MapParam(name, description)
+
+    protected fun listParam(name: String, description: String): ListParam =
+        ListParam(name, description)
+
+    protected fun instantParam(name: String, description: String): InstantParam =
+        InstantParam(name, description)
+
+    // ---------- delegate wiring ----------
+
+    /**
+     * Binding of a [ParamDef] to a concrete property. Holds the most recent
+     * extracted value so [getValue] can return it.
+     */
+    private class ParamBinding<T>(val propertyName: String, val param: ParamDef<T>) :
+        ReadOnlyProperty<McpTool, T?> {
+        var cached: T? = null
+        override fun getValue(thisRef: McpTool, property: KProperty<*>): T? = cached
+    }
+
+    /**
+     * `val packageName by stringParam(...)` — captured here. We register the
+     * binding, then hand back a [ReadOnlyProperty] that reads the cached value.
+     */
+    protected operator fun <T, P : ParamDef<T>> P.provideDelegate(
+        thisRef: McpTool,
+        property: KProperty<*>
+    ): ReadOnlyProperty<McpTool, T?> {
+        val binding = ParamBinding(property.name, this)
+        thisRef.params.add(binding)
+        return binding
+    }
+
+    // ---------- framework-internal ----------
+
+    fun buildSchema(): ToolSchema {
+        val properties = buildJsonObject {
+            for (binding in params) {
+                put(binding.param.name, binding.param.schema())
+            }
+        }
+        val required = params
+            .filter { it.param.required }
+            .map { it.param.name }
+        return ToolSchema(properties = properties, required = required)
+    }
+
+    fun paramNames(): List<String> = params.map { it.param.name }
+
+    /**
+     * Extract all params, populate bindings, and run [execute]. Any exception
+     * thrown by [execute] is caught and converted to [ToolResult.Error] so one
+     * misbehaving tool cannot kill the MCP session.
+     */
+    suspend fun invoke(args: JsonObject?): ToolResult {
+        boundArgs = args
+        for (binding in params) {
+            @Suppress("UNCHECKED_CAST")
+            val b = binding as ParamBinding<Any>
+            when (val ex = b.param.extract(args)) {
+                is ParamExtract.Value -> b.cached = ex.value
+                is ParamExtract.Error -> return ToolResult.Error(ex.message)
+            }
+        }
+        return try {
+            execute()
+        } catch (ce: kotlinx.coroutines.CancellationException) {
+            throw ce
+        } catch (
+            @Suppress("TooGenericExceptionCaught")
+            t: Throwable
+        ) {
+            ToolResult.Error(t.message ?: t::class.qualifiedName ?: "unknown error")
+        }
+    }
+
+    abstract suspend fun execute(): ToolResult
+}

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/McpToolFactory.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/McpToolFactory.kt
@@ -1,0 +1,34 @@
+package com.rousecontext.mcp.tool
+
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+
+/**
+ * Register a tool built with the [McpTool] DSL on an MCP [Server].
+ *
+ * The [factory] is invoked twice at registration — once to read the
+ * (static) name / description / schema, and then once more at each tool call
+ * so each invocation sees a fresh instance. This means you can hold
+ * per-call state as regular fields on your tool subclass without worrying
+ * about concurrent calls stomping on each other.
+ *
+ * ```kotlin
+ * server.registerTool { LaunchAppTool(context, launchNotifier) }
+ * ```
+ */
+fun Server.registerTool(factory: () -> McpTool) {
+    // Introspect once at registration time. Building a fresh instance here
+    // discovers every delegate-backed ParamDef.
+    val prototype = factory()
+    val name = prototype.name
+    val description = prototype.description
+    val schema = prototype.buildSchema()
+
+    addTool(
+        name = name,
+        description = description,
+        inputSchema = schema
+    ) { request ->
+        val tool = factory()
+        tool.invoke(request.params.arguments).toCallToolResult()
+    }
+}

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/README.md
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/README.md
@@ -1,0 +1,120 @@
+# `McpTool` — tool authoring DSL
+
+Write an MCP tool as a subclass of `McpTool`. The framework generates JSON
+Schema, extracts typed arguments, converts results to `CallToolResult`, and
+turns unexpected exceptions into proper error responses.
+
+## Minimal template
+
+```kotlin
+class GreetTool : McpTool() {
+    override val name = "greet"
+    override val description = "Say hello"
+
+    val who by stringParam("who", "Person to greet")
+
+    override suspend fun execute(): ToolResult =
+        ToolResult.Success("hello, $who")
+}
+
+// Register — framework introspects params once at registration time.
+server.registerTool { GreetTool() }
+```
+
+## Param types
+
+| Helper                      | JSON schema          | Kotlin type         |
+|-----------------------------|----------------------|---------------------|
+| `stringParam(...)`          | `string`             | `String`            |
+| `intParam(...)`             | `integer`            | `Int`               |
+| `boolParam(...)`            | `boolean`            | `Boolean`           |
+| `enumParam(..., X::class)`  | `string` + `enum`    | `X` (Kotlin enum)   |
+| `mapParam(...)`             | `object` (str→str)   | `Map<String,String>`|
+| `listParam(...)`            | `array<string>`      | `List<String>`      |
+| `instantParam(...)`         | `string` date-time   | `java.time.Instant` |
+
+```kotlin
+val text    by stringParam("text", "Body text")
+val count   by intParam("count", "How many").range(1..10)
+val verbose by boolParam("verbose", "Show details").default(false)
+val mode    by enumParam("mode", "DND mode", DndMode::class)
+val extras  by mapParam("extras", "String extras").optional()
+val tags    by listParam("tags", "Tag filter").optional()
+val since   by instantParam("since", "Start time").optional()
+```
+
+Optional + required params declared at the same property produce a nullable
+type; required params are still nullable at the Kotlin level but the framework
+short-circuits with an `Error` before `execute()` runs, so you can freely
+`!!`-unwrap required params inside `execute()`.
+
+## Modifiers
+
+- `.optional()` — missing value yields `null` instead of an error.
+- `.default(v)` — supply a fallback. Implies optional.
+- `.choices("a","b")` — string-only; rejects anything outside the set.
+- `.range(0..10)` — int-only; rejects values outside the range.
+
+Chain them: `stringParam("mode", "...").default("auto").choices("auto","manual","off")`.
+
+## Results
+
+```kotlin
+ToolResult.Success("plain text message")
+ToolResult.Error("something went wrong")     // isError = true
+ToolResult.Json(buildJsonObject { put("ok", JsonPrimitive(true)) })
+```
+
+Exceptions thrown by `execute()` are caught and converted to
+`ToolResult.Error`. Cancellation is rethrown.
+
+## Migration — before / after
+
+### Before
+```kotlin
+server.addTool(
+    name = "launch_app",
+    description = "Launch an installed app by package name",
+    inputSchema = ToolSchema(
+        properties = buildJsonObject {
+            put("package_name", buildJsonObject {
+                put("type", JsonPrimitive("string"))
+                put("description", JsonPrimitive("Package name"))
+            })
+        },
+        required = listOf("package_name")
+    )
+) { request ->
+    val pkg = request.params.arguments?.get("package_name")?.jsonPrimitive?.content
+        ?: return@addTool errorResult("Missing package_name")
+    val intent = context.packageManager.getLaunchIntentForPackage(pkg)
+        ?: return@addTool errorResult("App not found: $pkg")
+    // ... start intent ...
+    successResult("Launched $pkg")
+}
+```
+
+### After
+```kotlin
+class LaunchAppTool(private val context: Context) : McpTool() {
+    override val name = "launch_app"
+    override val description = "Launch an installed app by package name"
+
+    val packageName by stringParam("package_name", "Package name")
+
+    override suspend fun execute(): ToolResult {
+        val intent = context.packageManager.getLaunchIntentForPackage(packageName!!)
+            ?: return ToolResult.Error("App not found: $packageName")
+        // ... start intent ...
+        return ToolResult.Success("Launched $packageName")
+    }
+}
+
+server.registerTool { LaunchAppTool(context) }
+```
+
+## Lifecycle
+
+Every call creates a fresh instance via the factory. It is therefore safe
+(and expected) to hold request-scoped state as ordinary fields. Do not cache
+an instance; the framework owns that decision.

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/ToolResult.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/ToolResult.kt
@@ -1,0 +1,42 @@
+package com.rousecontext.mcp.tool
+
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Result of a tool execution. Converted to [CallToolResult] by the framework.
+ *
+ *  - [Success] — plain-text success payload.
+ *  - [Error]   — plain-text error payload; the framework maps to `isError = true`.
+ *  - [Json]    — raw JSON payload delivered as a single [TextContent]. Used when a
+ *                tool wants to return a structured result without handcrafting the
+ *                JSON-in-string encoding itself.
+ */
+sealed class ToolResult {
+    data class Success(val text: String, val meta: JsonObject? = null) : ToolResult()
+
+    data class Error(val message: String, val meta: JsonObject? = null) : ToolResult()
+
+    data class Json(val value: JsonElement, val meta: JsonObject? = null) : ToolResult()
+
+    /**
+     * Convert to the MCP SDK's [CallToolResult]. Keeps wire-format stable across
+     * tool-author code churn.
+     */
+    fun toCallToolResult(): CallToolResult = when (this) {
+        is Success -> CallToolResult(
+            content = listOf(TextContent(text)),
+            isError = false
+        )
+        is Error -> CallToolResult(
+            content = listOf(TextContent(message)),
+            isError = true
+        )
+        is Json -> CallToolResult(
+            content = listOf(TextContent(value.toString())),
+            isError = false
+        )
+    }
+}

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/BoolParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/BoolParam.kt
@@ -1,0 +1,42 @@
+package com.rousecontext.mcp.tool.params
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+class BoolParam(name: String, description: String) : ParamDef<Boolean>(name, description) {
+
+    fun optional(): BoolParam = apply { required = false }
+
+    fun default(value: Boolean): BoolParam = apply {
+        required = false
+        defaultValue = value
+    }
+
+    override fun schema(): JsonObject = buildJsonObject {
+        put("type", JsonPrimitive("boolean"))
+        put("description", JsonPrimitive(description))
+        defaultValue?.let { put("default", JsonPrimitive(it)) }
+    }
+
+    override fun extract(args: JsonObject?): ParamExtract<Boolean> {
+        val raw = rawValue(args, name) ?: run {
+            if (required) return ParamExtract.Error("Missing required parameter '$name'")
+            return ParamExtract.Value(defaultValue)
+        }
+        if (raw !is JsonPrimitive) {
+            return ParamExtract.Error(
+                "Parameter '$name' must be a boolean, got ${describeJsonType(raw)}"
+            )
+        }
+        // Accept both true-boolean primitives ("true"/"false" with !isString) and
+        // string-coded booleans (client serializer may quote them).
+        val parsed = when {
+            !raw.isString -> raw.content.toBooleanStrictOrNull()
+            else -> raw.content.toBooleanStrictOrNull()
+        } ?: return ParamExtract.Error(
+            "Parameter '$name' must be a boolean, got '${raw.content}'"
+        )
+        return ParamExtract.Value(parsed)
+    }
+}

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/BoolParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/BoolParam.kt
@@ -19,6 +19,7 @@ class BoolParam(name: String, description: String) : ParamDef<Boolean>(name, des
         defaultValue?.let { put("default", JsonPrimitive(it)) }
     }
 
+    @Suppress("ReturnCount")
     override fun extract(args: JsonObject?): ParamExtract<Boolean> {
         val raw = rawValue(args, name) ?: run {
             if (required) return ParamExtract.Error("Missing required parameter '$name'")

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/EnumParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/EnumParam.kt
@@ -26,6 +26,7 @@ class EnumParam<T : Enum<T>>(name: String, description: String, private val kCla
         defaultValue?.let { put("default", JsonPrimitive(it.name.lowercase())) }
     }
 
+    @Suppress("ReturnCount")
     override fun extract(args: JsonObject?): ParamExtract<T> {
         val raw = rawValue(args, name) ?: run {
             if (required) return ParamExtract.Error("Missing required parameter '$name'")

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/EnumParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/EnumParam.kt
@@ -1,0 +1,48 @@
+package com.rousecontext.mcp.tool.params
+
+import kotlin.reflect.KClass
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+class EnumParam<T : Enum<T>>(name: String, description: String, private val kClass: KClass<T>) :
+    ParamDef<T>(name, description) {
+
+    private val values: Array<T> = kClass.java.enumConstants
+        ?: error("EnumParam requires an enum class, got ${kClass.qualifiedName}")
+
+    fun optional(): EnumParam<T> = apply { required = false }
+
+    fun default(value: T): EnumParam<T> = apply {
+        required = false
+        defaultValue = value
+    }
+
+    override fun schema(): JsonObject = buildJsonObject {
+        put("type", JsonPrimitive("string"))
+        put("description", JsonPrimitive(description))
+        put("enum", JsonArray(values.map { JsonPrimitive(it.name.lowercase()) }))
+        defaultValue?.let { put("default", JsonPrimitive(it.name.lowercase())) }
+    }
+
+    override fun extract(args: JsonObject?): ParamExtract<T> {
+        val raw = rawValue(args, name) ?: run {
+            if (required) return ParamExtract.Error("Missing required parameter '$name'")
+            return ParamExtract.Value(defaultValue)
+        }
+        if (raw !is JsonPrimitive || !raw.isString) {
+            return ParamExtract.Error(
+                "Parameter '$name' must be a string, got ${describeJsonType(raw)}"
+            )
+        }
+        val str = raw.content.lowercase()
+        val match = values.firstOrNull { it.name.lowercase() == str }
+            ?: return ParamExtract.Error(
+                "Parameter '$name' must be one of " +
+                    values.joinToString(", ") { it.name.lowercase() } +
+                    ", got '${raw.content}'"
+            )
+        return ParamExtract.Value(match)
+    }
+}

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/InstantParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/InstantParam.kt
@@ -1,0 +1,46 @@
+package com.rousecontext.mcp.tool.params
+
+import java.time.Instant
+import java.time.format.DateTimeParseException
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+/**
+ * ISO-8601 timestamp parameter, parsed via [java.time.Instant.parse].
+ */
+class InstantParam(name: String, description: String) : ParamDef<Instant>(name, description) {
+
+    fun optional(): InstantParam = apply { required = false }
+
+    fun default(value: Instant): InstantParam = apply {
+        required = false
+        defaultValue = value
+    }
+
+    override fun schema(): JsonObject = buildJsonObject {
+        put("type", JsonPrimitive("string"))
+        put("format", JsonPrimitive("date-time"))
+        put("description", JsonPrimitive(description))
+        defaultValue?.let { put("default", JsonPrimitive(it.toString())) }
+    }
+
+    override fun extract(args: JsonObject?): ParamExtract<Instant> {
+        val raw = rawValue(args, name) ?: run {
+            if (required) return ParamExtract.Error("Missing required parameter '$name'")
+            return ParamExtract.Value(defaultValue)
+        }
+        if (raw !is JsonPrimitive || !raw.isString) {
+            return ParamExtract.Error(
+                "Parameter '$name' must be an ISO-8601 string, got ${describeJsonType(raw)}"
+            )
+        }
+        return try {
+            ParamExtract.Value(Instant.parse(raw.content))
+        } catch (e: DateTimeParseException) {
+            ParamExtract.Error(
+                "Parameter '$name' must be a valid ISO-8601 instant, got '${raw.content}'"
+            )
+        }
+    }
+}

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/IntParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/IntParam.kt
@@ -26,6 +26,7 @@ class IntParam(name: String, description: String) : ParamDef<Int>(name, descript
         defaultValue?.let { put("default", JsonPrimitive(it)) }
     }
 
+    @Suppress("ReturnCount")
     override fun extract(args: JsonObject?): ParamExtract<Int> {
         val raw = rawValue(args, name) ?: run {
             if (required) return ParamExtract.Error("Missing required parameter '$name'")

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/IntParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/IntParam.kt
@@ -1,0 +1,56 @@
+package com.rousecontext.mcp.tool.params
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+class IntParam(name: String, description: String) : ParamDef<Int>(name, description) {
+    private var range: IntRange? = null
+
+    fun optional(): IntParam = apply { required = false }
+
+    fun default(value: Int): IntParam = apply {
+        required = false
+        defaultValue = value
+    }
+
+    fun range(r: IntRange): IntParam = apply { range = r }
+
+    override fun schema(): JsonObject = buildJsonObject {
+        put("type", JsonPrimitive("integer"))
+        put("description", JsonPrimitive(description))
+        range?.let {
+            put("minimum", JsonPrimitive(it.first))
+            put("maximum", JsonPrimitive(it.last))
+        }
+        defaultValue?.let { put("default", JsonPrimitive(it)) }
+    }
+
+    override fun extract(args: JsonObject?): ParamExtract<Int> {
+        val raw = rawValue(args, name) ?: run {
+            if (required) return ParamExtract.Error("Missing required parameter '$name'")
+            return ParamExtract.Value(defaultValue)
+        }
+        if (raw !is JsonPrimitive || raw.isString) {
+            return ParamExtract.Error(
+                "Parameter '$name' must be an integer, got ${describeJsonType(raw)}"
+            )
+        }
+        val asLong = raw.content.toLongOrNull()
+            ?: return ParamExtract.Error(
+                "Parameter '$name' must be an integer, got '${raw.content}'"
+            )
+        if (asLong < Int.MIN_VALUE.toLong() || asLong > Int.MAX_VALUE.toLong()) {
+            return ParamExtract.Error("Parameter '$name' out of Int range: $asLong")
+        }
+        val value = asLong.toInt()
+        range?.let {
+            if (value !in it) {
+                return ParamExtract.Error(
+                    "Parameter '$name' must be in range ${it.first}..${it.last}, got $value"
+                )
+            }
+        }
+        return ParamExtract.Value(value)
+    }
+}

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/ListParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/ListParam.kt
@@ -28,6 +28,7 @@ class ListParam(name: String, description: String) : ParamDef<List<String>>(name
         )
     }
 
+    @Suppress("ReturnCount")
     override fun extract(args: JsonObject?): ParamExtract<List<String>> {
         val raw = rawValue(args, name) ?: run {
             if (required) return ParamExtract.Error("Missing required parameter '$name'")

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/ListParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/ListParam.kt
@@ -1,0 +1,56 @@
+package com.rousecontext.mcp.tool.params
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+/**
+ * A list of string primitives. The more complex list-of-objects case (e.g.
+ * notification action buttons) is handled by callers reading the raw JSON
+ * themselves via [com.rousecontext.mcp.tool.McpTool.rawArgs].
+ */
+class ListParam(name: String, description: String) : ParamDef<List<String>>(name, description) {
+
+    fun optional(): ListParam = apply { required = false }
+
+    fun default(value: List<String>): ListParam = apply {
+        required = false
+        defaultValue = value
+    }
+
+    override fun schema(): JsonObject = buildJsonObject {
+        put("type", JsonPrimitive("array"))
+        put("description", JsonPrimitive(description))
+        put(
+            "items",
+            buildJsonObject { put("type", JsonPrimitive("string")) }
+        )
+    }
+
+    override fun extract(args: JsonObject?): ParamExtract<List<String>> {
+        val raw = rawValue(args, name) ?: run {
+            if (required) return ParamExtract.Error("Missing required parameter '$name'")
+            return ParamExtract.Value(defaultValue)
+        }
+        if (raw !is JsonArray) {
+            return ParamExtract.Error(
+                "Parameter '$name' must be an array, got ${describeJsonType(raw)}"
+            )
+        }
+        val out = ArrayList<String>(raw.size)
+        for ((i, el) in raw.withIndex()) {
+            val p = el as? JsonPrimitive
+                ?: return ParamExtract.Error(
+                    "Parameter '$name[$i]' must be a string primitive"
+                )
+            if (!p.isString) {
+                return ParamExtract.Error(
+                    "Parameter '$name[$i]' must be a string, got ${describeJsonType(el)}"
+                )
+            }
+            out.add(p.content)
+        }
+        return ParamExtract.Value(out)
+    }
+}

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/MapParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/MapParam.kt
@@ -1,0 +1,53 @@
+package com.rousecontext.mcp.tool.params
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+/**
+ * Map of string to string — matches the common "extras" / headers pattern.
+ * Values that aren't string primitives are coerced to their `.content` form.
+ */
+class MapParam(name: String, description: String) :
+    ParamDef<Map<String, String>>(
+        name,
+        description
+    ) {
+
+    fun optional(): MapParam = apply { required = false }
+
+    fun default(value: Map<String, String>): MapParam = apply {
+        required = false
+        defaultValue = value
+    }
+
+    override fun schema(): JsonObject = buildJsonObject {
+        put("type", JsonPrimitive("object"))
+        put("description", JsonPrimitive(description))
+        put(
+            "additionalProperties",
+            buildJsonObject { put("type", JsonPrimitive("string")) }
+        )
+    }
+
+    override fun extract(args: JsonObject?): ParamExtract<Map<String, String>> {
+        val raw = rawValue(args, name) ?: run {
+            if (required) return ParamExtract.Error("Missing required parameter '$name'")
+            return ParamExtract.Value(defaultValue)
+        }
+        if (raw !is JsonObject) {
+            return ParamExtract.Error(
+                "Parameter '$name' must be an object, got ${describeJsonType(raw)}"
+            )
+        }
+        val result = mutableMapOf<String, String>()
+        for ((k, v) in raw) {
+            val primitive = v as? JsonPrimitive
+                ?: return ParamExtract.Error(
+                    "Parameter '$name.$k' must be a string primitive"
+                )
+            result[k] = primitive.content
+        }
+        return ParamExtract.Value(result)
+    }
+}

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/MapParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/MapParam.kt
@@ -30,6 +30,7 @@ class MapParam(name: String, description: String) :
         )
     }
 
+    @Suppress("ReturnCount")
     override fun extract(args: JsonObject?): ParamExtract<Map<String, String>> {
         val raw = rawValue(args, name) ?: run {
             if (required) return ParamExtract.Error("Missing required parameter '$name'")

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/ParamDef.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/ParamDef.kt
@@ -1,0 +1,46 @@
+package com.rousecontext.mcp.tool.params
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * A named, typed parameter attached to an [com.rousecontext.mcp.tool.McpTool].
+ *
+ * One [ParamDef] instance describes one JSON property in the tool's input schema
+ * and knows how to extract a value of type [T] from the arguments supplied to a
+ * tool call. Instances are bound to Kotlin properties via [provideDelegate] so
+ * tool authors can write `val foo by stringParam("foo", "...")` and read the
+ * extracted value transparently during [com.rousecontext.mcp.tool.McpTool.execute].
+ */
+abstract class ParamDef<T>(val name: String, val description: String) {
+    /** Whether a missing value should produce an error. Flipped by [optional]. */
+    var required: Boolean = true
+        protected set
+
+    /** Default value when optional and missing. Null means "no default". */
+    var defaultValue: T? = null
+        protected set
+
+    /** JSON schema fragment for this parameter. Composed into the tool schema. */
+    abstract fun schema(): JsonObject
+
+    /**
+     * Extract the typed value from the raw arguments, or return a
+     * [ParamExtract.Error] if missing/invalid.
+     */
+    abstract fun extract(args: JsonObject?): ParamExtract<T>
+}
+
+sealed class ParamExtract<out T> {
+    data class Value<T>(val value: T?) : ParamExtract<T>()
+    data class Error(val message: String) : ParamExtract<Nothing>()
+}
+
+/**
+ * Fetch `args[name]`, treating `JsonNull` as missing.
+ */
+internal fun rawValue(args: JsonObject?, name: String): JsonElement? {
+    val raw = args?.get(name) ?: return null
+    if (raw is kotlinx.serialization.json.JsonNull) return null
+    return raw
+}

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/StringParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/StringParam.kt
@@ -28,6 +28,7 @@ class StringParam(name: String, description: String) : ParamDef<String>(name, de
         defaultValue?.let { put("default", JsonPrimitive(it)) }
     }
 
+    @Suppress("ReturnCount")
     override fun extract(args: JsonObject?): ParamExtract<String> {
         val raw = rawValue(args, name) ?: run {
             if (required) return ParamExtract.Error("Missing required parameter '$name'")

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/StringParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/StringParam.kt
@@ -1,0 +1,66 @@
+package com.rousecontext.mcp.tool.params
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+
+class StringParam(name: String, description: String) : ParamDef<String>(name, description) {
+    private var choices: List<String>? = null
+
+    fun optional(): StringParam = apply { required = false }
+
+    fun default(value: String): StringParam = apply {
+        required = false
+        defaultValue = value
+    }
+
+    fun choices(vararg values: String): StringParam = apply {
+        require(values.isNotEmpty()) { "choices() requires at least one value" }
+        choices = values.toList()
+    }
+
+    override fun schema(): JsonObject = buildJsonObject {
+        put("type", JsonPrimitive("string"))
+        put("description", JsonPrimitive(description))
+        choices?.let { put("enum", JsonArray(it.map { v -> JsonPrimitive(v) })) }
+        defaultValue?.let { put("default", JsonPrimitive(it)) }
+    }
+
+    override fun extract(args: JsonObject?): ParamExtract<String> {
+        val raw = rawValue(args, name) ?: run {
+            if (required) return ParamExtract.Error("Missing required parameter '$name'")
+            return ParamExtract.Value(defaultValue)
+        }
+        if (raw !is JsonPrimitive || !raw.isString) {
+            val typeName = describeJsonType(raw)
+            return ParamExtract.Error(
+                "Parameter '$name' must be a string, got $typeName"
+            )
+        }
+        val str = raw.content
+        val allowed = choices
+        if (allowed != null && str !in allowed) {
+            return ParamExtract.Error(
+                "Parameter '$name' must be one of ${allowed.joinToString(", ")}, got '$str'"
+            )
+        }
+        return ParamExtract.Value(str)
+    }
+}
+
+internal fun describeJsonType(el: kotlinx.serialization.json.JsonElement): String = when (el) {
+    is JsonNull -> "null"
+    is JsonPrimitive -> when {
+        el.isString -> "string"
+        el.booleanOrNullTyped() != null -> "boolean"
+        el.content.toLongOrNull() != null || el.content.toDoubleOrNull() != null -> "number"
+        else -> "primitive"
+    }
+    is JsonObject -> "object"
+    is JsonArray -> "array"
+}
+
+private fun JsonPrimitive.booleanOrNullTyped(): Boolean? =
+    if (isString) null else content.toBooleanStrictOrNull()

--- a/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/McpToolEndToEndTest.kt
+++ b/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/McpToolEndToEndTest.kt
@@ -1,0 +1,110 @@
+package com.rousecontext.mcp.tool
+
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequestParams
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * End-to-end: register a DSL tool on a real [Server] and invoke it through the
+ * SDK's registered-tool handler. Verifies the Tool exposed to `tools/list`
+ * contains the generated schema, and that `tools/call` via the handler yields
+ * the right CallToolResult for valid, missing, and invalid args.
+ */
+class McpToolEndToEndTest {
+
+    private class GreetTool : McpTool() {
+        override val name = "greet"
+        override val description = "Say hello"
+        val who by stringParam("who", "Person to greet")
+        val excited by boolParam("excited", "Add exclamation").default(false)
+        override suspend fun execute(): ToolResult =
+            ToolResult.Success("hello, $who" + if (excited == true) "!" else "")
+    }
+
+    private fun server() = Server(
+        Implementation("test", "0.1"),
+        ServerOptions(
+            capabilities = ServerCapabilities(
+                tools = ServerCapabilities.Tools(listChanged = false)
+            )
+        )
+    )
+
+    @Test
+    fun `tool registration exposes generated schema`() {
+        val server = server()
+        server.registerTool { GreetTool() }
+        val tool = server.tools["greet"]!!.tool
+        assertEquals("greet", tool.name)
+        assertEquals("Say hello", tool.description)
+        val props = tool.inputSchema.properties!!
+        assertEquals("string", props["who"]!!.jsonObject["type"]!!.jsonPrimitive.content)
+        assertEquals("boolean", props["excited"]!!.jsonObject["type"]!!.jsonPrimitive.content)
+        assertEquals(listOf("who"), tool.inputSchema.required)
+    }
+
+    @Test
+    fun `tools-call with valid args returns success`() = runBlocking {
+        val server = server()
+        server.registerTool { GreetTool() }
+        val handler = server.tools["greet"]!!.handler
+        val request = CallToolRequest(
+            params = CallToolRequestParams(
+                name = "greet",
+                arguments = buildJsonObject {
+                    put("who", JsonPrimitive("world"))
+                    put("excited", JsonPrimitive(true))
+                }
+            )
+        )
+        val result = handler.invoke(StubClientConnection, request)
+        assertEquals(false, result.isError == true)
+        assertEquals("hello, world!", (result.content.first() as TextContent).text)
+    }
+
+    @Test
+    fun `tools-call with missing required param returns MCP error`() = runBlocking {
+        val server = server()
+        server.registerTool { GreetTool() }
+        val handler = server.tools["greet"]!!.handler
+        val request = CallToolRequest(
+            params = CallToolRequestParams(
+                name = "greet",
+                arguments = buildJsonObject {}
+            )
+        )
+        val result = handler.invoke(StubClientConnection, request)
+        assertTrue(result.isError == true)
+        val text = (result.content.first() as TextContent).text!!
+        assertTrue(text, text.contains("Missing required parameter 'who'"))
+    }
+
+    @Test
+    fun `tools-call with wrong type returns MCP error`() = runBlocking {
+        val server = server()
+        server.registerTool { GreetTool() }
+        val handler = server.tools["greet"]!!.handler
+        val request = CallToolRequest(
+            params = CallToolRequestParams(
+                name = "greet",
+                arguments = buildJsonObject { put("who", JsonPrimitive(42)) }
+            )
+        )
+        val result = handler.invoke(StubClientConnection, request)
+        assertTrue(result.isError == true)
+        val text = (result.content.first() as TextContent).text!!
+        assertTrue(text, text.contains("must be a string"))
+    }
+}

--- a/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/McpToolRegistrationTest.kt
+++ b/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/McpToolRegistrationTest.kt
@@ -1,0 +1,141 @@
+package com.rousecontext.mcp.tool
+
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class McpToolRegistrationTest {
+
+    private fun makeServer(): Server = Server(
+        Implementation("test", "0.1"),
+        ServerOptions(
+            capabilities = ServerCapabilities(
+                tools = ServerCapabilities.Tools(listChanged = false)
+            )
+        )
+    )
+
+    private class CountingTool(private val counter: AtomicInteger) : McpTool() {
+        override val name = "count"
+        override val description = "increment and return the counter"
+        val prefix by stringParam("prefix", "label").optional()
+        override suspend fun execute(): ToolResult {
+            val v = counter.incrementAndGet()
+            return ToolResult.Success("${prefix ?: "count"}=$v")
+        }
+    }
+
+    @Test
+    fun `factory is called once per invocation so no state bleed`() = runBlocking {
+        val factoryCalls = AtomicInteger(0)
+        val counter = AtomicInteger(0)
+        val server = makeServer()
+        server.registerTool {
+            factoryCalls.incrementAndGet()
+            CountingTool(counter)
+        }
+        // One factory call at registration (schema introspection).
+        assertEquals(1, factoryCalls.get())
+        val registered = server.tools["count"]
+        assertNotNull(registered)
+
+        val handler = registered!!.handler
+        // Invoke twice — factory must produce a fresh instance each time.
+        val r1 = handler.invoke(
+            StubClientConnection,
+            io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest(
+                params = io.modelcontextprotocol.kotlin.sdk.types.CallToolRequestParams(
+                    name = "count",
+                    arguments = buildJsonObject { put("prefix", JsonPrimitive("a")) }
+                )
+            )
+        )
+        val r2 = handler.invoke(
+            StubClientConnection,
+            io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest(
+                params = io.modelcontextprotocol.kotlin.sdk.types.CallToolRequestParams(
+                    name = "count",
+                    arguments = buildJsonObject { put("prefix", JsonPrimitive("b")) }
+                )
+            )
+        )
+        assertEquals("a=1", (r1.content.first() as TextContent).text)
+        assertEquals("b=2", (r2.content.first() as TextContent).text)
+        assertEquals(3, factoryCalls.get())
+    }
+
+    @Test
+    fun `exception in execute becomes error result`() = runBlocking {
+        class BoomTool : McpTool() {
+            override val name = "boom"
+            override val description = "d"
+            override suspend fun execute(): ToolResult {
+                error("kaboom")
+            }
+        }
+        val tool = BoomTool()
+        val result = tool.invoke(null)
+        assertTrue(result is ToolResult.Error)
+        val err = result as ToolResult.Error
+        assertTrue(err.message.contains("kaboom"))
+    }
+
+    @Test
+    fun `cancellation propagates through execute`() = runBlocking {
+        class SlowTool(val started: CompletableDeferred<Unit>) : McpTool() {
+            override val name = "slow"
+            override val description = "d"
+            override suspend fun execute(): ToolResult {
+                started.complete(Unit)
+                awaitCancellation()
+            }
+        }
+        val started = CompletableDeferred<Unit>()
+        val tool = SlowTool(started)
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        val job = scope.async { tool.invoke(null) }
+        started.await()
+        job.cancel()
+        var gotCancelled = false
+        try {
+            job.await()
+        } catch (_: kotlinx.coroutines.CancellationException) {
+            gotCancelled = true
+        }
+        assertTrue(gotCancelled)
+    }
+
+    @Test
+    fun `missing required param returns extraction error without calling execute`() = runBlocking {
+        var executeCalled = false
+        class EchoTool : McpTool() {
+            override val name = "echo"
+            override val description = "d"
+            val s by stringParam("s", "value")
+            override suspend fun execute(): ToolResult {
+                executeCalled = true
+                return ToolResult.Success("ignored")
+            }
+        }
+        val tool = EchoTool()
+        val result = tool.invoke(buildJsonObject {})
+        assertTrue(result is ToolResult.Error)
+        assertTrue((result as ToolResult.Error).message.contains("Missing required parameter 's'"))
+        assertEquals(false, executeCalled)
+    }
+}

--- a/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/ParamExtractionTest.kt
+++ b/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/ParamExtractionTest.kt
@@ -1,0 +1,234 @@
+package com.rousecontext.mcp.tool
+
+import com.rousecontext.mcp.tool.params.BoolParam
+import com.rousecontext.mcp.tool.params.EnumParam
+import com.rousecontext.mcp.tool.params.InstantParam
+import com.rousecontext.mcp.tool.params.IntParam
+import com.rousecontext.mcp.tool.params.ListParam
+import com.rousecontext.mcp.tool.params.MapParam
+import com.rousecontext.mcp.tool.params.ParamExtract
+import com.rousecontext.mcp.tool.params.StringParam
+import java.time.Instant
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Covers every param type: valid, missing (required/optional), type mismatch, range/choices, null handling. */
+class ParamExtractionTest {
+
+    private fun <T> Any?.valueOr(default: Nothing? = null): T? {
+        val r = this as ParamExtract<*>
+        return when (r) {
+            is ParamExtract.Value<*> ->
+                @Suppress("UNCHECKED_CAST")
+                (r.value as T?)
+            is ParamExtract.Error -> error(r.message)
+        }
+    }
+
+    private fun Any?.error(): String {
+        val r = this as ParamExtract<*>
+        return (r as ParamExtract.Error).message
+    }
+
+    // -------- StringParam --------
+
+    @Test
+    fun `string extract valid`() {
+        val p = StringParam("x", "desc")
+        val args = buildJsonObject { put("x", JsonPrimitive("hi")) }
+        assertEquals("hi", p.extract(args).valueOr<String>())
+    }
+
+    @Test
+    fun `string missing required errors`() {
+        val p = StringParam("x", "desc")
+        val msg = p.extract(buildJsonObject {}).error()
+        assertTrue(msg, msg.contains("Missing required parameter 'x'"))
+    }
+
+    @Test
+    fun `string missing optional returns null`() {
+        val p = StringParam("x", "d").optional()
+        assertNull(p.extract(buildJsonObject {}).valueOr<String>())
+    }
+
+    @Test
+    fun `string default used when missing`() {
+        val p = StringParam("x", "d").default("fallback")
+        assertEquals("fallback", p.extract(buildJsonObject {}).valueOr<String>())
+    }
+
+    @Test
+    fun `string wrong type errors`() {
+        val p = StringParam("x", "d")
+        val args = buildJsonObject { put("x", JsonPrimitive(42)) }
+        val msg = p.extract(args).error()
+        assertTrue(msg, msg.contains("must be a string") && msg.contains("number"))
+    }
+
+    @Test
+    fun `string null treated as missing`() {
+        val p = StringParam("x", "d")
+        val args = buildJsonObject { put("x", JsonNull) }
+        val msg = p.extract(args).error()
+        assertTrue(msg, msg.contains("Missing required"))
+    }
+
+    @Test
+    fun `string choices violation errors`() {
+        val p = StringParam("x", "d").choices("a", "b")
+        val args = buildJsonObject { put("x", JsonPrimitive("c")) }
+        val msg = p.extract(args).error()
+        assertTrue(msg, msg.contains("must be one of"))
+    }
+
+    // -------- IntParam --------
+
+    @Test
+    fun `int extract valid`() {
+        val p = IntParam("x", "d")
+        val args = buildJsonObject { put("x", JsonPrimitive(7)) }
+        assertEquals(7, p.extract(args).valueOr<Int>())
+    }
+
+    @Test
+    fun `int range violation errors`() {
+        val p = IntParam("x", "d").range(0..10)
+        val args = buildJsonObject { put("x", JsonPrimitive(20)) }
+        val msg = p.extract(args).error()
+        assertTrue(msg, msg.contains("must be in range 0..10"))
+    }
+
+    @Test
+    fun `int wrong type errors`() {
+        val p = IntParam("x", "d")
+        val args = buildJsonObject { put("x", JsonPrimitive("nope")) }
+        val msg = p.extract(args).error()
+        assertTrue(msg, msg.contains("must be an integer"))
+    }
+
+    @Test
+    fun `int default used when missing`() {
+        val p = IntParam("x", "d").default(5)
+        assertEquals(5, p.extract(buildJsonObject {}).valueOr<Int>())
+    }
+
+    // -------- BoolParam --------
+
+    @Test
+    fun `bool extract valid true`() {
+        val p = BoolParam("x", "d")
+        val args = buildJsonObject { put("x", JsonPrimitive(true)) }
+        assertEquals(true, p.extract(args).valueOr<Boolean>())
+    }
+
+    @Test
+    fun `bool extract string coded`() {
+        val p = BoolParam("x", "d")
+        val args = buildJsonObject { put("x", JsonPrimitive("false")) }
+        assertEquals(false, p.extract(args).valueOr<Boolean>())
+    }
+
+    @Test
+    fun `bool wrong string errors`() {
+        val p = BoolParam("x", "d")
+        val args = buildJsonObject { put("x", JsonPrimitive("maybe")) }
+        val msg = p.extract(args).error()
+        assertTrue(msg, msg.contains("must be a boolean"))
+    }
+
+    // -------- EnumParam --------
+
+    enum class Color { RED, BLUE }
+
+    @Test
+    fun `enum extract case insensitive`() {
+        val p = EnumParam("c", "d", Color::class)
+        val args = buildJsonObject { put("c", JsonPrimitive("Red")) }
+        assertEquals(Color.RED, p.extract(args).valueOr<Color>())
+    }
+
+    @Test
+    fun `enum invalid choice errors`() {
+        val p = EnumParam("c", "d", Color::class)
+        val args = buildJsonObject { put("c", JsonPrimitive("green")) }
+        val msg = p.extract(args).error()
+        assertTrue(msg, msg.contains("must be one of"))
+    }
+
+    // -------- MapParam --------
+
+    @Test
+    fun `map extract valid`() {
+        val p = MapParam("m", "d")
+        val args = buildJsonObject {
+            put("m", buildJsonObject { put("k", JsonPrimitive("v")) })
+        }
+        val out: Map<String, String> = p.extract(args).valueOr()!!
+        assertEquals(mapOf("k" to "v"), out)
+    }
+
+    @Test
+    fun `map wrong type errors`() {
+        val p = MapParam("m", "d")
+        val args = buildJsonObject { put("m", JsonPrimitive("nope")) }
+        val msg = p.extract(args).error()
+        assertTrue(msg, msg.contains("must be an object"))
+    }
+
+    // -------- ListParam --------
+
+    @Test
+    fun `list extract valid`() {
+        val p = ListParam("xs", "d")
+        val args = buildJsonObject {
+            put(
+                "xs",
+                buildJsonArray {
+                    add(JsonPrimitive("a"))
+                    add(JsonPrimitive("b"))
+                }
+            )
+        }
+        assertEquals(listOf("a", "b"), p.extract(args).valueOr<List<String>>())
+    }
+
+    @Test
+    fun `list non-string element errors`() {
+        val p = ListParam("xs", "d")
+        val args = buildJsonObject {
+            put("xs", buildJsonArray { add(JsonPrimitive(1)) })
+        }
+        val msg = p.extract(args).error()
+        assertTrue(msg, msg.contains("xs[0]"))
+    }
+
+    // -------- InstantParam --------
+
+    @Test
+    fun `instant extract valid`() {
+        val p = InstantParam("t", "d")
+        val args = buildJsonObject { put("t", JsonPrimitive("2024-01-01T00:00:00Z")) }
+        assertEquals(Instant.parse("2024-01-01T00:00:00Z"), p.extract(args).valueOr<Instant>())
+    }
+
+    @Test
+    fun `instant invalid string errors`() {
+        val p = InstantParam("t", "d")
+        val args = buildJsonObject { put("t", JsonPrimitive("not-a-date")) }
+        val msg = p.extract(args).error()
+        assertTrue(msg, msg.contains("ISO-8601"))
+    }
+
+    @Test
+    fun `instant missing optional returns null`() {
+        val p = InstantParam("t", "d").optional()
+        assertNull(p.extract(buildJsonObject {}).valueOr<Instant>())
+    }
+}

--- a/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/SchemaGenerationTest.kt
+++ b/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/SchemaGenerationTest.kt
@@ -1,0 +1,121 @@
+package com.rousecontext.mcp.tool
+
+import com.rousecontext.mcp.tool.params.BoolParam
+import com.rousecontext.mcp.tool.params.EnumParam
+import com.rousecontext.mcp.tool.params.InstantParam
+import com.rousecontext.mcp.tool.params.IntParam
+import com.rousecontext.mcp.tool.params.ListParam
+import com.rousecontext.mcp.tool.params.MapParam
+import com.rousecontext.mcp.tool.params.StringParam
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SchemaGenerationTest {
+
+    private val json = Json { prettyPrint = false }
+
+    @Test
+    fun `string schema contains type and description`() {
+        val s = StringParam("x", "my desc").schema()
+        assertEquals("string", s["type"]!!.jsonPrimitive.content)
+        assertEquals("my desc", s["description"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `string with choices emits enum`() {
+        val s = StringParam("x", "d").choices("a", "b", "c").schema()
+        val values = s["enum"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertEquals(listOf("a", "b", "c"), values)
+    }
+
+    @Test
+    fun `int with range emits minimum and maximum`() {
+        val s = IntParam("x", "d").range(0..5).schema()
+        assertEquals("integer", s["type"]!!.jsonPrimitive.content)
+        assertEquals(0, s["minimum"]!!.jsonPrimitive.content.toInt())
+        assertEquals(5, s["maximum"]!!.jsonPrimitive.content.toInt())
+    }
+
+    @Test
+    fun `bool schema`() {
+        val s = BoolParam("x", "d").schema()
+        assertEquals("boolean", s["type"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `bool default emits default`() {
+        val s = BoolParam("x", "d").default(true).schema()
+        assertEquals(true, s["default"]!!.jsonPrimitive.content.toBoolean())
+    }
+
+    @Test
+    fun `enum schema emits string enum values`() {
+        val s = EnumParam("c", "d", ParamExtractionTest.Color::class).schema()
+        assertEquals("string", s["type"]!!.jsonPrimitive.content)
+        val values = s["enum"]!!.jsonArray.map { it.jsonPrimitive.content }
+        assertEquals(setOf("red", "blue"), values.toSet())
+    }
+
+    @Test
+    fun `map schema emits object with string additionalProperties`() {
+        val s = MapParam("m", "d").schema()
+        assertEquals("object", s["type"]!!.jsonPrimitive.content)
+        assertEquals(
+            "string",
+            s["additionalProperties"]!!.jsonObject["type"]!!.jsonPrimitive.content
+        )
+    }
+
+    @Test
+    fun `list schema emits array with string items`() {
+        val s = ListParam("xs", "d").schema()
+        assertEquals("array", s["type"]!!.jsonPrimitive.content)
+        assertEquals("string", s["items"]!!.jsonObject["type"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `instant schema uses date-time format`() {
+        val s = InstantParam("t", "d").schema()
+        assertEquals("string", s["type"]!!.jsonPrimitive.content)
+        assertEquals("date-time", s["format"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `required list matches non-optional params`() {
+        val t = object : McpTool() {
+            override val name = "probe"
+            override val description = "desc"
+            val a by stringParam("a", "d")
+            val b by stringParam("b", "d").optional()
+            val c by intParam("c", "d").default(7)
+            override suspend fun execute(): ToolResult = ToolResult.Success("ok")
+        }
+        val schema = t.buildSchema()
+        assertEquals(listOf("a"), schema.required)
+        val names = schema.properties!!.keys
+        assertEquals(setOf("a", "b", "c"), names)
+    }
+
+    /** Golden-file style assertion: full tool schema emitted is stable. */
+    @Test
+    fun `golden schema for launch-app shape`() {
+        val t = object : McpTool() {
+            override val name = "launch_app"
+            override val description = "Launch an installed app by package name"
+            val packageName by stringParam("package_name", "Package name, e.g. com.example.app")
+            val extras by mapParam("extras", "String-valued intent extras").optional()
+            override suspend fun execute(): ToolResult = ToolResult.Success("ok")
+        }
+        val expected =
+            """{"package_name":{"type":"string",""" +
+                """"description":"Package name, e.g. com.example.app"},""" +
+                """"extras":{"type":"object","description":"String-valued intent extras",""" +
+                """"additionalProperties":{"type":"string"}}}"""
+        assertEquals(expected, t.buildSchema().properties.toString())
+        assertEquals(listOf("package_name"), t.buildSchema().required)
+    }
+}

--- a/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/StubClientConnection.kt
+++ b/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/StubClientConnection.kt
@@ -1,0 +1,55 @@
+package com.rousecontext.mcp.tool
+
+import io.modelcontextprotocol.kotlin.sdk.server.ClientConnection
+import io.modelcontextprotocol.kotlin.sdk.shared.RequestOptions
+import io.modelcontextprotocol.kotlin.sdk.types.CreateMessageRequest
+import io.modelcontextprotocol.kotlin.sdk.types.CreateMessageResult
+import io.modelcontextprotocol.kotlin.sdk.types.ElicitRequest
+import io.modelcontextprotocol.kotlin.sdk.types.ElicitRequestParams
+import io.modelcontextprotocol.kotlin.sdk.types.ElicitResult
+import io.modelcontextprotocol.kotlin.sdk.types.EmptyResult
+import io.modelcontextprotocol.kotlin.sdk.types.ListRootsRequest
+import io.modelcontextprotocol.kotlin.sdk.types.ListRootsResult
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotification
+import io.modelcontextprotocol.kotlin.sdk.types.PingRequest
+import io.modelcontextprotocol.kotlin.sdk.types.RequestId
+import io.modelcontextprotocol.kotlin.sdk.types.ResourceUpdatedNotification
+import io.modelcontextprotocol.kotlin.sdk.types.ServerNotification
+
+/**
+ * Minimal [ClientConnection] stand-in used by DSL framework tests. We only need
+ * the handler signature satisfied — the registered tool handlers do not touch
+ * the connection for simple request/response tool calls.
+ */
+internal object StubClientConnection : ClientConnection {
+    override val sessionId: String = "stub"
+
+    override suspend fun notification(
+        notification: ServerNotification,
+        relatedRequestId: RequestId?
+    ) = Unit
+    override suspend fun ping(request: PingRequest, options: RequestOptions?): EmptyResult =
+        error("stub")
+    override suspend fun createMessage(
+        request: CreateMessageRequest,
+        options: RequestOptions?
+    ): CreateMessageResult = error("stub")
+    override suspend fun listRoots(
+        request: ListRootsRequest,
+        options: RequestOptions?
+    ): ListRootsResult = error("stub")
+    override suspend fun createElicitation(
+        message: String,
+        requestedSchema: ElicitRequestParams.RequestedSchema,
+        options: RequestOptions?
+    ): ElicitResult = error("stub")
+    override suspend fun createElicitation(
+        request: ElicitRequest,
+        options: RequestOptions?
+    ): ElicitResult = error("stub")
+    override suspend fun sendLoggingMessage(notification: LoggingMessageNotification) = Unit
+    override suspend fun sendResourceUpdated(notification: ResourceUpdatedNotification) = Unit
+    override suspend fun sendResourceListChanged() = Unit
+    override suspend fun sendToolListChanged() = Unit
+    override suspend fun sendPromptListChanged() = Unit
+}

--- a/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/ToolResultConversionTest.kt
+++ b/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/ToolResultConversionTest.kt
@@ -1,0 +1,37 @@
+package com.rousecontext.mcp.tool
+
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ToolResultConversionTest {
+
+    @Test
+    fun `success becomes non-error CallToolResult with text content`() {
+        val r = ToolResult.Success("hello").toCallToolResult()
+        assertFalse(r.isError == true)
+        val text = (r.content.first() as TextContent).text
+        assertEquals("hello", text)
+    }
+
+    @Test
+    fun `error becomes isError=true with message preserved`() {
+        val r = ToolResult.Error("bad things").toCallToolResult()
+        assertTrue(r.isError == true)
+        val text = (r.content.first() as TextContent).text
+        assertEquals("bad things", text)
+    }
+
+    @Test
+    fun `json serializes element into a text content block`() {
+        val payload = buildJsonObject { put("ok", JsonPrimitive(true)) }
+        val r = ToolResult.Json(payload).toCallToolResult()
+        assertFalse(r.isError == true)
+        val text = (r.content.first() as TextContent).text
+        assertEquals("""{"ok":true}""", text)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ ktor-client-websockets = { group = "io.ktor", name = "ktor-client-websockets", v
 ktor-server-websockets = { group = "io.ktor", name = "ktor-server-websockets", version.ref = "ktor" }
 kotlinx-io-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-io-core", version.ref = "kotlinx-io" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
+kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect", version.ref = "kotlin" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit-jupiter" }
 junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit-jupiter" }

--- a/integrations/src/main/kotlin/com/rousecontext/integrations/outreach/OutreachMcpProvider.kt
+++ b/integrations/src/main/kotlin/com/rousecontext/integrations/outreach/OutreachMcpProvider.kt
@@ -19,16 +19,13 @@ import com.rousecontext.mcp.core.Clock
 import com.rousecontext.mcp.core.McpServerProvider
 import com.rousecontext.mcp.core.RateLimiter
 import com.rousecontext.mcp.core.SystemClock
+import com.rousecontext.mcp.tool.McpTool
+import com.rousecontext.mcp.tool.ToolResult
+import com.rousecontext.mcp.tool.registerTool
 import io.modelcontextprotocol.kotlin.sdk.server.Server
-import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
-import io.modelcontextprotocol.kotlin.sdk.types.TextContent
-import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -36,6 +33,9 @@ import kotlinx.serialization.json.jsonPrimitive
 /**
  * MCP server provider for outreach actions: launching apps, opening links,
  * copying to clipboard, sending notifications, and optionally controlling DND.
+ *
+ * Tools are authored with the [McpTool] DSL; this provider just wires
+ * dependencies and registers them.
  */
 class OutreachMcpProvider(
     private val context: Context,
@@ -57,17 +57,23 @@ class OutreachMcpProvider(
 
     override fun register(server: Server) {
         ensureNotificationChannel()
-        registerLaunchApp(server)
-        registerOpenLink(server)
-        registerCopyToClipboard(server)
-        registerSendNotification(server)
-        registerListInstalledApps(server)
-        registerCreateNotificationChannel(server)
-        registerListNotificationChannels(server)
-        registerDeleteNotificationChannel(server)
+        server.registerTool { LaunchAppTool(context, canLaunchDirectly, launchNotifier) }
+        server.registerTool { OpenLinkTool(context, canLaunchDirectly, launchNotifier) }
+        server.registerTool { CopyToClipboardTool(context) }
+        server.registerTool {
+            SendNotificationTool(
+                context = context,
+                rateLimiter = notificationRateLimiter,
+                idCounter = notificationIdCounter
+            )
+        }
+        server.registerTool { ListInstalledAppsTool(context) }
+        server.registerTool { CreateNotificationChannelTool(context) }
+        server.registerTool { ListNotificationChannelsTool(context) }
+        server.registerTool { DeleteNotificationChannelTool(context) }
         if (dndEnabled) {
-            registerGetDndState(server)
-            registerSetDndState(server)
+            server.registerTool { GetDndStateTool(context) }
+            server.registerTool { SetDndStateTool(context) }
         }
     }
 
@@ -86,477 +92,15 @@ class OutreachMcpProvider(
         }
     }
 
-    private fun registerLaunchApp(server: Server) {
-        server.addTool(
-            name = "launch_app",
-            description = "Launch an installed app on the device by package name",
-            inputSchema = launchAppSchema()
-        ) { request ->
-            val packageName = request.params.arguments?.get("package_name")?.jsonPrimitive?.content
-                ?: return@addTool errorResult("Missing package_name")
-
-            val intent = context.packageManager.getLaunchIntentForPackage(packageName)
-                ?: return@addTool errorResult("App not found: $packageName")
-
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-
-            // Add simple string extras only (security: no arbitrary types)
-            request.params.arguments?.get("extras")?.jsonObject?.forEach { (key, value) ->
-                intent.putExtra(key, value.jsonPrimitive.content)
-            }
-
-            launchActivitySafely(
-                intent = intent,
-                description = "launch $packageName",
-                fallback = { launchNotifier?.postLaunchApp(intent, packageName) }
-            )
-        }
-    }
-
-    private fun registerOpenLink(server: Server) {
-        server.addTool(
-            name = "open_link",
-            description = "Open a URL in the default browser or appropriate app",
-            inputSchema = stringParamSchema("url", "URL to open (http or https only)")
-        ) { request ->
-            val url = request.params.arguments?.get("url")?.jsonPrimitive?.content
-                ?: return@addTool errorResult("Missing url")
-
-            val uri = Uri.parse(url)
-            val scheme = uri.scheme?.lowercase()
-            if (scheme != "http" && scheme != "https") {
-                return@addTool errorResult(
-                    "Only http and https URLs are allowed, got: $scheme"
-                )
-            }
-
-            val intent = Intent(Intent.ACTION_VIEW, uri).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            }
-
-            launchActivitySafely(
-                intent = intent,
-                description = "open $url",
-                fallback = { launchNotifier?.postOpenLink(intent, url) }
-            )
-        }
-    }
-
-    private fun registerCopyToClipboard(server: Server) {
-        server.addTool(
-            name = "copy_to_clipboard",
-            description = "Copy text to the device clipboard",
-            inputSchema = clipboardSchema()
-        ) { request ->
-            val text = request.params.arguments?.get("text")?.jsonPrimitive?.content
-                ?: return@addTool errorResult("Missing text")
-            val label = request.params.arguments?.get("label")?.jsonPrimitive?.content
-                ?: "Copied text"
-
-            withContext(Dispatchers.Main) {
-                val clipboard = context.getSystemService(ClipboardManager::class.java)
-                clipboard.setPrimaryClip(ClipData.newPlainText(label, text))
-            }
-
-            successResult("Copied to clipboard")
-        }
-    }
-
-    private fun registerSendNotification(server: Server) {
-        server.addTool(
-            name = "send_notification",
-            description = "Send a notification to the user on the device",
-            inputSchema = notificationSchema()
-        ) { request ->
-            val title = request.params.arguments?.get("title")?.jsonPrimitive?.content
-                ?: return@addTool errorResult("Missing title")
-            val message = request.params.arguments?.get("message")?.jsonPrimitive?.content
-                ?: return@addTool errorResult("Missing message")
-            val priority = request.params.arguments?.get("priority")?.jsonPrimitive?.content
-            val channelId = request.params.arguments?.get("channel_id")?.jsonPrimitive?.content
-
-            if (!notificationRateLimiter.tryAcquire("send_notification")) {
-                return@addTool errorResult(
-                    "Rate limited: max $MAX_NOTIFICATIONS_PER_MINUTE per minute"
-                )
-            }
-
-            val resolvedChannel = resolveChannelId(channelId)
-            val notificationId = notificationIdCounter.getAndIncrement()
-            val builder = buildNotification(title, message, priority, resolvedChannel)
-            addNotificationActions(builder, request, notificationId)
-
-            val nm = context.getSystemService(NotificationManager::class.java)
-            nm.notify(notificationId, builder.build())
-            CallToolResult(
-                content = listOf(
-                    TextContent(
-                        """{"success":true,"notification_id":$notificationId}"""
-                    )
-                )
-            )
-        }
-    }
-
-    /**
-     * Resolve a channel_id parameter to an actual channel ID.
-     * If provided, ensures it has the AI prefix. If omitted, uses default.
-     */
-    private fun resolveChannelId(channelId: String?): String {
-        if (channelId == null) return CHANNEL_ID
-        return if (channelId.startsWith(AI_CHANNEL_PREFIX)) {
-            channelId
-        } else {
-            "$AI_CHANNEL_PREFIX$channelId"
-        }
-    }
-
-    private fun buildNotification(
-        title: String,
-        message: String,
-        priority: String?,
-        channelId: String = CHANNEL_ID
-    ): NotificationCompat.Builder = NotificationCompat.Builder(context, channelId)
-        .setSmallIcon(com.rousecontext.api.R.drawable.ic_stat_rouse)
-        .setContentTitle(title)
-        .setContentText(message)
-        .setAutoCancel(true)
-        .setPriority(parsePriority(priority))
-
-    private fun addNotificationActions(
-        builder: NotificationCompat.Builder,
-        request: io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest,
-        notificationId: Int
-    ) {
-        request.params.arguments?.get("actions")?.jsonArray
-            ?.take(MAX_NOTIFICATION_ACTIONS)
-            ?.forEach { actionElement ->
-                val action = actionElement.jsonObject
-                val label = action["label"]?.jsonPrimitive?.content
-                    ?: return@forEach
-                val url = action["url"]?.jsonPrimitive?.content
-                    ?: return@forEach
-                val uri = Uri.parse(url)
-                val scheme = uri.scheme?.lowercase()
-                if (scheme == "http" || scheme == "https") {
-                    val intent = Intent(Intent.ACTION_VIEW, uri)
-                    val pi = PendingIntent.getActivity(
-                        context,
-                        notificationId + label.hashCode(),
-                        intent,
-                        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_ONE_SHOT
-                    )
-                    builder.addAction(0, label, pi)
-                }
-            }
-    }
-
-    private fun registerCreateNotificationChannel(server: Server) {
-        server.addTool(
-            name = "create_notification_channel",
-            description = "Create a notification channel for sending categorized notifications",
-            inputSchema = createChannelSchema()
-        ) { request ->
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-                return@addTool successResult(
-                    "Channel creation not supported on this Android version (API < 26). " +
-                        "Notifications will still work with default settings."
-                )
-            }
-
-            val rawId = request.params.arguments?.get("id")?.jsonPrimitive?.content
-                ?: return@addTool errorResult("Missing id")
-            val name = request.params.arguments?.get("name")?.jsonPrimitive?.content
-                ?: return@addTool errorResult("Missing name")
-            val description = request.params.arguments?.get("description")?.jsonPrimitive?.content
-            val importance = request.params.arguments?.get("importance")?.jsonPrimitive?.content
-                ?: "default"
-            val vibrate = request.params.arguments?.get("vibrate")?.jsonPrimitive?.content
-                ?.toBooleanStrictOrNull()
-            val sound = request.params.arguments?.get("sound")?.jsonPrimitive?.content
-                ?.toBooleanStrictOrNull() ?: true
-            val showBadge = request.params.arguments?.get("show_badge")?.jsonPrimitive?.content
-                ?.toBooleanStrictOrNull()
-
-            val channelId = if (rawId.startsWith(AI_CHANNEL_PREFIX)) {
-                rawId
-            } else {
-                "$AI_CHANNEL_PREFIX$rawId"
-            }
-            val level = parseImportance(importance)
-
-            val channel = NotificationChannel(channelId, name, level).apply {
-                if (description != null) this.description = description
-                if (vibrate != null) enableVibration(vibrate)
-                if (!sound) setSound(null, null)
-                if (showBadge != null) setShowBadge(showBadge)
-            }
-
-            val nm = context.getSystemService(NotificationManager::class.java)
-            nm.createNotificationChannel(channel)
-
-            CallToolResult(
-                content = listOf(
-                    TextContent(
-                        buildChannelJson(nm.getNotificationChannel(channelId))
-                    )
-                )
-            )
-        }
-    }
-
-    private fun registerListNotificationChannels(server: Server) {
-        server.addTool(
-            name = "list_notification_channels",
-            description = "List AI-created notification channels on the device",
-            inputSchema = ToolSchema(properties = buildJsonObject {}, required = emptyList())
-        ) { _ ->
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-                return@addTool CallToolResult(
-                    content = listOf(TextContent("[]"))
-                )
-            }
-
-            val nm = context.getSystemService(NotificationManager::class.java)
-            val channels = nm.notificationChannels
-                .filter { it.id.startsWith(AI_CHANNEL_PREFIX) }
-                .joinToString(",") { buildChannelJson(it) }
-
-            CallToolResult(
-                content = listOf(TextContent("[$channels]"))
-            )
-        }
-    }
-
-    private fun registerDeleteNotificationChannel(server: Server) {
-        server.addTool(
-            name = "delete_notification_channel",
-            description = "Delete an AI-created notification channel",
-            inputSchema = stringParamSchema("id", "Channel ID to delete")
-        ) { request ->
-            val rawId = request.params.arguments?.get("id")?.jsonPrimitive?.content
-                ?: return@addTool errorResult("Missing id")
-
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-                return@addTool successResult(
-                    "Channel deletion not supported on this Android version (API < 26)"
-                )
-            }
-
-            val channelId = if (rawId.startsWith(AI_CHANNEL_PREFIX)) {
-                rawId
-            } else {
-                "$AI_CHANNEL_PREFIX$rawId"
-            }
-
-            val nm = context.getSystemService(NotificationManager::class.java)
-            val existing = nm.getNotificationChannel(channelId)
-                ?: return@addTool errorResult("Channel not found: $channelId")
-
-            nm.deleteNotificationChannel(channelId)
-            successResult("Deleted channel: ${existing.name}")
-        }
-    }
-
-    @Suppress("MagicNumber")
-    private fun buildChannelJson(channel: NotificationChannel): String {
-        val imp = when (channel.importance) {
-            NotificationManager.IMPORTANCE_MIN -> "min"
-            NotificationManager.IMPORTANCE_LOW -> "low"
-            NotificationManager.IMPORTANCE_HIGH -> "high"
-            else -> "default"
-        }
-        val desc = channel.description?.escapeJson() ?: ""
-        return """{"id":"${channel.id}","name":"${channel.name.toString().escapeJson()}",""" +
-            """"description":"$desc","importance":"$imp",""" +
-            """"vibration":${channel.shouldVibrate()},""" +
-            """"sound":${channel.sound != null},""" +
-            """"show_badge":${channel.canShowBadge()}}"""
-    }
-
-    private fun registerListInstalledApps(server: Server) {
-        server.addTool(
-            name = "list_installed_apps",
-            description = "List installed apps on the device",
-            inputSchema = optionalStringSchema("filter", "Optional text to filter apps by name")
-        ) { request ->
-            val filter = request.params.arguments?.get(
-                "filter"
-            )?.jsonPrimitive?.content?.lowercase()
-            val apps = queryInstalledApps(filter)
-            CallToolResult(
-                content = listOf(TextContent("[${apps.joinToString(",")}]"))
-            )
-        }
-    }
-
-    @Suppress("DEPRECATION")
-    private fun queryInstalledApps(filter: String?): List<String> {
-        val pm = context.packageManager
-        val allApps = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            pm.getInstalledApplications(
-                PackageManager.ApplicationInfoFlags.of(0)
-            )
-        } else {
-            pm.getInstalledApplications(0)
-        }
-        return allApps.mapNotNull { appInfo ->
-            // Filter out system apps that aren't user-visible (no launcher intent, not updated)
-            val isSystem = appInfo.flags and ApplicationInfo.FLAG_SYSTEM != 0
-            val isUpdatedSystem = appInfo.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP != 0
-            val hasLauncher = pm.getLaunchIntentForPackage(appInfo.packageName) != null
-            if (isSystem && !isUpdatedSystem && !hasLauncher) return@mapNotNull null
-
-            val appName = pm.getApplicationLabel(appInfo).toString()
-            if (filter != null && !appName.lowercase().contains(filter)) {
-                null
-            } else {
-                val systemFlag = isSystem && !isUpdatedSystem
-                """{"package":"${appInfo.packageName}",""" +
-                    """"name":"${appName.escapeJson()}",""" +
-                    """"system":$systemFlag}"""
-            }
-        }.sorted()
-    }
-
-    private fun registerGetDndState(server: Server) {
-        server.addTool(
-            name = "get_dnd_state",
-            description = "Check Do Not Disturb status",
-            inputSchema = ToolSchema(properties = buildJsonObject {}, required = emptyList())
-        ) { _ ->
-            val nm = context.getSystemService(NotificationManager::class.java)
-            val filter = nm.currentInterruptionFilter
-            val enabled = filter != NotificationManager.INTERRUPTION_FILTER_ALL
-            val mode = filterToMode(filter)
-            CallToolResult(
-                content = listOf(
-                    TextContent("""{"enabled":$enabled,"mode":"$mode"}""")
-                )
-            )
-        }
-    }
-
-    private fun registerSetDndState(server: Server) {
-        server.addTool(
-            name = "set_dnd_state",
-            description = "Control Do Not Disturb state",
-            inputSchema = dndSchema()
-        ) { request ->
-            handleSetDnd(request)
-        }
-    }
-
-    private fun handleSetDnd(
-        request: io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
-    ): CallToolResult {
-        val enabledStr = request.params.arguments?.get("enabled")?.jsonPrimitive?.content
-        val enabled = enabledStr?.toBooleanStrictOrNull()
-            ?: return errorResult(
-                "Missing or invalid 'enabled' (must be true/false)"
-            )
-        val mode = request.params.arguments?.get("mode")?.jsonPrimitive?.content
-
-        val nm = context.getSystemService(NotificationManager::class.java)
-
-        if (!nm.isNotificationPolicyAccessGranted) {
-            return errorResult(
-                "ACCESS_NOTIFICATION_POLICY permission not granted"
-            )
-        }
-
-        val previousFilter = nm.currentInterruptionFilter
-        val previousEnabled =
-            previousFilter != NotificationManager.INTERRUPTION_FILTER_ALL
-        val previousMode = filterToMode(previousFilter)
-
-        val newFilter = if (!enabled) {
-            NotificationManager.INTERRUPTION_FILTER_ALL
-        } else {
-            modeToFilter(mode)
-        }
-
-        nm.setInterruptionFilter(newFilter)
-
-        return CallToolResult(
-            content = listOf(
-                TextContent(
-                    """{"success":true,"previous_state":""" +
-                        """{"enabled":$previousEnabled,"mode":"$previousMode"}}"""
-                )
-            )
-        )
-    }
-
-    /**
-     * Launch an activity, or fall back to a tap-to-launch notification when the
-     * app cannot start activities directly from the background.
-     *
-     * On Android 14+ the sender of a PendingIntent must hold background-activity-start
-     * privilege at `send()` time. `FOREGROUND_SERVICE_TYPE_DATA_SYNC` (what Rouse uses)
-     * does NOT grant BAL, so without SYSTEM_ALERT_WINDOW the PendingIntent silently
-     * no-ops. The [canLaunchDirectly] predicate decides which path to take; the
-     * notification path stays valid regardless of BAL since tap-launches are always
-     * allowed.
-     *
-     * On pre-Android-14, [canLaunchDirectly] defaults to true and the PendingIntent
-     * path is used as before.
-     */
-    @Suppress("TooGenericExceptionCaught")
-    private fun launchActivitySafely(
-        intent: Intent,
-        description: String,
-        fallback: () -> Int?
-    ): CallToolResult {
-        if (!canLaunchDirectly() && launchNotifier != null) {
-            return try {
-                val id = fallback()
-                if (id != null) {
-                    successResult("Notification posted: tap to $description")
-                } else {
-                    errorResult("Failed to $description: no fallback notifier available")
-                }
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to post launch notification for $description", e)
-                errorResult(
-                    "Failed to $description: ${e.javaClass.simpleName} - ${e.message}"
-                )
-            }
-        }
-
-        return try {
-            val pendingIntent = PendingIntent.getActivity(
-                context,
-                intent.hashCode(),
-                intent,
-                PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-            )
-            pendingIntent.send()
-            successResult("Launched: $description")
-        } catch (e: android.content.ActivityNotFoundException) {
-            Log.e(TAG, "No activity found to $description", e)
-            errorResult("No app found to $description: ${e.message}")
-        } catch (e: SecurityException) {
-            Log.e(TAG, "Permission denied to $description", e)
-            errorResult("Permission denied to $description: ${e.message}")
-        } catch (e: PendingIntent.CanceledException) {
-            Log.e(TAG, "PendingIntent cancelled for $description", e)
-            errorResult("Failed to $description: activity launch was cancelled")
-        } catch (e: Exception) {
-            Log.e(TAG, "Unexpected error trying to $description", e)
-            errorResult("Failed to $description: ${e.javaClass.simpleName} - ${e.message}")
-        }
-    }
-
     companion object {
         const val CHANNEL_ID = "outreach"
         const val AI_CHANNEL_PREFIX = "rouse_ai_"
-        private const val CHANNEL_NAME = "AI Outreach"
-        private const val NOTIFICATION_ID_BASE = 10000
-        private const val MAX_NOTIFICATIONS_PER_MINUTE = 10
-        private const val RATE_LIMIT_WINDOW_MS = 60_000L
-        private const val MAX_NOTIFICATION_ACTIONS = 3
-        private const val TAG = "OutreachMcp"
+        internal const val CHANNEL_NAME = "AI Outreach"
+        internal const val NOTIFICATION_ID_BASE = 10000
+        internal const val MAX_NOTIFICATIONS_PER_MINUTE = 10
+        internal const val RATE_LIMIT_WINDOW_MS = 60_000L
+        internal const val MAX_NOTIFICATION_ACTIONS = 3
+        internal const val TAG = "OutreachMcp"
 
         /**
          * Default "can launch activity directly" check used when the caller does
@@ -573,310 +117,431 @@ class OutreachMcpProvider(
     }
 }
 
-private fun parseImportance(importance: String?): Int = when (importance?.lowercase()) {
+// ---------- tools ----------
+
+internal class LaunchAppTool(
+    private val context: Context,
+    private val canLaunchDirectly: () -> Boolean,
+    private val launchNotifier: LaunchRequestNotifierApi?
+) : McpTool() {
+    override val name = "launch_app"
+    override val description = "Launch an installed app on the device by package name"
+
+    val packageName by stringParam("package_name", "Package name of the app to launch")
+    val extras by mapParam("extras", "Optional string key-value extras to pass to the intent")
+        .optional()
+
+    override suspend fun execute(): ToolResult {
+        val pkg = packageName!!
+        val intent = context.packageManager.getLaunchIntentForPackage(pkg)
+            ?: return outreachError("App not found: $pkg")
+
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        extras?.forEach { (k, v) -> intent.putExtra(k, v) }
+
+        return launchActivitySafely(
+            context = context,
+            canLaunchDirectly = canLaunchDirectly,
+            launchNotifier = launchNotifier,
+            intent = intent,
+            description = "launch $pkg",
+            fallback = { launchNotifier?.postLaunchApp(intent, pkg) }
+        )
+    }
+}
+
+internal class OpenLinkTool(
+    private val context: Context,
+    private val canLaunchDirectly: () -> Boolean,
+    private val launchNotifier: LaunchRequestNotifierApi?
+) : McpTool() {
+    override val name = "open_link"
+    override val description = "Open a URL in the default browser or appropriate app"
+
+    val url by stringParam("url", "URL to open (http or https only)")
+
+    override suspend fun execute(): ToolResult {
+        val u = url!!
+        val uri = Uri.parse(u)
+        val scheme = uri.scheme?.lowercase()
+        if (scheme != "http" && scheme != "https") {
+            return outreachError("Only http and https URLs are allowed, got: $scheme")
+        }
+        val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        return launchActivitySafely(
+            context = context,
+            canLaunchDirectly = canLaunchDirectly,
+            launchNotifier = launchNotifier,
+            intent = intent,
+            description = "open $u",
+            fallback = { launchNotifier?.postOpenLink(intent, u) }
+        )
+    }
+}
+
+internal class CopyToClipboardTool(private val context: Context) : McpTool() {
+    override val name = "copy_to_clipboard"
+    override val description = "Copy text to the device clipboard"
+
+    val text by stringParam("text", "Text to copy")
+    val label by stringParam("label", "Optional label describing the content").optional()
+
+    override suspend fun execute(): ToolResult {
+        withContext(Dispatchers.Main) {
+            val clipboard = context.getSystemService(ClipboardManager::class.java)
+            clipboard.setPrimaryClip(ClipData.newPlainText(label ?: "Copied text", text))
+        }
+        return outreachSuccess("Copied to clipboard")
+    }
+}
+
+internal class SendNotificationTool(
+    private val context: Context,
+    private val rateLimiter: RateLimiter,
+    private val idCounter: AtomicInteger
+) : McpTool() {
+    override val name = "send_notification"
+    override val description = "Send a notification to the user on the device"
+
+    val title by stringParam("title", "Notification title")
+    val message by stringParam("message", "Notification body text")
+    val priority by stringParam("priority", "Notification priority: low, default, or high")
+        .optional().choices("low", "default", "high")
+    val channelId by stringParam(
+        "channel_id",
+        "Optional channel ID created via create_notification_channel. Uses default channel if omitted."
+    ).optional()
+
+    override suspend fun execute(): ToolResult {
+        if (!rateLimiter.tryAcquire("send_notification")) {
+            return outreachError(
+                "Rate limited: max ${OutreachMcpProvider.MAX_NOTIFICATIONS_PER_MINUTE} per minute"
+            )
+        }
+        val resolved = resolveChannelId(channelId)
+        val notificationId = idCounter.getAndIncrement()
+        val builder = NotificationCompat.Builder(context, resolved)
+            .setSmallIcon(com.rousecontext.api.R.drawable.ic_stat_rouse)
+            .setContentTitle(title!!)
+            .setContentText(message!!)
+            .setAutoCancel(true)
+            .setPriority(parsePriority(priority))
+        addNotificationActions(context, builder, rawArgs, notificationId)
+        val nm = context.getSystemService(NotificationManager::class.java)
+        nm.notify(notificationId, builder.build())
+        return ToolResult.Success("""{"success":true,"notification_id":$notificationId}""")
+    }
+}
+
+internal class ListInstalledAppsTool(private val context: Context) : McpTool() {
+    override val name = "list_installed_apps"
+    override val description = "List installed apps on the device"
+
+    val filter by stringParam("filter", "Optional text to filter apps by name").optional()
+
+    override suspend fun execute(): ToolResult {
+        val apps = queryInstalledApps(context, filter?.lowercase())
+        return ToolResult.Success("[${apps.joinToString(",")}]")
+    }
+}
+
+internal class CreateNotificationChannelTool(private val context: Context) : McpTool() {
+    override val name = "create_notification_channel"
+    override val description = "Create a notification channel for sending categorized notifications"
+
+    val id by stringParam("id", "Unique channel identifier")
+    val channelName by stringParam("name", "User-visible channel name")
+    val channelDescription by stringParam("description", "Optional channel description").optional()
+    val importance by stringParam("importance", "Channel importance: min, low, default, or high")
+        .default("default").choices("min", "low", "default", "high")
+    val vibrate by boolParam("vibrate", "Whether the channel should vibrate").optional()
+    val soundEnabled by boolParam("sound", "Whether to play sound (default true)").default(true)
+    val showBadge by boolParam("show_badge", "Whether to show badge on app icon").optional()
+
+    override suspend fun execute(): ToolResult {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return outreachSuccess(
+                "Channel creation not supported on this Android version (API < 26). " +
+                    "Notifications will still work with default settings."
+            )
+        }
+        val rawId = id!!
+        val channelId = if (rawId.startsWith(OutreachMcpProvider.AI_CHANNEL_PREFIX)) {
+            rawId
+        } else {
+            "${OutreachMcpProvider.AI_CHANNEL_PREFIX}$rawId"
+        }
+        val level = parseImportance(importance)
+        val wantsSound = soundEnabled
+        val wantsVibrate = vibrate
+        val wantsBadge = showBadge
+        val desc = channelDescription
+        val channel = NotificationChannel(channelId, channelName, level).apply {
+            desc?.let { description = it }
+            wantsVibrate?.let { enableVibration(it) }
+            if (wantsSound == false) setSound(null, null)
+            wantsBadge?.let { setShowBadge(it) }
+        }
+        val nm = context.getSystemService(NotificationManager::class.java)
+        nm.createNotificationChannel(channel)
+        return ToolResult.Success(buildChannelJson(nm.getNotificationChannel(channelId)))
+    }
+}
+
+internal class ListNotificationChannelsTool(private val context: Context) : McpTool() {
+    override val name = "list_notification_channels"
+    override val description = "List AI-created notification channels on the device"
+
+    override suspend fun execute(): ToolResult {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return ToolResult.Success("[]")
+        }
+        val nm = context.getSystemService(NotificationManager::class.java)
+        val channels = nm.notificationChannels
+            .filter { it.id.startsWith(OutreachMcpProvider.AI_CHANNEL_PREFIX) }
+            .joinToString(",") { buildChannelJson(it) }
+        return ToolResult.Success("[$channels]")
+    }
+}
+
+internal class DeleteNotificationChannelTool(private val context: Context) : McpTool() {
+    override val name = "delete_notification_channel"
+    override val description = "Delete an AI-created notification channel"
+
+    val id by stringParam("id", "Channel ID to delete")
+
+    override suspend fun execute(): ToolResult {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return outreachSuccess(
+                "Channel deletion not supported on this Android version (API < 26)"
+            )
+        }
+        val rawId = id!!
+        val channelId = if (rawId.startsWith(OutreachMcpProvider.AI_CHANNEL_PREFIX)) {
+            rawId
+        } else {
+            "${OutreachMcpProvider.AI_CHANNEL_PREFIX}$rawId"
+        }
+        val nm = context.getSystemService(NotificationManager::class.java)
+        val existing = nm.getNotificationChannel(channelId)
+            ?: return outreachError("Channel not found: $channelId")
+        nm.deleteNotificationChannel(channelId)
+        return outreachSuccess("Deleted channel: ${existing.name}")
+    }
+}
+
+internal class GetDndStateTool(private val context: Context) : McpTool() {
+    override val name = "get_dnd_state"
+    override val description = "Check Do Not Disturb status"
+
+    override suspend fun execute(): ToolResult {
+        val nm = context.getSystemService(NotificationManager::class.java)
+        val filter = nm.currentInterruptionFilter
+        val enabled = filter != NotificationManager.INTERRUPTION_FILTER_ALL
+        val mode = filterToMode(filter)
+        return ToolResult.Success("""{"enabled":$enabled,"mode":"$mode"}""")
+    }
+}
+
+internal class SetDndStateTool(private val context: Context) : McpTool() {
+    override val name = "set_dnd_state"
+    override val description = "Control Do Not Disturb state"
+
+    val enabled by boolParam("enabled", "Whether to enable or disable DND")
+    val mode by stringParam("mode", "DND mode: total_silence, priority_only, or alarms_only")
+        .optional().choices("total_silence", "priority_only", "alarms_only")
+
+    override suspend fun execute(): ToolResult {
+        val nm = context.getSystemService(NotificationManager::class.java)
+        if (!nm.isNotificationPolicyAccessGranted) {
+            return outreachError("ACCESS_NOTIFICATION_POLICY permission not granted")
+        }
+        val previousFilter = nm.currentInterruptionFilter
+        val previousEnabled =
+            previousFilter != NotificationManager.INTERRUPTION_FILTER_ALL
+        val previousMode = filterToMode(previousFilter)
+        val newFilter = if (enabled != true) {
+            NotificationManager.INTERRUPTION_FILTER_ALL
+        } else {
+            modeToFilter(mode)
+        }
+        nm.setInterruptionFilter(newFilter)
+        return ToolResult.Success(
+            """{"success":true,"previous_state":""" +
+                """{"enabled":$previousEnabled,"mode":"$previousMode"}}"""
+        )
+    }
+}
+
+// ---------- shared helpers ----------
+
+/**
+ * Launch an activity, or fall back to a tap-to-launch notification when the
+ * app cannot start activities directly from the background.
+ */
+@Suppress("TooGenericExceptionCaught", "LongParameterList")
+internal fun launchActivitySafely(
+    context: Context,
+    canLaunchDirectly: () -> Boolean,
+    launchNotifier: LaunchRequestNotifierApi?,
+    intent: Intent,
+    description: String,
+    fallback: () -> Int?
+): ToolResult {
+    if (!canLaunchDirectly() && launchNotifier != null) {
+        return try {
+            val id = fallback()
+            if (id != null) {
+                outreachSuccess("Notification posted: tap to $description")
+            } else {
+                outreachError("Failed to $description: no fallback notifier available")
+            }
+        } catch (e: Exception) {
+            Log.e(OutreachMcpProvider.TAG, "Failed to post launch notification for $description", e)
+            outreachError(
+                "Failed to $description: ${e.javaClass.simpleName} - ${e.message}"
+            )
+        }
+    }
+    return try {
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            intent.hashCode(),
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        pendingIntent.send()
+        outreachSuccess("Launched: $description")
+    } catch (e: android.content.ActivityNotFoundException) {
+        Log.e(OutreachMcpProvider.TAG, "No activity found to $description", e)
+        outreachError("No app found to $description: ${e.message}")
+    } catch (e: SecurityException) {
+        Log.e(OutreachMcpProvider.TAG, "Permission denied to $description", e)
+        outreachError("Permission denied to $description: ${e.message}")
+    } catch (e: PendingIntent.CanceledException) {
+        Log.e(OutreachMcpProvider.TAG, "PendingIntent cancelled for $description", e)
+        outreachError("Failed to $description: activity launch was cancelled")
+    } catch (e: Exception) {
+        Log.e(OutreachMcpProvider.TAG, "Unexpected error trying to $description", e)
+        outreachError("Failed to $description: ${e.javaClass.simpleName} - ${e.message}")
+    }
+}
+
+internal fun resolveChannelId(channelId: String?): String {
+    if (channelId == null) return OutreachMcpProvider.CHANNEL_ID
+    return if (channelId.startsWith(OutreachMcpProvider.AI_CHANNEL_PREFIX)) {
+        channelId
+    } else {
+        "${OutreachMcpProvider.AI_CHANNEL_PREFIX}$channelId"
+    }
+}
+
+internal fun addNotificationActions(
+    context: Context,
+    builder: NotificationCompat.Builder,
+    args: kotlinx.serialization.json.JsonObject?,
+    notificationId: Int
+) {
+    args?.get("actions")?.jsonArray
+        ?.take(OutreachMcpProvider.MAX_NOTIFICATION_ACTIONS)
+        ?.forEach { actionElement ->
+            val action = actionElement.jsonObject
+            val label = action["label"]?.jsonPrimitive?.content ?: return@forEach
+            val url = action["url"]?.jsonPrimitive?.content ?: return@forEach
+            val uri = Uri.parse(url)
+            val scheme = uri.scheme?.lowercase()
+            if (scheme == "http" || scheme == "https") {
+                val intent = Intent(Intent.ACTION_VIEW, uri)
+                val pi = PendingIntent.getActivity(
+                    context,
+                    notificationId + label.hashCode(),
+                    intent,
+                    PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_ONE_SHOT
+                )
+                builder.addAction(0, label, pi)
+            }
+        }
+}
+
+@Suppress("MagicNumber")
+internal fun buildChannelJson(channel: NotificationChannel): String {
+    val imp = when (channel.importance) {
+        NotificationManager.IMPORTANCE_MIN -> "min"
+        NotificationManager.IMPORTANCE_LOW -> "low"
+        NotificationManager.IMPORTANCE_HIGH -> "high"
+        else -> "default"
+    }
+    val desc = channel.description?.escapeJson() ?: ""
+    return """{"id":"${channel.id}","name":"${channel.name.toString().escapeJson()}",""" +
+        """"description":"$desc","importance":"$imp",""" +
+        """"vibration":${channel.shouldVibrate()},""" +
+        """"sound":${channel.sound != null},""" +
+        """"show_badge":${channel.canShowBadge()}}"""
+}
+
+@Suppress("DEPRECATION")
+internal fun queryInstalledApps(context: Context, filter: String?): List<String> {
+    val pm = context.packageManager
+    val allApps = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        pm.getInstalledApplications(PackageManager.ApplicationInfoFlags.of(0))
+    } else {
+        pm.getInstalledApplications(0)
+    }
+    return allApps.mapNotNull { appInfo ->
+        val isSystem = appInfo.flags and ApplicationInfo.FLAG_SYSTEM != 0
+        val isUpdatedSystem = appInfo.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP != 0
+        val hasLauncher = pm.getLaunchIntentForPackage(appInfo.packageName) != null
+        if (isSystem && !isUpdatedSystem && !hasLauncher) return@mapNotNull null
+        val appName = pm.getApplicationLabel(appInfo).toString()
+        if (filter != null && !appName.lowercase().contains(filter)) {
+            null
+        } else {
+            val systemFlag = isSystem && !isUpdatedSystem
+            """{"package":"${appInfo.packageName}",""" +
+                """"name":"${appName.escapeJson()}",""" +
+                """"system":$systemFlag}"""
+        }
+    }.sorted()
+}
+
+internal fun parseImportance(importance: String?): Int = when (importance?.lowercase()) {
     "min" -> NotificationManager.IMPORTANCE_MIN
     "low" -> NotificationManager.IMPORTANCE_LOW
     "high" -> NotificationManager.IMPORTANCE_HIGH
     else -> NotificationManager.IMPORTANCE_DEFAULT
 }
 
-private fun parsePriority(priority: String?): Int = when (priority?.lowercase()) {
+internal fun parsePriority(priority: String?): Int = when (priority?.lowercase()) {
     "low" -> NotificationCompat.PRIORITY_LOW
     "high" -> NotificationCompat.PRIORITY_HIGH
     else -> NotificationCompat.PRIORITY_DEFAULT
 }
 
-private fun filterToMode(filter: Int): String = when (filter) {
+internal fun filterToMode(filter: Int): String = when (filter) {
     NotificationManager.INTERRUPTION_FILTER_NONE -> "total_silence"
     NotificationManager.INTERRUPTION_FILTER_PRIORITY -> "priority_only"
     NotificationManager.INTERRUPTION_FILTER_ALARMS -> "alarms_only"
     else -> "off"
 }
 
-private fun modeToFilter(mode: String?): Int = when (mode) {
+internal fun modeToFilter(mode: String?): Int = when (mode) {
     "total_silence" -> NotificationManager.INTERRUPTION_FILTER_NONE
     "alarms_only" -> NotificationManager.INTERRUPTION_FILTER_ALARMS
     else -> NotificationManager.INTERRUPTION_FILTER_PRIORITY
 }
 
-private fun errorResult(message: String): CallToolResult = CallToolResult(
-    content = listOf(TextContent("""{"success":false,"error":"$message"}""")),
-    isError = true
+internal fun outreachError(message: String): ToolResult = ToolResult.Error(
+    """{"success":false,"error":"$message"}"""
 )
 
-private fun successResult(message: String): CallToolResult = CallToolResult(
-    content = listOf(TextContent("""{"success":true,"message":"$message"}"""))
+internal fun outreachSuccess(message: String): ToolResult = ToolResult.Success(
+    """{"success":true,"message":"$message"}"""
 )
 
-private fun String.escapeJson(): String = replace("\\", "\\\\")
+internal fun String.escapeJson(): String = replace("\\", "\\\\")
     .replace("\"", "\\\"")
     .replace("\n", "\\n")
     .replace("\r", "\\r")
     .replace("\t", "\\t")
-
-// --- Input schema builders ---
-
-private fun launchAppSchema() = ToolSchema(
-    properties = buildJsonObject {
-        put(
-            "package_name",
-            buildJsonObject {
-                put("type", JsonPrimitive("string"))
-                put("description", JsonPrimitive("Package name of the app to launch"))
-            }
-        )
-        put(
-            "extras",
-            buildJsonObject {
-                put("type", JsonPrimitive("object"))
-                put(
-                    "description",
-                    JsonPrimitive("Optional string key-value extras to pass to the intent")
-                )
-                put(
-                    "additionalProperties",
-                    buildJsonObject { put("type", JsonPrimitive("string")) }
-                )
-            }
-        )
-    },
-    required = listOf("package_name")
-)
-
-private fun stringParamSchema(name: String, desc: String) = ToolSchema(
-    properties = buildJsonObject {
-        put(
-            name,
-            buildJsonObject {
-                put("type", JsonPrimitive("string"))
-                put("description", JsonPrimitive(desc))
-            }
-        )
-    },
-    required = listOf(name)
-)
-
-private fun optionalStringSchema(name: String, desc: String) = ToolSchema(
-    properties = buildJsonObject {
-        put(
-            name,
-            buildJsonObject {
-                put("type", JsonPrimitive("string"))
-                put("description", JsonPrimitive(desc))
-            }
-        )
-    },
-    required = emptyList()
-)
-
-private fun clipboardSchema() = ToolSchema(
-    properties = buildJsonObject {
-        put(
-            "text",
-            buildJsonObject {
-                put("type", JsonPrimitive("string"))
-                put("description", JsonPrimitive("Text to copy"))
-            }
-        )
-        put(
-            "label",
-            buildJsonObject {
-                put("type", JsonPrimitive("string"))
-                put("description", JsonPrimitive("Optional label describing the content"))
-            }
-        )
-    },
-    required = listOf("text")
-)
-
-private fun notificationSchema() = ToolSchema(
-    properties = buildJsonObject {
-        put(
-            "title",
-            buildJsonObject {
-                put("type", JsonPrimitive("string"))
-                put("description", JsonPrimitive("Notification title"))
-            }
-        )
-        put(
-            "message",
-            buildJsonObject {
-                put("type", JsonPrimitive("string"))
-                put("description", JsonPrimitive("Notification body text"))
-            }
-        )
-        put(
-            "priority",
-            buildJsonObject {
-                put("type", JsonPrimitive("string"))
-                put(
-                    "description",
-                    JsonPrimitive("Notification priority: low, default, or high")
-                )
-                put(
-                    "enum",
-                    JsonArray(
-                        listOf(
-                            JsonPrimitive("low"),
-                            JsonPrimitive("default"),
-                            JsonPrimitive("high")
-                        )
-                    )
-                )
-            }
-        )
-        put(
-            "channel_id",
-            buildJsonObject {
-                put("type", JsonPrimitive("string"))
-                put(
-                    "description",
-                    JsonPrimitive(
-                        "Optional channel ID created via create_notification_channel. " +
-                            "Uses default channel if omitted."
-                    )
-                )
-            }
-        )
-        put(
-            "actions",
-            buildJsonObject {
-                put("type", JsonPrimitive("array"))
-                put("description", JsonPrimitive("Optional action buttons"))
-                put(
-                    "items",
-                    buildJsonObject {
-                        put("type", JsonPrimitive("object"))
-                        put(
-                            "properties",
-                            buildJsonObject {
-                                put(
-                                    "label",
-                                    buildJsonObject {
-                                        put("type", JsonPrimitive("string"))
-                                    }
-                                )
-                                put(
-                                    "url",
-                                    buildJsonObject {
-                                        put("type", JsonPrimitive("string"))
-                                    }
-                                )
-                            }
-                        )
-                        put(
-                            "required",
-                            JsonArray(
-                                listOf(JsonPrimitive("label"), JsonPrimitive("url"))
-                            )
-                        )
-                    }
-                )
-            }
-        )
-    },
-    required = listOf("title", "message")
-)
-
-@Suppress("LongMethod")
-private fun createChannelSchema() = ToolSchema(
-    properties = buildJsonObject {
-        put(
-            "id",
-            buildJsonObject {
-                put("type", JsonPrimitive("string"))
-                put("description", JsonPrimitive("Unique channel identifier"))
-            }
-        )
-        put(
-            "name",
-            buildJsonObject {
-                put("type", JsonPrimitive("string"))
-                put("description", JsonPrimitive("User-visible channel name"))
-            }
-        )
-        put(
-            "description",
-            buildJsonObject {
-                put("type", JsonPrimitive("string"))
-                put("description", JsonPrimitive("Optional channel description"))
-            }
-        )
-        put(
-            "importance",
-            buildJsonObject {
-                put("type", JsonPrimitive("string"))
-                put(
-                    "description",
-                    JsonPrimitive("Channel importance: min, low, default, or high")
-                )
-                put(
-                    "enum",
-                    JsonArray(
-                        listOf(
-                            JsonPrimitive("min"),
-                            JsonPrimitive("low"),
-                            JsonPrimitive("default"),
-                            JsonPrimitive("high")
-                        )
-                    )
-                )
-            }
-        )
-        put(
-            "vibrate",
-            buildJsonObject {
-                put("type", JsonPrimitive("boolean"))
-                put("description", JsonPrimitive("Whether the channel should vibrate"))
-            }
-        )
-        put(
-            "sound",
-            buildJsonObject {
-                put("type", JsonPrimitive("boolean"))
-                put("description", JsonPrimitive("Whether to play sound (default true)"))
-            }
-        )
-        put(
-            "show_badge",
-            buildJsonObject {
-                put("type", JsonPrimitive("boolean"))
-                put("description", JsonPrimitive("Whether to show badge on app icon"))
-            }
-        )
-    },
-    required = listOf("id", "name")
-)
-
-private fun dndSchema() = ToolSchema(
-    properties = buildJsonObject {
-        put(
-            "enabled",
-            buildJsonObject {
-                put("type", JsonPrimitive("boolean"))
-                put("description", JsonPrimitive("Whether to enable or disable DND"))
-            }
-        )
-        put(
-            "mode",
-            buildJsonObject {
-                put("type", JsonPrimitive("string"))
-                put(
-                    "description",
-                    JsonPrimitive("DND mode: total_silence, priority_only, or alarms_only")
-                )
-                put(
-                    "enum",
-                    JsonArray(
-                        listOf(
-                            JsonPrimitive("total_silence"),
-                            JsonPrimitive("priority_only"),
-                            JsonPrimitive("alarms_only")
-                        )
-                    )
-                )
-            }
-        )
-    },
-    required = listOf("enabled")
-)


### PR DESCRIPTION
## Summary
- Land the `McpTool` Clikt-style DSL in `:core:mcp` (framework + 5 test suites + 2-minute README)
- Migrate `:integrations/outreach` (ten tools) to the new shape as the first consumer; outreach provider shrinks from 883 → 547 lines
- Filed #154, #155, #156 for the three remaining provider migrations (usage / health / notifications)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Test plan
- [x] `./gradlew :core:mcp:jvmTest` — five new suites green (param extraction, schema generation, ToolResult conversion, registration/factory lifecycle, end-to-end through real Server)
- [x] `./gradlew :integrations:testDebugUnitTest` — existing `OutreachMcpProviderTest` passes unchanged against the migrated provider
- [x] `./gradlew :app:testDebugUnitTest` — no regressions
- [x] `./gradlew ktlintCheck detekt` — detekt sits at 72 weighted issues (baseline ~70; no new issues in the added framework / migrated code)

Framework: 628 LOC main + 698 LOC tests across seven test/helper files. Wire format for migrated tool successes and tool-logic errors is byte-identical; framework-level validation (missing required param, type mismatch, range, choices) is the only output path whose format changed and no existing tests / user-facing contracts exercised those paths.

Follow-ups (mechanical): #154, #155, #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)