### PR TITLE
Fix #221: Restore :app:testDebugUnitTest gate (57 failing tests)

### DIFF
--- a/app/src/test/resources/robolectric.properties
+++ b/app/src/test/resources/robolectric.properties
@@ -1,1 +1,2 @@
 sdk=33
+application=com.rousecontext.app.TestApplication


### PR DESCRIPTION
## Summary
- All 57 failing `:app:testDebugUnitTest` tests shared a single root cause: Robolectric was instantiating the manifest's `android:name=.RouseApplication`, whose `onCreate()` builds Koin's `appModule` -> constructs `FieldEncryptor` -> calls `KeyStore.getInstance("AndroidKeyStore")`, which does not exist in the plain JVM test runtime.
- Setting `application=com.rousecontext.app.TestApplication` in `robolectric.properties` makes the existing minimal `TestApplication` the default. Tests that already declare `@Config(application=...)` continue to use their explicit override.
- No production code changed. Restores the CI gate so PRs no longer need `--admin` merge overrides (ref #214, #215, #220).

## Failure classes addressed (all same root cause)
- `AndroidKeystoreDeviceKeyManagerTest` (3) - already had `assumeTrue` skip, but @Before never ran
- `FileCertificateStoreTest` (20)
- `AppStatePreferencesTest` (4)
- `PreferencesSnapshotHolderTest` (2)
- `BugReportUriBuilderTest` (5)
- `OnboardingViewModelTest` (6)
- `SettingsViewModelTest` (17)

## Test plan
- [x] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :app:testDebugUnitTest` -> 305 tests, 0 failed
- [x] `./gradlew :app:ktlintCheck` -> clean
- [ ] CI Build & Test on this PR green

Closes #221