### PR TITLE
Fix #215: Render relay env + firebase-sa from GH secrets at deploy time

### DIFF
--- a/.github/workflows/relay-deploy.yml
+++ b/.github/workflows/relay-deploy.yml
@@ -34,6 +34,51 @@ jobs:
         working-directory: relay
         run: cargo test
 
+      # Render runtime secrets into files the deploy step will ship to the VPS.
+      # We use printf + file redirection (NOT echo) and write into a mode-0700
+      # tempdir so values never appear in logs. GitHub log redaction is
+      # best-effort; file redirection is the belt-and-suspenders approach.
+      - name: Render /etc/rouse-relay/env + firebase-sa.json
+        if: github.ref == 'refs/heads/main'
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          RELAY_GTS_EAB_KID: ${{ secrets.RELAY_GTS_EAB_KID }}
+          RELAY_GTS_EAB_HMAC: ${{ secrets.RELAY_GTS_EAB_HMAC }}
+          RELAY_RUST_LOG: ${{ secrets.RELAY_RUST_LOG }}
+          RELAY_FIREBASE_SERVICE_ACCOUNT_JSON: ${{ secrets.RELAY_FIREBASE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          set -u -o pipefail
+          RENDER_DIR=$(mktemp -d)
+          chmod 700 "$RENDER_DIR"
+          echo "RENDER_DIR=$RENDER_DIR" >> "$GITHUB_ENV"
+
+          # Env file — systemd KEY=VALUE, no quoting needed (values have no spaces).
+          # Using printf with explicit format strings avoids any echo-flag pitfalls.
+          {
+            printf 'CLOUDFLARE_API_TOKEN=%s\n' "$CLOUDFLARE_API_TOKEN"
+            printf 'CLOUDFLARE_ZONE_ID=%s\n'   "$CLOUDFLARE_ZONE_ID"
+            printf 'RUST_LOG=%s\n'             "$RELAY_RUST_LOG"
+            printf 'GTS_EAB_KID=%s\n'          "$RELAY_GTS_EAB_KID"
+            printf 'GTS_EAB_HMAC=%s\n'         "$RELAY_GTS_EAB_HMAC"
+          } > "$RENDER_DIR/env"
+          chmod 600 "$RENDER_DIR/env"
+
+          # Firebase service account JSON comes in as base64 (multi-line-safe).
+          # Decode into place; do not echo the decoded contents.
+          printf '%s' "$RELAY_FIREBASE_SERVICE_ACCOUNT_JSON" \
+            | base64 -d > "$RENDER_DIR/firebase-sa.json"
+          chmod 600 "$RENDER_DIR/firebase-sa.json"
+
+          # Sanity check: rendered env must parse as KEY=VALUE and firebase-sa
+          # must be valid JSON. Never log contents, only counts.
+          env_lines=$(wc -l < "$RENDER_DIR/env")
+          sa_bytes=$(wc -c < "$RENDER_DIR/firebase-sa.json")
+          echo "Rendered env file: ${env_lines} lines"
+          echo "Rendered firebase-sa.json: ${sa_bytes} bytes"
+          python3 -c "import json,sys; json.load(open('$RENDER_DIR/firebase-sa.json'))"
+          echo "firebase-sa.json: valid JSON"
+
       - name: Deploy to VPS
         if: github.ref == 'refs/heads/main'
         env:
@@ -41,20 +86,52 @@ jobs:
           VPS_HOST: ${{ secrets.VPS_HOST }}
           VPS_USER: ${{ secrets.VPS_USER }}
         run: |
+          set -u -o pipefail
           mkdir -p ~/.ssh
-          echo "$SSH_KEY" > ~/.ssh/deploy_key
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H "$VPS_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
+          # Binary
           scp -i ~/.ssh/deploy_key \
             relay/target/x86_64-unknown-linux-musl/release/rouse-relay \
             "$VPS_USER@$VPS_HOST":/tmp/rouse-relay.new
 
+          # Runtime secrets (rendered in previous step)
+          scp -i ~/.ssh/deploy_key \
+            "$RENDER_DIR/env" \
+            "$VPS_USER@$VPS_HOST":/tmp/rouse-relay.env.new
+          scp -i ~/.ssh/deploy_key \
+            "$RENDER_DIR/firebase-sa.json" \
+            "$VPS_USER@$VPS_HOST":/tmp/rouse-relay.firebase-sa.json.new
+
           ssh -i ~/.ssh/deploy_key "$VPS_USER@$VPS_HOST" bash -s <<'EOF'
+          set -u -o pipefail
+
+          # Binary
           sudo mv /tmp/rouse-relay.new /opt/rouse-relay/rouse-relay
           sudo chmod +x /opt/rouse-relay/rouse-relay
           sudo chown relay:relay /opt/rouse-relay/rouse-relay
+
+          # Env file
+          sudo mv /tmp/rouse-relay.env.new /etc/rouse-relay/env
+          sudo chown root:relay /etc/rouse-relay/env
+          sudo chmod 0640 /etc/rouse-relay/env
+
+          # Firebase service account JSON
+          sudo mv /tmp/rouse-relay.firebase-sa.json.new /etc/rouse-relay/firebase-sa.json
+          sudo chown root:relay /etc/rouse-relay/firebase-sa.json
+          sudo chmod 0640 /etc/rouse-relay/firebase-sa.json
+
           sudo systemctl restart rouse-relay || echo "Service not fully configured yet"
           sleep 2
           sudo systemctl is-active rouse-relay || echo "Service not active (may need TLS cert)"
           EOF
+
+      - name: Shred render tempdir
+        if: always() && env.RENDER_DIR != ''
+        run: |
+          if [ -d "$RENDER_DIR" ]; then
+            find "$RENDER_DIR" -type f -exec shred -u {} + 2>/dev/null || true
+            rm -rf "$RENDER_DIR"
+          fi

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -251,3 +251,74 @@ If any step fails, tail the relay logs (`journalctl -u rouse-relay -f`) and the 
 **`strip_prefix("relay.")` doesn't match my hostname** — set `[server].base_domain` explicitly in `relay.toml`.
 
 **ACME rate limit (50 certs/week)** — use the staging directory (`https://acme-staging-v02.api.letsencrypt.org/directory`) for development, and persist `acme.account_key_path` so you don't register new accounts on every restart.
+
+## Appendix: Runtime secrets for the upstream deploy (maintainers)
+
+The upstream Rouse Context deploy reads all VPS runtime secrets from GitHub repo
+secrets at deploy time, rather than maintaining them by hand on the VPS. The
+`relay-deploy.yml` workflow renders `/etc/rouse-relay/env` and
+`/etc/rouse-relay/firebase-sa.json` on each run and SCPs them to the VPS.
+
+### Secret inventory
+
+Naming convention: secrets added during this migration use a `RELAY_` prefix.
+Secrets that predate the migration (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_ID`)
+keep their unprefixed names to avoid churn — the Cloudflare creds are also used
+directly by other workflows (e.g. cert renewal), not only at relay runtime.
+
+| GH secret name | Purpose | Format | Rotated by |
+|---|---|---|---|
+| `CLOUDFLARE_API_TOKEN` | DNS-01 challenges via Cloudflare API (relay runtime + cert renewal workflow) | plain token | Cloudflare dashboard |
+| `CLOUDFLARE_ZONE_ID` | Cloudflare zone id for `rousecontext.com` | hex string | Cloudflare dashboard |
+| `RELAY_RUST_LOG` | `RUST_LOG` value baked into the env file | e.g. `rustls=debug,rouse_relay=debug` | edit repo secret |
+| `RELAY_GTS_EAB_KID` | Google Trust Services ACME EAB key id | plain string | GTS console |
+| `RELAY_GTS_EAB_HMAC` | Google Trust Services ACME EAB HMAC | base64url | GTS console |
+| `RELAY_FIREBASE_SERVICE_ACCOUNT_JSON` | Service account JSON for FCM + Firebase Auth, **base64-encoded** | `base64` of the raw JSON file | Firebase console (new key) |
+
+### What the workflow does
+
+1. Renders the env file with `printf '%s=%s\n'` (not `echo`) into a mode-0700
+   tempdir on the runner. No secret values are ever passed as command-line args
+   or written to stdout.
+2. Base64-decodes `RELAY_FIREBASE_SERVICE_ACCOUNT_JSON` into a JSON file in the
+   same tempdir, validates it parses.
+3. `scp`s both files to `/tmp/*.new` on the VPS.
+4. Over SSH: `mv` into `/etc/rouse-relay/`, `chown root:relay`, `chmod 0640`,
+   then `systemctl restart rouse-relay`.
+5. `shred -u`s the tempdir on the runner regardless of success/failure.
+
+### Rotating a secret
+
+1. Generate/obtain the new value from the upstream provider (Cloudflare, GTS,
+   Firebase).
+2. `gh secret set <NAME> --repo Monkopedia/rouse-context` (value via stdin,
+   never as a shell arg).
+3. Trigger the `Deploy Relay` workflow (`gh workflow run relay-deploy.yml`).
+4. Verify `systemctl is-active rouse-relay` and tail logs briefly.
+
+### Adding a new secret
+
+1. Add the secret via `gh secret set`.
+2. Update `.github/workflows/relay-deploy.yml`'s render step to include a new
+   `printf 'NAME=%s\n' "$NEW_SECRET"` line (or write it to a separate file if
+   it's not a KEY=VALUE env var).
+3. Update the inventory table above.
+4. Deploy.
+
+### Recovering / onboarding: backfill from a running VPS
+
+If you ever lose the repo secrets (e.g. setting up a fork, or the repo was
+rotated), `scripts/backfill-relay-secrets.sh` re-syncs them by SSHing to the
+VPS, reading `/etc/rouse-relay/env` and `firebase-sa.json`, and piping each
+value into `gh secret set`. It never echoes secret values and shreds its temp
+files on exit. Requires `gcloud` (for the SSH) and `gh` (for the API).
+
+```bash
+./scripts/backfill-relay-secrets.sh Monkopedia/rouse-context
+```
+
+### Why the `EnvironmentFile` pattern (vs. systemd `Environment=` lines)
+
+The production unit uses `EnvironmentFile=/etc/rouse-relay/env` so the deploy
+workflow only has to drop a single 0640 file into place rather than edit the
+unit. This is the recommended pattern in this repo.

--- a/scripts/backfill-relay-secrets.sh
+++ b/scripts/backfill-relay-secrets.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+#
+# backfill-relay-secrets.sh — Re-sync GH repo secrets from the live VPS.
+#
+# Reads /etc/rouse-relay/env and /etc/rouse-relay/firebase-sa.json from the
+# production VPS and populates the corresponding GitHub repository secrets
+# consumed by .github/workflows/relay-deploy.yml.
+#
+# Use this when:
+#   - bootstrapping a fork (secrets empty, VPS has the source of truth)
+#   - the repo was rotated / recreated and secrets need to be rebuilt
+#   - an out-of-band edit was made on the VPS and the workflow needs to match
+#     before the next deploy would clobber it
+#
+# Safety:
+#   - set -u -o pipefail (NOT -x; avoid leaking values into set -x traces)
+#   - all intermediate files written with mode 0600 under a mode-0700 tmpdir
+#   - shred -u on exit (success, failure, or interrupt)
+#   - never echoes secret values to stdout; only sizes/counts for sanity
+#   - requires explicit "yes" confirmation before mutating GH state
+#
+# Prereqs:
+#   - gcloud configured with access to the `relay` GCE instance
+#   - gh authenticated with repo admin rights on the target repo
+#
+# Usage:
+#   scripts/backfill-relay-secrets.sh <owner/repo>
+# Example:
+#   scripts/backfill-relay-secrets.sh Monkopedia/rouse-context
+
+set -u -o pipefail
+
+REPO="${1:-}"
+if [[ -z "$REPO" ]]; then
+  echo "Usage: $0 <owner/repo>" >&2
+  exit 2
+fi
+
+# Values baked in: the production VPS is the `relay` GCE instance in
+# us-central1-a. Override via environment for forks.
+GCE_INSTANCE="${GCE_INSTANCE:-relay}"
+GCE_ZONE="${GCE_ZONE:-us-central1-a}"
+
+echo "About to:"
+echo "  1. SSH to GCE instance '${GCE_INSTANCE}' (zone '${GCE_ZONE}')"
+echo "  2. Read /etc/rouse-relay/env and /etc/rouse-relay/firebase-sa.json"
+echo "  3. Overwrite these GitHub repo secrets on '${REPO}':"
+echo "       CLOUDFLARE_API_TOKEN"
+echo "       CLOUDFLARE_ZONE_ID"
+echo "       RELAY_GTS_EAB_KID"
+echo "       RELAY_GTS_EAB_HMAC"
+echo "       RELAY_RUST_LOG"
+echo "       RELAY_FIREBASE_SERVICE_ACCOUNT_JSON  (base64 of firebase-sa.json)"
+echo
+read -r -p "Type 'yes' to proceed: " confirm
+if [[ "$confirm" != "yes" ]]; then
+  echo "Aborted."
+  exit 1
+fi
+
+# Require tools up front
+for cmd in gcloud gh base64 python3; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Required command not found: $cmd" >&2
+    exit 3
+  fi
+done
+
+# Mode-0700 tempdir; best-effort shred on exit.
+WORK=$(mktemp -d)
+chmod 700 "$WORK"
+
+cleanup() {
+  if [[ -d "$WORK" ]]; then
+    find "$WORK" -type f -exec shred -u {} + 2>/dev/null || true
+    rm -rf "$WORK"
+  fi
+}
+trap cleanup EXIT INT TERM
+
+# --- 1. Pull env file ---------------------------------------------------------
+echo "Reading /etc/rouse-relay/env ..."
+gcloud compute ssh "$GCE_INSTANCE" --zone="$GCE_ZONE" \
+  --command='sudo cat /etc/rouse-relay/env' \
+  > "$WORK/env" 2>/dev/null
+chmod 600 "$WORK/env"
+
+# Sanity: file should be non-empty and contain KEY=VALUE lines.
+env_lines=$(wc -l < "$WORK/env")
+if [[ "$env_lines" -lt 1 ]]; then
+  echo "ERROR: /etc/rouse-relay/env came back empty" >&2
+  exit 4
+fi
+echo "  ${env_lines} lines"
+
+# Extract a single KEY's value from the env file into a file, with trailing
+# newlines stripped. Never prints the value.
+extract_into() {
+  local key="$1"
+  local out="$2"
+  python3 -c "
+import sys, re
+key = sys.argv[1]
+with open(sys.argv[2], 'r') as fh:
+    for line in fh:
+        m = re.match(rf'^{re.escape(key)}=(.*?)\s*$', line)
+        if m:
+            val = m.group(1)
+            # Strip optional surrounding double quotes (systemd EnvironmentFile quoting)
+            if len(val) >= 2 and val[0] == '\"' and val[-1] == '\"':
+                val = val[1:-1]
+            with open(sys.argv[3], 'w') as o:
+                o.write(val)
+            sys.exit(0)
+    sys.exit(1)
+" "$key" "$WORK/env" "$out"
+  chmod 600 "$out"
+}
+
+extract_into CLOUDFLARE_API_TOKEN "$WORK/cf_api_token" \
+  || { echo "ERROR: CLOUDFLARE_API_TOKEN not present in env" >&2; exit 5; }
+extract_into CLOUDFLARE_ZONE_ID   "$WORK/cf_zone_id" \
+  || { echo "ERROR: CLOUDFLARE_ZONE_ID not present in env" >&2; exit 5; }
+extract_into GTS_EAB_KID          "$WORK/gts_eab_kid" \
+  || { echo "ERROR: GTS_EAB_KID not present in env" >&2; exit 5; }
+extract_into GTS_EAB_HMAC         "$WORK/gts_eab_hmac" \
+  || { echo "ERROR: GTS_EAB_HMAC not present in env" >&2; exit 5; }
+extract_into RUST_LOG             "$WORK/rust_log" \
+  || { echo "WARN: RUST_LOG not present in env; leaving RELAY_RUST_LOG untouched" >&2; rm -f "$WORK/rust_log"; }
+
+# --- 2. Pull firebase service account JSON ------------------------------------
+echo "Reading /etc/rouse-relay/firebase-sa.json ..."
+gcloud compute ssh "$GCE_INSTANCE" --zone="$GCE_ZONE" \
+  --command='sudo cat /etc/rouse-relay/firebase-sa.json' \
+  > "$WORK/firebase-sa.json" 2>/dev/null
+chmod 600 "$WORK/firebase-sa.json"
+
+# Validate it parses as JSON before uploading it to GH.
+python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$WORK/firebase-sa.json" \
+  || { echo "ERROR: firebase-sa.json is not valid JSON" >&2; exit 6; }
+
+base64 -w0 "$WORK/firebase-sa.json" > "$WORK/firebase_sa_b64"
+chmod 600 "$WORK/firebase_sa_b64"
+echo "  $(wc -c < "$WORK/firebase_sa_b64") bytes (base64)"
+
+# --- 3. Push to GH secrets ----------------------------------------------------
+push_secret() {
+  local name="$1"
+  local file="$2"
+  if [[ ! -f "$file" ]]; then
+    echo "  [skip] $name (no value captured)"
+    return 0
+  fi
+  echo "  [set]  $name ($(wc -c < "$file") bytes)"
+  gh secret set "$name" --repo "$REPO" < "$file"
+}
+
+echo "Updating GitHub secrets on $REPO ..."
+push_secret CLOUDFLARE_API_TOKEN                 "$WORK/cf_api_token"
+push_secret CLOUDFLARE_ZONE_ID                   "$WORK/cf_zone_id"
+push_secret RELAY_GTS_EAB_KID                    "$WORK/gts_eab_kid"
+push_secret RELAY_GTS_EAB_HMAC                   "$WORK/gts_eab_hmac"
+push_secret RELAY_RUST_LOG                       "$WORK/rust_log"
+push_secret RELAY_FIREBASE_SERVICE_ACCOUNT_JSON  "$WORK/firebase_sa_b64"
+
+echo "Done. Verify with: gh secret list --repo $REPO"


### PR DESCRIPTION
## Summary

- Relay runtime secrets now live as GitHub repo secrets, not manually-maintained files on the VPS.
- `relay-deploy.yml` renders `/etc/rouse-relay/env` and `/etc/rouse-relay/firebase-sa.json` on each run and ships them alongside the binary.
- `scripts/backfill-relay-secrets.sh` re-syncs secrets from the VPS to GH (for fork bootstrap, repo rotation, or OOB edits).

## Secrets populated

Pulled from the running VPS and verified byte-for-byte against the workflow-rendered output before filing this PR. Names only (values never echoed):

- `CLOUDFLARE_API_TOKEN` (pre-existing, re-synced)
- `CLOUDFLARE_ZONE_ID` (pre-existing, re-synced)
- `RELAY_RUST_LOG`
- `RELAY_GTS_EAB_KID`
- `RELAY_GTS_EAB_HMAC`
- `RELAY_FIREBASE_SERVICE_ACCOUNT_JSON` (base64 of `firebase-sa.json`)

Naming convention: secrets added in this migration use `RELAY_` prefix; existing `CLOUDFLARE_*` keep their unprefixed names to avoid churn and because other workflows (e.g. cert renewal) already reference them. Documented in `docs/self-hosting.md`.

## What the workflow now does

1. `Render` step: `printf` runtime secrets into a mode-0700 tempdir (no `echo`, no secret values on argv). Base64-decode the Firebase SA. Validate JSON.
2. `Deploy` step: `scp` binary + env + firebase-sa, then `ssh ... mv` into `/etc/rouse-relay/` with `chown root:relay` and `chmod 0640`, then `systemctl restart`.
3. `Shred` step: `shred -u` the render tempdir regardless of outcome.

## First post-merge deploy — needs the user's eyes

First `Deploy Relay` run after merge will overwrite `/etc/rouse-relay/env` and `firebase-sa.json` with the workflow-rendered versions. Parity is confirmed, but since this is the cutover run, I did NOT auto-dispatch the workflow — user should kick it off and watch `systemctl is-active rouse-relay`.

## Rotation is now

```
gh secret set <NAME> --repo Monkopedia/rouse-context
gh workflow run relay-deploy.yml
```

## Test plan

- [x] Render step parity: byte-for-byte diff against `/etc/rouse-relay/env` — exact match
- [x] Firebase SA base64 roundtrip — exact match, 2357 bytes
- [x] Workflow YAML parses
- [x] `bash -n scripts/backfill-relay-secrets.sh` — ok
- [ ] User dispatches `Deploy Relay` after merge; verifies `systemctl is-active rouse-relay`
- [ ] User verifies no new journal errors after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)