### PR TITLE
Fix #216: flaky rotate_secret_cache_rejects_secrets_not_in_list

### DIFF
--- a/relay/tests/valid_secrets_cache_test.rs
+++ b/relay/tests/valid_secrets_cache_test.rs
@@ -181,6 +181,17 @@ async fn rotate_secret_updates_cache_and_passthrough_accepts_new_secret() {
 
 /// Passthrough should reject a secret that is not in the cache (and the
 /// cache is authoritative once seeded).
+///
+/// Regression note (#216): `/rotate-secret` generates
+/// `{adjective}-{integrationId}` secrets using `rand::thread_rng()`, drawing
+/// the adjective from the fixed list in `words::adjectives` which contains
+/// `"old"`. Rotating integration `"health"` therefore had a ~1/217 chance of
+/// producing the literal secret `"old-health"`, making this test flaky under
+/// any amount of parallel or repeated execution. To keep the assertion
+/// structurally collision-proof, we rotate a DIFFERENT integration
+/// (`"usage"`) than the one whose legacy secret we replay (`"old-health"`):
+/// the rotation produces `{adj}-usage`, which can never equal `"old-health"`
+/// for any adjective in the list.
 #[tokio::test]
 async fn rotate_secret_cache_rejects_secrets_not_in_list() {
     let firestore =
@@ -218,8 +229,10 @@ async fn rotate_secret_cache_rejects_secrets_not_in_list() {
         device_ca: Some(ca),
     });
 
-    // Ask the relay to generate a fresh health secret. The old secret
-    // ("old-health") is no longer in the cache after this call.
+    // Rotate the "usage" integration (not "health"). After this call the
+    // cache holds `[{adj}-usage]` for exactly one adjective pick, so the
+    // legacy `"old-health"` secret cannot be present in the cache under any
+    // RNG outcome.
     // DeviceIdentity is layered in to simulate mTLS (see #202).
     let app = build_router(app_state.clone()).layer(axum::Extension(DeviceIdentity {
         subdomain: "cool-penguin".to_string(),
@@ -230,7 +243,7 @@ async fn rotate_secret_cache_rejects_secrets_not_in_list() {
         .header("content-type", "application/json")
         .body(axum::body::Body::from(
             serde_json::json!({
-                "integrations": ["health"]
+                "integrations": ["usage"]
             })
             .to_string(),
         ))
@@ -246,8 +259,9 @@ async fn rotate_secret_cache_rejects_secrets_not_in_list() {
         Arc::new(MockFcm::new()),
     );
 
-    // An unknown secret must be rejected even if the legacy secret_prefix
-    // in Firestore matches.
+    // An unknown secret (the legacy "old-health", which is never in the
+    // rotated `{adj}-usage` set) must be rejected even if the legacy
+    // secret_prefix in Firestore matches.
     let result = resolve_device_stream(
         &ctx,
         "cool-penguin",


### PR DESCRIPTION
## Summary

- Flake was not a concurrency bug. `/rotate-secret` generates `{adjective}-{integrationId}` via `rand::thread_rng()`, and the adjective list in `relay/src/words/adjectives.rs` contains `"old"`. Rotating integration `"health"` therefore had a ~1/217 chance of producing the literal secret `"old-health"`, which is exactly the secret the test seeds as the "legacy" value and expects to be rejected. When rotation collided with it, the cache legitimately contained `"old-health"` and the assertion flipped.
- Parallel test runs just amplified the observation (more runs per CI invocation, more chances to roll `"old"`). Each test keeps its own `RelayState`/`SessionRegistry`/`MockFirestore`, and there is no global mutable state in the relay, so isolation was never the problem.
- Fix: rotate a different integration (`"usage"`) than the one whose legacy secret is replayed (`"old-health"`). The rotation now produces `{adj}-usage`, which can never equal `"old-health"` for any adjective in the list. Added a long regression-note comment to pin this reasoning.

## Test plan

- [x] `cd relay && cargo fmt`
- [x] `cd relay && cargo test` — full suite passes
- [x] `cd relay && cargo clippy --all-targets -- -D warnings` — clean
- [x] Ran `cargo test --test valid_secrets_cache_test rotate_secret_cache_rejects` in a 1000-iteration loop post-fix; 1000/1000 passes
- [x] Pre-fix repro on same machine: 1 FAIL in 500 runs, matching the ~1/217 theoretical rate

Closes #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)