### PR TITLE
Fix #225: AbruptDisconnectTest hang — relay 403 + factory swallows failure

### DIFF
--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/AbruptDisconnectTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/AbruptDisconnectTest.kt
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Timeout
  * client can reconnect by calling [TunnelClientImpl.connect] manually.
  */
 @Tag("integration")
+@Timeout(value = 180, unit = TimeUnit.SECONDS)
 class AbruptDisconnectTest {
 
     companion object {

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/CertRotationIntegrationTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/CertRotationIntegrationTest.kt
@@ -21,6 +21,7 @@ import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import java.security.spec.ECGenParameterSpec
 import java.util.Base64
+import java.util.concurrent.TimeUnit
 import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManagerFactory
@@ -39,6 +40,7 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 
 /**
  * End-to-end cert rotation test against the real Rust relay binary.
@@ -60,6 +62,7 @@ import org.junit.jupiter.api.Test
  *   cd relay && cargo build
  */
 @Tag("integration")
+@Timeout(value = 180, unit = TimeUnit.SECONDS)
 class CertRotationIntegrationTest {
 
     companion object {

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/ClaudeFullFlowEndToEndTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/ClaudeFullFlowEndToEndTest.kt
@@ -27,6 +27,7 @@ import java.security.MessageDigest
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import java.util.Base64
+import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocket
 import kotlin.test.assertEquals
@@ -53,6 +54,7 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.TestMethodOrder
+import org.junit.jupiter.api.Timeout
 
 /**
  * Claude-style full-flow end-to-end test exercising every step a real
@@ -78,6 +80,7 @@ import org.junit.jupiter.api.TestMethodOrder
 @Tag("integration")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+@Timeout(value = 180, unit = TimeUnit.SECONDS)
 class ClaudeFullFlowEndToEndTest {
 
     companion object {

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/EndToEndSessionTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/EndToEndSessionTest.kt
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 
 /**
  * End-to-end session tests using the real Rust relay binary.
@@ -58,6 +59,7 @@ import org.junit.jupiter.api.Test
  */
 @Suppress("LargeClass")
 @Tag("integration")
+@Timeout(value = 180, unit = TimeUnit.SECONDS)
 class EndToEndSessionTest {
 
     companion object {

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/HalfOpenDetectionTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/HalfOpenDetectionTest.kt
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Timeout
  * production ~120s.
  */
 @Tag("integration")
+@Timeout(value = 240, unit = TimeUnit.SECONDS)
 class HalfOpenDetectionTest {
 
     companion object {

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/MtlsWebSocketFactory.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/MtlsWebSocketFactory.kt
@@ -67,8 +67,18 @@ class MtlsWebSocketFactory(private val sslContext: SSLContext) : WebSocketFactor
             .build()
 
         try {
+            // buildAsync returns a CompletableFuture that completes exceptionally
+            // if the handshake fails (TLS error, server rejects upgrade with
+            // non-101 status, etc.). If we don't observe it the listener never
+            // learns about the failure and the caller's opened.await() hangs
+            // forever. See issue #225.
             client.newWebSocketBuilder()
                 .buildAsync(URI.create(url), javaListener)
+                .whenComplete { _, error ->
+                    if (error != null && !handle.isBound()) {
+                        listener.onFailure(error)
+                    }
+                }
         } catch (e: Exception) {
             listener.onFailure(e)
         }

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/MultiClientConcurrencyTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/MultiClientConcurrencyTest.kt
@@ -28,6 +28,7 @@ import java.security.MessageDigest
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import java.util.Base64
+import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocket
 import kotlin.test.assertEquals
@@ -54,6 +55,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.Timeout
 
 /**
  * Multi-client concurrency integration test (issue #186).
@@ -69,6 +71,7 @@ import org.junit.jupiter.api.TestInstance
 @Suppress("LargeClass")
 @Tag("integration")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Timeout(value = 180, unit = TimeUnit.SECONDS)
 class MultiClientConcurrencyTest {
 
     companion object {

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/OAuthEndToEndTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/OAuthEndToEndTest.kt
@@ -27,6 +27,7 @@ import java.security.MessageDigest
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import java.util.Base64
+import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocket
 import kotlin.test.assertEquals
@@ -49,6 +50,7 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 
 /**
  * End-to-end test that exercises the full OAuth authorization code flow
@@ -63,6 +65,7 @@ import org.junit.jupiter.api.Test
  */
 @Suppress("LargeClass")
 @Tag("integration")
+@Timeout(value = 180, unit = TimeUnit.SECONDS)
 class OAuthEndToEndTest {
 
     companion object {

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/RealRelayIntegrationTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/RealRelayIntegrationTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 
 /**
  * Integration tests that start the real Rust relay binary as a subprocess
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Test
  * Build it with: cd relay && cargo build
  */
 @Tag("integration")
+@Timeout(value = 180, unit = TimeUnit.SECONDS)
 class RealRelayIntegrationTest {
 
     companion object {

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/RelayApiClientIntegrationTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/RelayApiClientIntegrationTest.kt
@@ -17,6 +17,7 @@ import java.security.Signature
 import java.security.cert.X509Certificate
 import java.security.spec.ECGenParameterSpec
 import java.util.Base64
+import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
 import javax.net.ssl.X509TrustManager
 import kotlin.test.AfterTest
@@ -31,6 +32,7 @@ import kotlinx.serialization.json.Json
 import okhttp3.Dns
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Timeout
 
 /**
  * End-to-end HTTP wire-contract tests for [RelayApiClient] against the real
@@ -48,6 +50,7 @@ import org.junit.jupiter.api.Tag
  *   cd relay && cargo build
  */
 @Tag("integration")
+@Timeout(value = 180, unit = TimeUnit.SECONDS)
 class RelayApiClientIntegrationTest {
 
     companion object {

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/TestRelayFixture.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/TestRelayFixture.kt
@@ -397,6 +397,14 @@ class TestRelayManager(
             max_streams_per_device = 8
             wake_rate_limit = 60
             fcm_wakeup_timeout_secs = 5
+            # Tunnel integration tests connect a simulated device directly to
+            # /ws without first calling /register -> /register/certs. That path
+            # relies on the relay auto-creating a Firestore record on WS upgrade
+            # when the device's mTLS cert validates. Production defaults this
+            # flag to false; tests opt in explicitly. See issue #209 for the
+            # security rationale and issue #225 for the test regression that
+            # missing this opt-in caused.
+            allow_ws_auto_create_device = true
             $deviceCaBlock
             $firebaseBlock
         """.trimIndent()

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/TunnelMcpIntegrationTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/TunnelMcpIntegrationTest.kt
@@ -24,6 +24,7 @@ import java.io.BufferedReader
 import java.io.InputStream
 import java.io.InputStreamReader
 import java.io.OutputStream
+import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLEngineResult
 import kotlin.test.assertEquals
@@ -43,6 +44,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
 
 /**
  * End-to-end integration tests verifying the full data path:
@@ -52,6 +54,7 @@ import org.junit.jupiter.api.Test
  * Tests IDs 97-99 from overall.md.
  */
 @Tag("integration")
+@Timeout(value = 180, unit = TimeUnit.SECONDS)
 class TunnelMcpIntegrationTest {
 
     private val mcpJson = Json { ignoreUnknownKeys = true }


### PR DESCRIPTION
## Summary

- `:core:tunnel:integrationTest` was burning the full 10-min CI step on `AbruptDisconnectTest > abrupt relay death detected and manual reconnect succeeds`. Two cooperating bugs:
  - Relay change from #209 started rejecting `/ws` with 403 unless the device has a Firestore record; tunnel integration tests connect without calling `/register`. `TestRelayManager` never opted into the test-harness flag `allow_ws_auto_create_device = true`.
  - `MtlsWebSocketFactory` discarded the `CompletableFuture<WebSocket>` returned by `HttpClient.buildAsync`, so a handshake failure never reached the `WebSocketListener`. `TunnelClientImpl.connect` then parked in `opened.await()` forever, turning a loud 403 into a silent hang.
- Fix: set `allow_ws_auto_create_device = true` in the test relay config, observe the `buildAsync` future and route exceptions to `listener.onFailure`, and add `@Timeout(180s)` at class level on every `:core:tunnel` integration test class as a safety net (mirrors #223/#224).

## Test plan

- [x] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :core:tunnel:integrationTest` green locally in under 3 minutes (was 10+ min hung+fail)
- [x] `:core:tunnel:integrationTest --rerun-tasks` still green (~3 min)
- [x] `./gradlew :core:tunnel:jvmTest` green
- [x] `./gradlew ktlintCheck` green
- [x] `detekt` unchanged at baseline weighted-issue count (pre-existing failure on main, not touched by this change)
- [ ] CI "Integration tests (relay)" step green on this PR

Fixes #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)