### PR TITLE
Fix #235: add Google Trust Services to EXPECTED_CERT_ISSUERS

### DIFF
--- a/app/src/main/java/com/rousecontext/app/di/AppModule.kt
+++ b/app/src/main/java/com/rousecontext/app/di/AppModule.kt
@@ -122,10 +122,22 @@ private const val IDLE_TIMEOUT_MS = 5 * 60 * 1000L
  * crt.sh issuer names that are legitimate for Rouse Context certificates.
  * Any CT log entry with an issuer outside this set triggers a security alert.
  *
- * The relay uses Let's Encrypt via ACME; these are the currently-rotated
- * Let's Encrypt intermediates. Update when LE rotates intermediates.
+ * Post-#213 the relay issues via Google Trust Services (WR/WE intermediates).
+ * Let's Encrypt intermediates are retained here because any pre-#213 device
+ * cert is still legitimate until its natural 90-day expiry. Update when
+ * either CA rotates intermediates.
  */
-private val EXPECTED_CERT_ISSUERS: Set<String> = setOf(
+internal val EXPECTED_CERT_ISSUERS: Set<String> = setOf(
+    // Google Trust Services (primary, post-#213)
+    "C=US, O=Google Trust Services, CN=WR1",
+    "C=US, O=Google Trust Services, CN=WR2",
+    "C=US, O=Google Trust Services, CN=WR3",
+    "C=US, O=Google Trust Services, CN=WR4",
+    "C=US, O=Google Trust Services, CN=WE1",
+    "C=US, O=Google Trust Services, CN=WE2",
+    "C=US, O=Google Trust Services, CN=WE3",
+    "C=US, O=Google Trust Services, CN=WE4",
+    // Let's Encrypt (transitional — legacy device certs valid until expiry)
     "C=US, O=Let's Encrypt, CN=R3",
     "C=US, O=Let's Encrypt, CN=R10",
     "C=US, O=Let's Encrypt, CN=R11",

--- a/app/src/test/java/com/rousecontext/app/di/ExpectedCertIssuersTest.kt
+++ b/app/src/test/java/com/rousecontext/app/di/ExpectedCertIssuersTest.kt
@@ -1,0 +1,35 @@
+package com.rousecontext.app.di
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression test for #235: the CT log allowlist must include Google Trust
+ * Services intermediates after the #213 ACME migration. Without at least one
+ * GTS entry, every post-#213 cert triggers a false-positive security alert.
+ */
+class ExpectedCertIssuersTest {
+
+    @Test
+    fun `includes Google Trust Services intermediates`() {
+        val hasGts = EXPECTED_CERT_ISSUERS.any { it.contains("Google Trust Services") }
+        assertTrue(
+            "EXPECTED_CERT_ISSUERS must include at least one Google Trust Services " +
+                "intermediate; otherwise post-#213 certs trigger false-positive alerts. " +
+                "Current set: $EXPECTED_CERT_ISSUERS",
+            hasGts
+        )
+    }
+
+    @Test
+    fun `retains Let's Encrypt intermediates for transitional legacy certs`() {
+        // Pre-#213 device certs from Let's Encrypt remain valid until natural
+        // expiry. They should not trigger alerts while they're still live.
+        val hasLe = EXPECTED_CERT_ISSUERS.any { it.contains("Let's Encrypt") }
+        assertTrue(
+            "EXPECTED_CERT_ISSUERS must retain Let's Encrypt entries until legacy " +
+                "pre-#213 certs have naturally expired (90-day max).",
+            hasLe
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Post-#213 the relay issues device certs via Google Trust Services, but `EXPECTED_CERT_ISSUERS` in `AppModule.kt` still only contained Let's Encrypt intermediates. Every newly-provisioned cert would fire a false-positive `Unexpected certificate issuer` alert on the next CT log scan.

- Add GTS WR1–WR4 and WE1–WE4 intermediates (current GTS TLS issuance CAs).
- Retain LE entries for any pre-#213 device whose cert is still within its 90-day validity.
- Promote the constant to `internal` and add `:app` unit test asserting the set contains both GTS and LE entries.

Closes #235

## Test plan

- [x] `:app:testDebugUnitTest --tests 'com.rousecontext.app.di.ExpectedCertIssuersTest'` passes
- [x] `ktlintCheck` clean
- [ ] CI Build & Test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)