### PR TITLE
Fix #223: Eliminate :core:bridge:jvmTest hang with nested runBlocking

### DIFF
--- a/core/bridge/src/jvmMain/kotlin/com/rousecontext/bridge/TunnelSessionManager.kt
+++ b/core/bridge/src/jvmMain/kotlin/com/rousecontext/bridge/TunnelSessionManager.kt
@@ -2,6 +2,7 @@ package com.rousecontext.bridge
 
 import com.rousecontext.tunnel.TunnelClient
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
@@ -30,13 +31,21 @@ class TunnelSessionManager(
     /**
      * Starts collecting incoming sessions. Safe to call multiple times;
      * subsequent calls are no-ops if already running.
+     *
+     * Each session is dispatched to [Dispatchers.IO] so that blocking socket
+     * I/O and Ktor's internal `runBlocking` bridges (e.g. `CIOApplicationEngine.start`)
+     * do not run on the caller's dispatcher. In production that dispatcher is
+     * typically the Android main thread; in tests it is the `runBlocking` event
+     * loop. Pinning handler work to IO prevents the nested runBlocking calls
+     * inside Ktor from deadlocking on the same thread that is driving the
+     * outer coroutine. See issue #223.
      */
     fun start() {
         if (collectionJob?.isActive == true) return
 
         collectionJob = scope.launch {
             tunnelClient.incomingSessions.collect { stream ->
-                launch {
+                launch(Dispatchers.IO) {
                     try {
                         sessionHandler.handleStream(stream)
                     } catch (_: Exception) {

--- a/core/bridge/src/jvmTest/kotlin/com/rousecontext/bridge/ClientPassthroughTest.kt
+++ b/core/bridge/src/jvmTest/kotlin/com/rousecontext/bridge/ClientPassthroughTest.kt
@@ -29,6 +29,8 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Rule
+import org.junit.rules.Timeout
 
 /**
  * Verifies the full client -> relay -> device passthrough path at the protocol level.
@@ -44,6 +46,13 @@ import kotlinx.serialization.json.jsonPrimitive
  *   MuxStream -> TLS unwrap -> Client HTTP response
  */
 class ClientPassthroughTest {
+
+    /**
+     * Fail fast if a test hangs instead of burning the full CI budget.
+     * See issue #223.
+     */
+    @get:Rule
+    val timeout: Timeout = Timeout.seconds(TEST_TIMEOUT_SECONDS)
 
     private val mcpJson = Json { ignoreUnknownKeys = true }
 

--- a/core/bridge/src/jvmTest/kotlin/com/rousecontext/bridge/HttpHeaderInjectorTest.kt
+++ b/core/bridge/src/jvmTest/kotlin/com/rousecontext/bridge/HttpHeaderInjectorTest.kt
@@ -4,6 +4,8 @@ import java.io.ByteArrayOutputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.junit.Rule
+import org.junit.rules.Timeout
 
 /**
  * Verifies the byte-level HTTP header injector used by [SessionHandler] to
@@ -11,6 +13,13 @@ import kotlin.test.assertTrue
  * server. See issue #177.
  */
 class HttpHeaderInjectorTest {
+
+    /**
+     * Fail fast if a test hangs instead of burning the full CI budget.
+     * See issue #223.
+     */
+    @get:Rule
+    val timeout: Timeout = Timeout.seconds(TEST_TIMEOUT_SECONDS)
 
     private val header = "X-Internal-Token: secret-abc"
 

--- a/core/bridge/src/jvmTest/kotlin/com/rousecontext/bridge/SessionHandlerTest.kt
+++ b/core/bridge/src/jvmTest/kotlin/com/rousecontext/bridge/SessionHandlerTest.kt
@@ -21,12 +21,21 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Rule
+import org.junit.rules.Timeout
 
 /**
  * Tests for [SessionHandler] verifying the full data path:
  * MuxStream -> TLS accept -> plaintext HTTP -> MCP session -> JSON-RPC response.
  */
 class SessionHandlerTest {
+
+    /**
+     * Fail fast if a test hangs instead of burning the full CI budget.
+     * See issue #223.
+     */
+    @get:Rule
+    val timeout: Timeout = Timeout.seconds(TEST_TIMEOUT_SECONDS)
 
     private val mcpJson = Json { ignoreUnknownKeys = true }
 

--- a/core/bridge/src/jvmTest/kotlin/com/rousecontext/bridge/TestCertHelper.kt
+++ b/core/bridge/src/jvmTest/kotlin/com/rousecontext/bridge/TestCertHelper.kt
@@ -7,6 +7,9 @@ import java.io.OutputStream
 import java.nio.ByteBuffer
 import java.security.KeyStore
 import java.security.cert.X509Certificate
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLEngineResult
@@ -123,6 +126,14 @@ internal fun createMuxPipe(streamId: UInt): Pair<ChannelMuxStream, ChannelMuxStr
 
 /**
  * Performs TLS client-side handshake over a [ChannelMuxStream] and returns plaintext I/O streams.
+ *
+ * After the handshake, a dedicated pump thread drains the MuxStream's incoming
+ * ciphertext into a [LinkedBlockingQueue] so that [TlsClientInputStream.read]
+ * can block on the queue without using a nested `runBlocking` on the caller's
+ * thread. A matching outbound pump drains writes from the output queue back to
+ * the MuxStream. This avoids deadlocks when the test body (typically driving
+ * `runBlocking`) invokes these blocking JDK streams while other coroutines are
+ * pending on the same event loop. See issue #223.
  */
 internal suspend fun tlsClientHandshake(
     certHelper: TestCertHelper,
@@ -134,6 +145,30 @@ internal suspend fun tlsClientHandshake(
     )
     sslEngine.useClientMode = true
 
+    val netIn = performTlsClientHandshake(sslEngine, clientStream)
+    val pumps = startTlsClientPumps(clientStream)
+    return Pair(
+        TlsClientInputStream(
+            sslEngine,
+            pumps.inboundQueue,
+            netIn,
+            pumps.closed,
+            pumps.inboundThread,
+            pumps.outboundThread
+        ),
+        TlsClientOutputStream(sslEngine, pumps.outboundQueue)
+    )
+}
+
+/**
+ * Drives the TLS client handshake synchronously against [clientStream] until
+ * it is finished, returning the residual ciphertext read buffer so the caller
+ * can continue decoding any already-received data.
+ */
+private suspend fun performTlsClientHandshake(
+    sslEngine: javax.net.ssl.SSLEngine,
+    clientStream: ChannelMuxStream
+): ByteBuffer {
     val session = sslEngine.session
     var netIn = ByteBuffer.allocate(session.packetBufferSize)
     val netOut = ByteBuffer.allocate(session.packetBufferSize)
@@ -178,12 +213,78 @@ internal suspend fun tlsClientHandshake(
             else -> break
         }
     }
-
-    return Pair(
-        TlsClientInputStream(sslEngine, clientStream, netIn),
-        TlsClientOutputStream(sslEngine, clientStream)
-    )
+    return netIn
 }
+
+private class TlsClientPumps(
+    val inboundQueue: LinkedBlockingQueue<ByteArray>,
+    val outboundQueue: LinkedBlockingQueue<ByteArray>,
+    val closed: AtomicBoolean,
+    val inboundThread: Thread,
+    val outboundThread: Thread
+)
+
+/**
+ * Starts a pair of dedicated pump threads that bridge the [clientStream]
+ * suspend API to blocking queues. The inbound pump drains ciphertext from the
+ * MuxStream and enqueues it for [TlsClientInputStream.read]. The outbound pump
+ * drains the queue that [TlsClientOutputStream.write] fills and sends to the
+ * MuxStream. Each pump owns its own `runBlocking` on its own thread, so the
+ * test's outer `runBlocking` event loop is never reentered.
+ */
+private fun startTlsClientPumps(clientStream: ChannelMuxStream): TlsClientPumps {
+    val inbound = LinkedBlockingQueue<ByteArray>()
+    val outbound = LinkedBlockingQueue<ByteArray>()
+    val closed = AtomicBoolean(false)
+
+    val inboundThread = Thread({
+        try {
+            while (!closed.get()) {
+                val data = kotlinx.coroutines.runBlocking { clientStream.read() }
+                inbound.put(data)
+            }
+        } catch (_: Exception) {
+            // EOF or close -- let the reader see EOF via sentinel.
+        } finally {
+            inbound.offer(EMPTY_EOF)
+        }
+    }, "tls-client-inbound-pump").apply {
+        isDaemon = true
+        start()
+    }
+
+    val outboundThread = Thread({
+        try {
+            while (!closed.get()) {
+                val data = outbound.poll(POLL_INTERVAL_MS, TimeUnit.MILLISECONDS) ?: continue
+                if (data === EMPTY_EOF) break
+                kotlinx.coroutines.runBlocking { clientStream.send(data) }
+            }
+        } catch (_: Exception) {
+            // Stream closed -- stop.
+        }
+    }, "tls-client-outbound-pump").apply {
+        isDaemon = true
+        start()
+    }
+
+    return TlsClientPumps(inbound, outbound, closed, inboundThread, outboundThread)
+}
+
+private const val POLL_INTERVAL_MS: Long = 100
+
+/**
+ * Sentinel value meaning "end of stream". Reference-equality checked.
+ */
+internal val EMPTY_EOF = ByteArray(0)
+
+/**
+ * Per-test wall-clock timeout used by the JUnit `Timeout` rule on each bridge
+ * test class. 30 seconds is generous for the slowest test (OAuth device flow
+ * waits 5.5 s past the RFC 8628 poll interval) while still failing fast if a
+ * coroutine deadlocks. See issue #223.
+ */
+internal const val TEST_TIMEOUT_SECONDS: Long = 30
 
 private fun ensureCapacity(buffer: ByteBuffer, additionalBytes: Int): ByteBuffer {
     if (buffer.remaining() >= additionalBytes) return buffer
@@ -195,11 +296,19 @@ private fun ensureCapacity(buffer: ByteBuffer, additionalBytes: Int): ByteBuffer
 
 /**
  * TLS client-side InputStream for tests.
+ *
+ * Reads ciphertext from a [LinkedBlockingQueue] fed by a dedicated pump thread
+ * rather than calling a nested `runBlocking` on the caller's thread. This keeps
+ * the test's outer `runBlocking` event loop free of reentrant blocking
+ * operations. See issue #223.
  */
 internal class TlsClientInputStream(
     private val engine: javax.net.ssl.SSLEngine,
-    private val stream: MuxStream,
-    private var netIn: ByteBuffer
+    private val inbound: LinkedBlockingQueue<ByteArray>,
+    private var netIn: ByteBuffer,
+    private val closedFlag: AtomicBoolean,
+    private val inboundPump: Thread,
+    private val outboundPump: Thread
 ) : InputStream() {
     private var appIn = ByteBuffer.allocate(engine.session.applicationBufferSize)
     init {
@@ -212,6 +321,7 @@ internal class TlsClientInputStream(
         return if (n == -1) -1 else buf[0].toInt() and 0xFF
     }
 
+    @Suppress("ReturnCount")
     override fun read(b: ByteArray, off: Int, len: Int): Int {
         if (appIn.hasRemaining()) {
             val toRead = minOf(len, appIn.remaining())
@@ -220,11 +330,15 @@ internal class TlsClientInputStream(
         }
         appIn.clear()
         while (true) {
+            // Block the JDK-side reader thread on the queue. The inbound pump
+            // thread performs the actual suspending read against the MuxStream.
             val tlsData = try {
-                kotlinx.coroutines.runBlocking { stream.read() }
-            } catch (_: Exception) {
+                inbound.take()
+            } catch (_: InterruptedException) {
+                Thread.currentThread().interrupt()
                 return -1
             }
+            if (tlsData === EMPTY_EOF) return -1
             netIn = ensureCapacity(netIn, tlsData.size)
             netIn.put(tlsData)
             netIn.flip()
@@ -254,14 +368,23 @@ internal class TlsClientInputStream(
             }
         }
     }
+
+    override fun close() {
+        closedFlag.set(true)
+        inboundPump.interrupt()
+        outboundPump.interrupt()
+    }
 }
 
 /**
  * TLS client-side OutputStream for tests.
+ *
+ * Pushes ciphertext onto a [LinkedBlockingQueue] drained by a dedicated pump
+ * thread. No nested `runBlocking` on the caller's thread. See issue #223.
  */
 internal class TlsClientOutputStream(
     private val engine: javax.net.ssl.SSLEngine,
-    private val stream: MuxStream
+    private val outbound: LinkedBlockingQueue<ByteArray>
 ) : OutputStream() {
     private val netOut = ByteBuffer.allocate(engine.session.packetBufferSize)
 
@@ -278,7 +401,7 @@ internal class TlsClientOutputStream(
             if (netOut.hasRemaining()) {
                 val data = ByteArray(netOut.remaining())
                 netOut.get(data)
-                kotlinx.coroutines.runBlocking { stream.send(data) }
+                outbound.put(data)
             }
             if (result.status != SSLEngineResult.Status.OK) {
                 throw java.io.IOException("TLS wrap failed: ${result.status}")

--- a/core/bridge/src/jvmTest/kotlin/com/rousecontext/bridge/TunnelSessionManagerTest.kt
+++ b/core/bridge/src/jvmTest/kotlin/com/rousecontext/bridge/TunnelSessionManagerTest.kt
@@ -29,11 +29,20 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Rule
+import org.junit.rules.Timeout
 
 /**
  * Tests for [TunnelSessionManager] verifying concurrent session handling.
  */
 class TunnelSessionManagerTest {
+
+    /**
+     * Fail fast if a test hangs instead of burning the full CI budget.
+     * See issue #223.
+     */
+    @get:Rule
+    val timeout: Timeout = Timeout.seconds(TEST_TIMEOUT_SECONDS)
 
     private val mcpJson = Json { ignoreUnknownKeys = true }
 


### PR DESCRIPTION
## Summary

- Root-caused the long-standing `:core:bridge:jvmTest` hang (issue #223) to two reentrant `runBlocking` patterns that deadlocked the test worker when multiple classes ran in one JVM: the `TlsClientInputStream`/`TlsClientOutputStream` test helpers wrapped the suspending `MuxStream` API in `runBlocking` on whatever thread called `InputStream.read`, and `TunnelSessionManager` launched `handleStream` on the caller's dispatcher so Ktor's `runBlockingBridge` landed back on the test's `runBlocking` event loop. The nested chain reached 3 deep and parked the JVM.
- Fixed by (a) dispatching `handleStream` onto `Dispatchers.IO` in `TunnelSessionManager` (also a production correctness fix -- the prior behaviour could wedge the Android main thread), and (b) replacing the test TLS client streams with a queue-backed design where dedicated pump threads own the `runBlocking` calls in isolation from the test's event loop.
- Added a JUnit 4 `Timeout` rule (30 s) to every class in the bridge jvmTest source set so any future regression fails fast instead of burning the 20-minute CI budget.

Full suite now completes in ~20 s and is stable across repeated `--rerun-tasks` runs. Verified with `jstack` against a hung worker to locate the exact deadlock before writing the fix.

Closes #223.

## Test plan

- [x] `:core:bridge:jvmTest` green locally (15 tests, ~20s)
- [x] Repeated runs with `--rerun-tasks` stable
- [x] The specific flaky `ClientPassthroughTest.concurrent passthrough sessions are independent` passes 3x in a row
- [x] `:core:bridge:ktlintCheck` passes
- [x] `detekt` weighted issue count unchanged from baseline (77 before, 77 after)
- [x] Combined `:core:tunnel:jvmTest :core:mcp:jvmTest :core:bridge:jvmTest` (the exact CI invocation) passes
- [ ] CI `Build & Test` and `test` jobs pass on this PR without `--admin`

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)