### PR TITLE
Fix #214: Trim tools/list descriptions and schemas

### DIFF
--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/BoolParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/BoolParam.kt
@@ -15,7 +15,7 @@ class BoolParam(name: String, description: String) : ParamDef<Boolean>(name, des
 
     override fun schema(): JsonObject = buildJsonObject {
         put("type", JsonPrimitive("boolean"))
-        put("description", JsonPrimitive(description))
+        if (description.isNotEmpty()) put("description", JsonPrimitive(description))
         defaultValue?.let { put("default", JsonPrimitive(it)) }
     }
 

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/EnumParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/EnumParam.kt
@@ -21,7 +21,7 @@ class EnumParam<T : Enum<T>>(name: String, description: String, private val kCla
 
     override fun schema(): JsonObject = buildJsonObject {
         put("type", JsonPrimitive("string"))
-        put("description", JsonPrimitive(description))
+        if (description.isNotEmpty()) put("description", JsonPrimitive(description))
         put("enum", JsonArray(values.map { JsonPrimitive(it.name.lowercase()) }))
         defaultValue?.let { put("default", JsonPrimitive(it.name.lowercase())) }
     }

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/InstantParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/InstantParam.kt
@@ -21,7 +21,7 @@ class InstantParam(name: String, description: String) : ParamDef<Instant>(name, 
     override fun schema(): JsonObject = buildJsonObject {
         put("type", JsonPrimitive("string"))
         put("format", JsonPrimitive("date-time"))
-        put("description", JsonPrimitive(description))
+        if (description.isNotEmpty()) put("description", JsonPrimitive(description))
         defaultValue?.let { put("default", JsonPrimitive(it.toString())) }
     }
 

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/IntParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/IntParam.kt
@@ -18,7 +18,7 @@ class IntParam(name: String, description: String) : ParamDef<Int>(name, descript
 
     override fun schema(): JsonObject = buildJsonObject {
         put("type", JsonPrimitive("integer"))
-        put("description", JsonPrimitive(description))
+        if (description.isNotEmpty()) put("description", JsonPrimitive(description))
         range?.let {
             put("minimum", JsonPrimitive(it.first))
             put("maximum", JsonPrimitive(it.last))

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/ListParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/ListParam.kt
@@ -21,7 +21,7 @@ class ListParam(name: String, description: String) : ParamDef<List<String>>(name
 
     override fun schema(): JsonObject = buildJsonObject {
         put("type", JsonPrimitive("array"))
-        put("description", JsonPrimitive(description))
+        if (description.isNotEmpty()) put("description", JsonPrimitive(description))
         put(
             "items",
             buildJsonObject { put("type", JsonPrimitive("string")) }

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/MapParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/MapParam.kt
@@ -23,7 +23,7 @@ class MapParam(name: String, description: String) :
 
     override fun schema(): JsonObject = buildJsonObject {
         put("type", JsonPrimitive("object"))
-        put("description", JsonPrimitive(description))
+        if (description.isNotEmpty()) put("description", JsonPrimitive(description))
         put(
             "additionalProperties",
             buildJsonObject { put("type", JsonPrimitive("string")) }

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/StringParam.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/params/StringParam.kt
@@ -23,7 +23,7 @@ class StringParam(name: String, description: String) : ParamDef<String>(name, de
 
     override fun schema(): JsonObject = buildJsonObject {
         put("type", JsonPrimitive("string"))
-        put("description", JsonPrimitive(description))
+        if (description.isNotEmpty()) put("description", JsonPrimitive(description))
         choices?.let { put("enum", JsonArray(it.map { v -> JsonPrimitive(v) })) }
         defaultValue?.let { put("default", JsonPrimitive(it)) }
     }

--- a/integrations/src/main/java/com/rousecontext/integrations/health/HealthConnectMcpServer.kt
+++ b/integrations/src/main/java/com/rousecontext/integrations/health/HealthConnectMcpServer.kt
@@ -79,8 +79,7 @@ class HealthConnectMcpServer(private val repository: HealthConnectRepository) : 
 
 internal class ListRecordTypesTool(private val repository: HealthConnectRepository) : McpTool() {
     override val name = "list_record_types"
-    override val description =
-        "Lists all available Health Connect record types with permission status"
+    override val description = "List Health Connect record types with permission status."
 
     override suspend fun execute(): ToolResult {
         val granted = repository.getGrantedPermissions()
@@ -96,22 +95,13 @@ internal class ListRecordTypesTool(private val repository: HealthConnectReposito
 internal class QueryHealthDataTool(private val repository: HealthConnectRepository) : McpTool() {
     override val name = "query_health_data"
     override val description =
-        "Query Health Connect records by type and time range. " +
-            "Use list_record_types to see available types."
+        "Query Health Connect records by type and time range; " +
+            "see list_record_types for types."
 
-    val recordType by stringParam(
-        "record_type",
-        "Record type name, e.g. Steps, HeartRate, SleepSession"
-    )
-    val since by stringParam(
-        "since",
-        "Start of time range, ISO 8601 datetime or date"
-    )
-    val until by stringParam(
-        "until",
-        "End of time range, ISO 8601 datetime or date. Defaults to now."
-    ).optional()
-    val limit by intParam("limit", "Maximum number of records to return").optional()
+    val recordType by stringParam("record_type", "e.g. Steps, HeartRate, SleepSession")
+    val since by stringParam("since", "ISO 8601 date or datetime")
+    val until by stringParam("until", "ISO 8601, defaults to now").optional()
+    val limit by intParam("limit", "").optional()
 
     override suspend fun execute(): ToolResult {
         val type = recordType!!
@@ -143,11 +133,9 @@ internal class QueryHealthDataTool(private val repository: HealthConnectReposito
 
 internal class GetHealthSummaryTool(private val repository: HealthConnectRepository) : McpTool() {
     override val name = "get_health_summary"
-    override val description =
-        "Get a high-level health summary across all permitted data types " +
-            "for a given period (today, week, or month)."
+    override val description = "Health summary across permitted types for a period."
 
-    val period by stringParam("period", "Summary period: today, week, or month")
+    val period by stringParam("period", "today|week|month")
 
     override suspend fun execute(): ToolResult {
         val now = Instant.now()

--- a/integrations/src/main/java/com/rousecontext/integrations/notifications/NotificationMcpProvider.kt
+++ b/integrations/src/main/java/com/rousecontext/integrations/notifications/NotificationMcpProvider.kt
@@ -78,10 +78,9 @@ internal class ListActiveNotificationsTool(
     private val activeNotificationSource: () -> Array<StatusBarNotification>
 ) : McpTool() {
     override val name = "list_active_notifications"
-    override val description = "Returns currently posted notifications on the device."
+    override val description = "List posted notifications."
 
-    val filter by stringParam("filter", "Optional app package name pattern to filter by")
-        .optional()
+    val filter by stringParam("filter", "").optional()
 
     override suspend fun execute(): ToolResult {
         val f = filter
@@ -103,14 +102,10 @@ internal class PerformNotificationActionTool(
     private val allowActions: Boolean
 ) : McpTool() {
     override val name = "perform_notification_action"
-    override val description = "Executes an action button on an active notification." +
-        " Rouse Context's own notifications cannot be acted on."
+    override val description = "Invoke an action button on an active notification."
 
-    val notificationKey by stringParam(
-        "notification_key",
-        "The notification key from list_active_notifications"
-    )
-    val actionIndex by intParam("action_index", "Zero-based index of the action to perform")
+    val notificationKey by stringParam("notification_key", "Key from list_active_notifications")
+    val actionIndex by intParam("action_index", "0-based")
 
     override suspend fun execute(): ToolResult {
         if (!allowActions) {
@@ -140,10 +135,9 @@ internal class DismissNotificationTool(
     private val allowActions: Boolean
 ) : McpTool() {
     override val name = "dismiss_notification"
-    override val description = "Dismisses an active notification by its key." +
-        " Rouse Context's own notifications cannot be dismissed."
+    override val description = "Dismiss an active notification by key."
 
-    val notificationKey by stringParam("notification_key", "The notification key to dismiss")
+    val notificationKey by stringParam("notification_key", "")
 
     override suspend fun execute(): ToolResult {
         if (!allowActions) {
@@ -171,14 +165,13 @@ internal class SearchNotificationHistoryTool(
     private val fieldEncryptor: FieldEncryptor?
 ) : McpTool() {
     override val name = "search_notification_history"
-    override val description = "Searches the notification history log." +
-        " Supports text search, package filter, and time range."
+    override val description = "Search notification history by text, package, or time range."
 
-    val query by stringParam("query", "Text to search in title and body").optional()
-    val packageFilter by stringParam("package", "Filter by package name").optional()
-    val since by stringParam("since", "ISO datetime start bound").optional()
-    val until by stringParam("until", "ISO datetime end bound").optional()
-    val limit by intParam("limit", "Max results (default 50)").optional()
+    val query by stringParam("query", "Text in title or body").optional()
+    val packageFilter by stringParam("package", "").optional()
+    val since by stringParam("since", "ISO 8601").optional()
+    val until by stringParam("until", "ISO 8601").optional()
+    val limit by intParam("limit", "Default 50").optional()
 
     override suspend fun execute(): ToolResult {
         val sinceMillis = since?.let { parseIsoToMillis(it) } ?: 0L
@@ -204,10 +197,9 @@ internal class SearchNotificationHistoryTool(
 
 internal class GetNotificationStatsTool(private val dao: NotificationDao) : McpTool() {
     override val name = "get_notification_stats"
-    override val description = "Returns aggregate notification statistics for a time period." +
-        " Includes total count, per-app breakdown, and busiest hour."
+    override val description = "Notification counts, top apps, and busiest hour for a period."
 
-    val period by stringParam("period", "Time period: 'today', 'week', or 'month'").optional()
+    val period by stringParam("period", "today|week|month, default today").optional()
 
     override suspend fun execute(): ToolResult {
         val periodStr = period ?: "today"

--- a/integrations/src/main/kotlin/com/rousecontext/integrations/outreach/OutreachMcpProvider.kt
+++ b/integrations/src/main/kotlin/com/rousecontext/integrations/outreach/OutreachMcpProvider.kt
@@ -127,11 +127,10 @@ internal class LaunchAppTool(
     private val launchNotifier: LaunchRequestNotifierApi?
 ) : McpTool() {
     override val name = "launch_app"
-    override val description = "Launch an installed app on the device by package name"
+    override val description = "Launch an installed app by package name."
 
-    val packageName by stringParam("package_name", "Package name of the app to launch")
-    val extras by mapParam("extras", "Optional string key-value extras to pass to the intent")
-        .optional()
+    val packageName by stringParam("package_name", "Reverse-DNS, e.g. com.example.app")
+    val extras by mapParam("extras", "").optional()
 
     override suspend fun execute(): ToolResult {
         val pkg = packageName!!
@@ -160,9 +159,9 @@ internal class OpenLinkTool(
     private val launchNotifier: LaunchRequestNotifierApi?
 ) : McpTool() {
     override val name = "open_link"
-    override val description = "Open a URL in the default browser or appropriate app"
+    override val description = "Open an http/https URL in the default app."
 
-    val url by stringParam("url", "URL to open (http or https only)")
+    val url by stringParam("url", "")
 
     override suspend fun execute(): ToolResult {
         val u = url!!
@@ -188,10 +187,10 @@ internal class OpenLinkTool(
 
 internal class CopyToClipboardTool(private val context: Context) : McpTool() {
     override val name = "copy_to_clipboard"
-    override val description = "Copy text to the device clipboard"
+    override val description = "Copy text to the clipboard."
 
-    val text by stringParam("text", "Text to copy")
-    val label by stringParam("label", "Optional label describing the content").optional()
+    val text by stringParam("text", "")
+    val label by stringParam("label", "").optional()
 
     override suspend fun execute(): ToolResult {
         withContext(Dispatchers.Main) {
@@ -208,16 +207,13 @@ internal class SendNotificationTool(
     private val idCounter: AtomicInteger
 ) : McpTool() {
     override val name = "send_notification"
-    override val description = "Send a notification to the user on the device"
+    override val description = "Post a notification."
 
-    val title by stringParam("title", "Notification title")
-    val message by stringParam("message", "Notification body text")
-    val priority by stringParam("priority", "Notification priority: low, default, or high")
+    val title by stringParam("title", "")
+    val message by stringParam("message", "")
+    val priority by stringParam("priority", "")
         .optional().choices("low", "default", "high")
-    val channelId by stringParam(
-        "channel_id",
-        "Optional channel ID created via create_notification_channel. Uses default channel if omitted."
-    ).optional()
+    val channelId by stringParam("channel_id", "From create_notification_channel").optional()
 
     override suspend fun execute(): ToolResult {
         if (!rateLimiter.tryAcquire("send_notification")) {
@@ -242,9 +238,9 @@ internal class SendNotificationTool(
 
 internal class ListInstalledAppsTool(private val context: Context) : McpTool() {
     override val name = "list_installed_apps"
-    override val description = "List installed apps on the device"
+    override val description = "List installed apps."
 
-    val filter by stringParam("filter", "Optional text to filter apps by name").optional()
+    val filter by stringParam("filter", "Name substring").optional()
 
     override suspend fun execute(): ToolResult {
         val apps = queryInstalledApps(context, filter?.lowercase())
@@ -254,16 +250,16 @@ internal class ListInstalledAppsTool(private val context: Context) : McpTool() {
 
 internal class CreateNotificationChannelTool(private val context: Context) : McpTool() {
     override val name = "create_notification_channel"
-    override val description = "Create a notification channel for sending categorized notifications"
+    override val description = "Create a notification channel."
 
-    val id by stringParam("id", "Unique channel identifier")
-    val channelName by stringParam("name", "User-visible channel name")
-    val channelDescription by stringParam("description", "Optional channel description").optional()
-    val importance by stringParam("importance", "Channel importance: min, low, default, or high")
+    val id by stringParam("id", "")
+    val channelName by stringParam("name", "User-visible name")
+    val channelDescription by stringParam("description", "").optional()
+    val importance by stringParam("importance", "")
         .default("default").choices("min", "low", "default", "high")
-    val vibrate by boolParam("vibrate", "Whether the channel should vibrate").optional()
-    val soundEnabled by boolParam("sound", "Whether to play sound (default true)").default(true)
-    val showBadge by boolParam("show_badge", "Whether to show badge on app icon").optional()
+    val vibrate by boolParam("vibrate", "").optional()
+    val soundEnabled by boolParam("sound", "Play sound").default(true)
+    val showBadge by boolParam("show_badge", "").optional()
 
     override suspend fun execute(): ToolResult {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -297,7 +293,7 @@ internal class CreateNotificationChannelTool(private val context: Context) : Mcp
 
 internal class ListNotificationChannelsTool(private val context: Context) : McpTool() {
     override val name = "list_notification_channels"
-    override val description = "List AI-created notification channels on the device"
+    override val description = "List AI-created notification channels."
 
     override suspend fun execute(): ToolResult {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -313,9 +309,9 @@ internal class ListNotificationChannelsTool(private val context: Context) : McpT
 
 internal class DeleteNotificationChannelTool(private val context: Context) : McpTool() {
     override val name = "delete_notification_channel"
-    override val description = "Delete an AI-created notification channel"
+    override val description = "Delete an AI-created notification channel."
 
-    val id by stringParam("id", "Channel ID to delete")
+    val id by stringParam("id", "")
 
     override suspend fun execute(): ToolResult {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -339,7 +335,7 @@ internal class DeleteNotificationChannelTool(private val context: Context) : Mcp
 
 internal class GetDndStateTool(private val context: Context) : McpTool() {
     override val name = "get_dnd_state"
-    override val description = "Check Do Not Disturb status"
+    override val description = "Get Do Not Disturb state."
 
     override suspend fun execute(): ToolResult {
         val nm = context.getSystemService(NotificationManager::class.java)
@@ -352,10 +348,10 @@ internal class GetDndStateTool(private val context: Context) : McpTool() {
 
 internal class SetDndStateTool(private val context: Context) : McpTool() {
     override val name = "set_dnd_state"
-    override val description = "Control Do Not Disturb state"
+    override val description = "Set Do Not Disturb state."
 
-    val enabled by boolParam("enabled", "Whether to enable or disable DND")
-    val mode by stringParam("mode", "DND mode: total_silence, priority_only, or alarms_only")
+    val enabled by boolParam("enabled", "")
+    val mode by stringParam("mode", "")
         .optional().choices("total_silence", "priority_only", "alarms_only")
 
     override suspend fun execute(): ToolResult {

--- a/integrations/src/main/kotlin/com/rousecontext/integrations/usage/UsageMcpProvider.kt
+++ b/integrations/src/main/kotlin/com/rousecontext/integrations/usage/UsageMcpProvider.kt
@@ -65,12 +65,10 @@ class UsageMcpProvider(private val context: Context) : McpServerProvider {
 
 internal class GetUsageSummaryTool(private val context: Context) : McpTool() {
     override val name = "get_usage_summary"
-    override val description =
-        "Get total screen time and per-app breakdown " +
-            "for a time period. Returns apps sorted by foreground time."
+    override val description = "Screen time totals and top apps for a period."
 
-    val period by stringParam("period", "Time period: today, yesterday, week, month")
-    val limit by intParam("limit", "Max apps to return (default 10)").optional()
+    val period by stringParam("period", "today|yesterday|week|month")
+    val limit by intParam("limit", "Max apps (default 10)").optional()
 
     override suspend fun execute(): ToolResult {
         val periodStr = period!!
@@ -104,11 +102,10 @@ internal class GetUsageSummaryTool(private val context: Context) : McpTool() {
 
 internal class GetAppUsageTool(private val context: Context) : McpTool() {
     override val name = "get_app_usage"
-    override val description =
-        "Get detailed usage for a specific app, including daily breakdown."
+    override val description = "Per-day usage for one app."
 
-    val packageName by stringParam("package_name", "Package name of the app")
-    val period by stringParam("period", "Time period: today, yesterday, week, month")
+    val packageName by stringParam("package_name", "")
+    val period by stringParam("period", "today|yesterday|week|month")
 
     override suspend fun execute(): ToolResult {
         val pkg = packageName!!
@@ -140,18 +137,16 @@ internal class GetAppUsageTool(private val context: Context) : McpTool() {
 
 internal class GetUsageEventsTool(private val context: Context) : McpTool() {
     override val name = "get_usage_events"
-    override val description =
-        "Get raw usage events (app opened, closed, etc.) for a time range."
+    override val description = "Raw app foreground/background events over a range."
 
-    val since by stringParam("since", "Start period: today, yesterday, week, month")
-    val until by stringParam("until", "End period: today, yesterday, week, month")
-    val packageFilter by stringParam("package", "Optional: filter to this package name")
-        .optional()
+    val since by stringParam("since", "today|yesterday|week|month")
+    val until by stringParam("until", "today|yesterday|week|month")
+    val packageFilter by stringParam("package", "").optional()
     val includeSystem by boolParam(
         "include_system",
-        "Include Rouse Context and Android system intelligence events (default false)"
+        "Include Rouse/Android system events (default false)"
     ).optional()
-    val limit by intParam("limit", "Max events to return (default 50)").optional()
+    val limit by intParam("limit", "Default 50").optional()
 
     override suspend fun execute(): ToolResult {
         val sinceStr = since!!
@@ -181,13 +176,11 @@ internal class GetUsageEventsTool(private val context: Context) : McpTool() {
 
 internal class CompareUsageTool(private val context: Context) : McpTool() {
     override val name = "compare_usage"
-    override val description =
-        "Compare app usage between two time periods. " +
-            "Shows biggest increases and decreases in screen time."
+    override val description = "Compare screen time between two periods; biggest deltas first."
 
-    val period1 by stringParam("period1", "First period: today, yesterday, week, month")
-    val period2 by stringParam("period2", "Second period: today, yesterday, week, month")
-    val limit by intParam("limit", "Max apps to compare (default 10)").optional()
+    val period1 by stringParam("period1", "today|yesterday|week|month")
+    val period2 by stringParam("period2", "today|yesterday|week|month")
+    val limit by intParam("limit", "Max apps (default 10)").optional()
 
     override suspend fun execute(): ToolResult {
         val p1Str = period1!!

--- a/integrations/src/test/kotlin/com/rousecontext/integrations/ToolsListSizeTest.kt
+++ b/integrations/src/test/kotlin/com/rousecontext/integrations/ToolsListSizeTest.kt
@@ -1,0 +1,108 @@
+package com.rousecontext.integrations
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.rousecontext.integrations.health.FakeHealthConnectRepository
+import com.rousecontext.integrations.health.HealthConnectMcpServer
+import com.rousecontext.integrations.notifications.NotificationDao
+import com.rousecontext.integrations.notifications.NotificationMcpProvider
+import com.rousecontext.integrations.outreach.OutreachMcpProvider
+import com.rousecontext.integrations.usage.UsageMcpProvider
+import com.rousecontext.mcp.core.McpServerProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Prints `tools/list` byte sizes per integration. Not a correctness assertion —
+ * used to measure the effect of description trimming (GH #214).
+ */
+@RunWith(RobolectricTestRunner::class)
+class ToolsListSizeTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private data class Captured(val name: String, val description: String?, val schema: ToolSchema)
+
+    private fun capture(provider: McpServerProvider): List<Captured> {
+        val captured = mutableListOf<Captured>()
+        val server = mockk<Server>(relaxed = true)
+        val n = slot<String>()
+        val d = slot<String>()
+        val s = slot<ToolSchema>()
+        every {
+            server.addTool(
+                name = capture(n),
+                description = capture(d),
+                inputSchema = capture(s),
+                handler = any()
+            )
+        } answers {
+            captured += Captured(n.captured, d.captured, s.captured)
+        }
+        provider.register(server)
+        return captured
+    }
+
+    private fun toJsonArray(tools: List<Captured>): JsonArray = buildJsonArray {
+        for (t in tools) {
+            add(
+                buildJsonObject {
+                    put("name", JsonPrimitive(t.name))
+                    t.description?.let { put("description", JsonPrimitive(it)) }
+                    put("inputSchema", schemaToJson(t.schema))
+                }
+            )
+        }
+    }
+
+    private fun schemaToJson(schema: ToolSchema): JsonObject = buildJsonObject {
+        put("type", JsonPrimitive("object"))
+        schema.properties?.let { put("properties", it) }
+        if (schema.required != null && schema.required!!.isNotEmpty()) {
+            put(
+                "required",
+                buildJsonArray {
+                    for (r in schema.required!!) add(JsonPrimitive(r))
+                }
+            )
+        }
+    }
+
+    private fun report(label: String, provider: McpServerProvider) {
+        val tools = capture(provider)
+        val arr = toJsonArray(tools)
+        val json = Json.encodeToString(JsonArray.serializer(), arr)
+        println("TOOLS_LIST_SIZE integration=$label tools=${tools.size} bytes=${json.length}")
+        if (System.getenv("TOOLS_LIST_DUMP") == "1") {
+            println("TOOLS_LIST_DUMP integration=$label json=$json")
+        }
+    }
+
+    @Test
+    fun `report sizes`() {
+        report("outreach", OutreachMcpProvider(context, dndEnabled = true))
+        report("usage", UsageMcpProvider(context))
+        report("health", HealthConnectMcpServer(FakeHealthConnectRepository()))
+        report(
+            "notifications",
+            NotificationMcpProvider(
+                dao = mockk<NotificationDao>(relaxed = true),
+                activeNotificationSource = { emptyArray() },
+                actionPerformer = { _, _ -> true },
+                notificationDismisser = { true }
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Shorten tool descriptions and drop redundant parameter descriptions across all
integrations to reduce the per-session token cost of `tools/list`.

Per-integration `tools/list` bytes:

| integration   | before | after | reduction |
| ------------- | ------:| -----:| ---------:|
| outreach      |   3342 |  2358 |   -29.4%  |
| usage         |   1845 |  1437 |   -22.1%  |
| health        |   1070 |   838 |   -21.7%  |
| notifications |   1848 |  1349 |   -27.0%  |

All four integrations comfortably clear the 20% target from the issue.

## Changes

- `integrations/`: trim tool `description` fields to single-sentence usage cues,
  drop parameter descriptions where the parameter name is self-explanatory, and
  compact enum-hint text (e.g. \`today|yesterday|week|month\` as the param
  description instead of a long sentence repeated in four tools).
- `core/mcp/.../params/`: the param DSL now omits \`description\` from the schema
  when the tool author passes an empty string. This lets integrations drop the
  field entirely for params like \`title\`, \`text\`, \`url\`, \`id\`, etc., instead of
  paying ~20 JSON bytes for a useless \"Title\" description. Non-empty
  descriptions behave exactly as before, so existing golden-schema tests stay
  green.

## Constraints preserved

- No tools removed.
- No tool names, parameter names, or schema shapes changed (types,
  required-ness, nesting all unchanged).
- Enum lists (choices) kept as-is; where a value set was inline prose, moved
  to a short \`a|b|c\` hint in the param description.

## Test plan

- [x] \`./gradlew :integrations:testDebugUnitTest :core:mcp:jvmTest :notifications:testDebugUnitTest :core:tunnel:jvmTest :api:testDebugUnitTest\` pass
- [x] \`./gradlew ktlintCheck\` clean
- [x] \`./gradlew detekt\` unchanged (77 weighted issues both before and after this PR — all pre-existing and outside scope)
- [x] New \`ToolsListSizeTest\` prints measured bytes per integration so future audits can track regression

Resolves #214.

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>