### PR TITLE
Fix #237: Present mTLS client cert for /rotate-secret

### DIFF
--- a/app/src/main/java/com/rousecontext/app/cert/FileMtlsCertSource.kt
+++ b/app/src/main/java/com/rousecontext/app/cert/FileMtlsCertSource.kt
@@ -1,0 +1,72 @@
+package com.rousecontext.app.cert
+
+import android.content.Context
+import android.util.Log
+import com.rousecontext.tunnel.DeviceKeyManager
+import com.rousecontext.tunnel.MtlsCertSource
+import com.rousecontext.tunnel.MtlsIdentity
+import java.io.File
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.util.Base64
+
+/**
+ * [MtlsCertSource] backed by the PEM files [FileCertificateStore] writes to
+ * `context.filesDir` plus the hardware-backed private key from
+ * [DeviceKeyManager].
+ *
+ * Reads are performed on every call so the source transparently switches
+ * from "not provisioned" (during early onboarding) to "provisioned" as
+ * soon as `/register/certs` writes the client cert to disk. See issue
+ * #237 and [com.rousecontext.tunnel.LazyMtlsKeyManager] for the rationale.
+ *
+ * The CLIENT cert file (`rouse_client_cert.pem`, issued by the relay CA
+ * with `clientAuth` EKU) is used here — NOT the server cert file
+ * (`rouse_cert.pem`, issued by Let's Encrypt with `serverAuth` EKU, which
+ * is for AI clients connecting to the device). This matches the split
+ * maintained by [MtlsWebSocketFactory] for the tunnel WebSocket path.
+ */
+class FileMtlsCertSource(context: Context, private val deviceKeyManager: DeviceKeyManager) :
+    MtlsCertSource {
+
+    private val clientCertFile: File = File(context.filesDir, CLIENT_CERT_PEM_FILE)
+    private val relayCaCertFile: File = File(context.filesDir, RELAY_CA_PEM_FILE)
+
+    override fun current(): MtlsIdentity? {
+        if (!clientCertFile.exists()) return null
+        val leaf = parsePemCertificates(clientCertFile.readText()).firstOrNull() ?: return null
+        val caCert = if (relayCaCertFile.exists()) {
+            parsePemCertificates(relayCaCertFile.readText()).firstOrNull()
+        } else {
+            null
+        }
+        val chain = if (caCert != null) listOf(leaf, caCert) else listOf(leaf)
+
+        val privateKey = try {
+            deviceKeyManager.getOrCreateKeyPair().private
+        } catch (e: Exception) {
+            Log.w(TAG, "DeviceKeyManager failed to produce a signing key; presenting no cert", e)
+            return null
+        }
+        return MtlsIdentity(privateKey = privateKey, certChain = chain)
+    }
+
+    private fun parsePemCertificates(pem: String): List<X509Certificate> {
+        val factory = CertificateFactory.getInstance("X.509")
+        val regex = Regex(
+            "-----BEGIN CERTIFICATE-----(.+?)-----END CERTIFICATE-----",
+            RegexOption.DOT_MATCHES_ALL
+        )
+        return regex.findAll(pem).map { match ->
+            val base64 = match.groupValues[1].replace("\\s".toRegex(), "")
+            val der = Base64.getDecoder().decode(base64)
+            factory.generateCertificate(der.inputStream()) as X509Certificate
+        }.toList()
+    }
+
+    companion object {
+        private const val TAG = "FileMtlsCertSource"
+        private const val CLIENT_CERT_PEM_FILE = "rouse_client_cert.pem"
+        private const val RELAY_CA_PEM_FILE = "rouse_relay_ca.pem"
+    }
+}

--- a/app/src/main/java/com/rousecontext/app/di/AppModule.kt
+++ b/app/src/main/java/com/rousecontext/app/di/AppModule.kt
@@ -16,6 +16,7 @@ import com.rousecontext.app.auth.FirebaseAnonymousAuthClient
 import com.rousecontext.app.auth.FirebaseFcmTokenProvider
 import com.rousecontext.app.cert.AndroidKeystoreDeviceKeyManager
 import com.rousecontext.app.cert.FileCertificateStore
+import com.rousecontext.app.cert.FileMtlsCertSource
 import com.rousecontext.app.cert.LazyWebSocketFactory
 import com.rousecontext.app.receivers.AuthApprovalReceiver
 import com.rousecontext.app.registry.HealthConnectIntegration
@@ -84,6 +85,7 @@ import com.rousecontext.tunnel.RelayApiClient
 import com.rousecontext.tunnel.SelfCertVerifier
 import com.rousecontext.tunnel.TunnelClient
 import com.rousecontext.tunnel.TunnelClientImpl
+import com.rousecontext.tunnel.createMtlsRelayHttpClient
 import com.rousecontext.work.AndroidKeystoreSigner
 import com.rousecontext.work.CertRenewalFlowRenewer
 import com.rousecontext.work.CertRenewalPreferences
@@ -200,8 +202,22 @@ val appModule = module {
     // --- Onboarding ---
     single { CsrGenerator() }
     single {
+        // Issue #237: construct the RelayApiClient with an HTTP client that
+        // presents the device's mTLS client certificate on handshakes once
+        // it has been provisioned. The default createDefaultClient() carried
+        // no KeyManager, so every `/rotate-secret` call after onboarding
+        // returned 401 "Valid client certificate required". The
+        // FileMtlsCertSource reads the PEM files on every call, so the same
+        // long-lived HttpClient transparently moves from "no cert" (during
+        // `/register`, `/register/certs`) to "present cert" (`/rotate-secret`,
+        // `/renew`) without a rebuild.
         val httpScheme = if (BuildConfig.RELAY_SCHEME == "wss") "https" else "http"
-        RelayApiClient("$httpScheme://${BuildConfig.RELAY_HOST}")
+        val certSource = FileMtlsCertSource(androidContext(), get<DeviceKeyManager>())
+        val httpClient = createMtlsRelayHttpClient(certSource)
+        RelayApiClient(
+            baseUrl = "$httpScheme://${BuildConfig.RELAY_HOST}",
+            httpClient = httpClient
+        )
     }
     single {
         OnboardingFlow(

--- a/core/tunnel/build.gradle.kts
+++ b/core/tunnel/build.gradle.kts
@@ -46,6 +46,11 @@ kotlin {
                 implementation(libs.ktor.client.content.negotiation)
                 implementation(libs.ktor.serialization.json)
                 implementation(libs.ktor.client.cio)
+                // OkHttp engine for relay REST mTLS (issue #237). Ktor CIO
+                // has historically dropped client certs; OkHttp's JSSE TLS
+                // stack presents them correctly.
+                implementation(libs.ktor.client.okhttp)
+                implementation(libs.okhttp)
             }
         }
         val jvmTest by getting {

--- a/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/LazyMtlsKeyManager.kt
+++ b/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/LazyMtlsKeyManager.kt
@@ -1,0 +1,82 @@
+package com.rousecontext.tunnel
+
+import java.net.Socket
+import java.security.Principal
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.X509ExtendedKeyManager
+
+/**
+ * [X509ExtendedKeyManager] that resolves the device's client certificate lazily
+ * on every TLS handshake via [MtlsCertSource.current].
+ *
+ * This solves the chicken-and-egg between onboarding (`/register`,
+ * `/register/certs`, `/request-subdomain`) and the mTLS-required endpoints
+ * (`/rotate-secret`, `/renew`) described in issue #237. A single long-lived
+ * HTTP client can front all of them: when the source returns `null` we hand
+ * the SSL engine no alias (presenting no client cert, which the relay
+ * accepts on unauthenticated paths), and as soon as provisioning writes a
+ * cert to disk the next handshake picks it up without any client rebuild.
+ *
+ * Hardware-backed keys (Android Keystore / StrongBox) work transparently:
+ * the [PrivateKey] we return is a JCA handle into the Keystore provider, and
+ * the SSL engine routes signing through that provider at handshake time. The
+ * raw key bytes never surface in app memory. See [DirectX509KeyManager]-style
+ * construction used elsewhere in the project for the same reason.
+ */
+class LazyMtlsKeyManager(private val source: MtlsCertSource) : X509ExtendedKeyManager() {
+
+    override fun getClientAliases(keyType: String?, issuers: Array<Principal>?): Array<String>? =
+        if (source.current() != null) arrayOf(ALIAS) else null
+
+    override fun chooseClientAlias(
+        keyType: Array<String>?,
+        issuers: Array<Principal>?,
+        socket: Socket?
+    ): String? = if (source.current() != null) ALIAS else null
+
+    override fun chooseEngineClientAlias(
+        keyType: Array<String>?,
+        issuers: Array<Principal>?,
+        engine: SSLEngine?
+    ): String? = if (source.current() != null) ALIAS else null
+
+    // Server-side aliases are not used by an HTTP client. Return null so that
+    // any accidental server-side use fails loudly instead of presenting the
+    // client identity as a server cert.
+    override fun getServerAliases(keyType: String?, issuers: Array<Principal>?): Array<String>? =
+        null
+
+    override fun chooseServerAlias(
+        keyType: String?,
+        issuers: Array<Principal>?,
+        socket: Socket?
+    ): String? = null
+
+    override fun chooseEngineServerAlias(
+        keyType: String?,
+        issuers: Array<Principal>?,
+        engine: SSLEngine?
+    ): String? = null
+
+    override fun getCertificateChain(alias: String?): Array<X509Certificate>? {
+        if (alias != ALIAS) return null
+        val identity = source.current() ?: return null
+        return identity.certChain.toTypedArray()
+    }
+
+    override fun getPrivateKey(alias: String?): PrivateKey? {
+        if (alias != ALIAS) return null
+        return source.current()?.privateKey
+    }
+
+    companion object {
+        /**
+         * Arbitrary alias string handed to the SSL engine. Must be stable
+         * across all `choose*Alias` / `getCertificateChain` / `getPrivateKey`
+         * calls within a single handshake — JSSE uses it as a lookup key.
+         */
+        const val ALIAS: String = "device"
+    }
+}

--- a/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/MtlsCertSource.kt
+++ b/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/MtlsCertSource.kt
@@ -1,0 +1,31 @@
+package com.rousecontext.tunnel
+
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+
+/**
+ * Snapshot of an mTLS client identity: private key + cert chain (leaf first).
+ */
+data class MtlsIdentity(val privateKey: PrivateKey, val certChain: List<X509Certificate>)
+
+/**
+ * Source of the device's current mTLS client identity, read on demand.
+ *
+ * Implementations MUST be cheap and safe to call on the TLS handshake thread:
+ * the JSSE engine invokes this synchronously while choosing a client
+ * certificate. File reads / Keystore lookups of the sort used on device today
+ * are fine (tens of microseconds); long-running I/O is not.
+ *
+ * Returns `null` when no cert is provisioned yet. During onboarding the
+ * device makes unauthenticated calls (`/register`, `/register/certs`,
+ * `/request-subdomain`) before a cert has been minted. The relay's TLS
+ * layer runs in `allow_unauthenticated` mode, so presenting no client cert
+ * still completes the handshake; the handler rejects privileged calls
+ * (`/rotate-secret`, `/renew`) that arrive without one. This chicken-and-egg
+ * shape is the reason the same long-lived HTTP client must transparently
+ * switch from "no cert" to "present cert" as soon as provisioning writes
+ * a cert to disk (issue #237).
+ */
+fun interface MtlsCertSource {
+    fun current(): MtlsIdentity?
+}

--- a/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/RelayHttpClientFactory.kt
+++ b/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/RelayHttpClientFactory.kt
@@ -1,0 +1,107 @@
+package com.rousecontext.tunnel
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import java.util.concurrent.TimeUnit
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+import kotlinx.serialization.json.Json
+import okhttp3.ConnectionPool
+import okhttp3.OkHttpClient
+
+/**
+ * Builds a Ktor [HttpClient] for [RelayApiClient] that presents the device's
+ * mTLS client certificate on handshakes via [LazyMtlsKeyManager].
+ *
+ * The OkHttp engine is used because its JSSE-backed TLS stack correctly
+ * presents client certificates — mirroring the #226 fix on the WebSocket
+ * path (`MtlsWebSocketFactory`). Ktor's CIO client has historically dropped
+ * client certs silently, so REST mTLS lands on the same engine the WS path
+ * already relies on.
+ *
+ * Connection pooling is disabled (`maxIdleConnections = 0`) so that every
+ * relay REST call performs a fresh TLS handshake. This closes the issue
+ * #237 window: if the first handshake happened before `/register/certs`
+ * wrote a cert to disk, no pooled connection can linger with a "no client
+ * cert" session identity. Onboarding issues a handful of REST calls, so
+ * the per-call handshake cost is not a concern.
+ *
+ * @param certSource Lazy source for the client identity; returns `null`
+ *   before provisioning completes.
+ * @param trustManagers Server-auth trust managers. Defaults to the JVM's
+ *   system trust store, which on Android contains the public CAs that
+ *   chain up to real relay certs (GTS / Let's Encrypt). Tests override
+ *   this to trust a fake CA.
+ * @param configureOkHttp Optional hook for additional OkHttp customization
+ *   (integration tests use this to wire a DNS override + loose hostname
+ *   verifier against the loopback test relay). Production callers should
+ *   not pass this.
+ */
+fun createMtlsRelayHttpClient(
+    certSource: MtlsCertSource,
+    trustManagers: Array<out TrustManager> = defaultSystemTrustManagers(),
+    configureOkHttp: (OkHttpClient.Builder.() -> Unit)? = null
+): HttpClient {
+    val keyManagers = arrayOf(LazyMtlsKeyManager(certSource))
+    val sslContext = SSLContext.getInstance("TLS").apply {
+        init(keyManagers, trustManagers, null)
+        // Disable TLS session caching so every request re-runs the full
+        // handshake and re-consults the LazyMtlsKeyManager. Without this,
+        // TLS 1.3 PSK / 1.2 session resumption can reuse a session
+        // negotiated before provisioning wrote a cert, and the resumed
+        // connection presents no client cert — the exact issue #237
+        // failure mode we are fixing.
+        clientSessionContext?.sessionCacheSize = 1
+        clientSessionContext?.sessionTimeout = 1
+    }
+    val trustManager = trustManagers.firstOrNull { it is X509TrustManager } as? X509TrustManager
+        ?: error("createMtlsRelayHttpClient requires at least one X509TrustManager")
+
+    return HttpClient(OkHttp) {
+        engine {
+            config {
+                sslSocketFactory(sslContext.socketFactory, trustManager)
+                // Disable idle-connection reuse so each request's handshake
+                // re-consults the LazyMtlsKeyManager; see the kdoc above.
+                connectionPool(
+                    ConnectionPool(
+                        /* maxIdleConnections = */
+                        0,
+                        /* keepAliveDuration = */
+                        1L,
+                        /* timeUnit = */
+                        TimeUnit.SECONDS
+                    )
+                )
+                if (configureOkHttp != null) configureOkHttp()
+            }
+        }
+        install(ContentNegotiation) {
+            json(
+                Json {
+                    ignoreUnknownKeys = true
+                    encodeDefaults = true
+                }
+            )
+        }
+        install(HttpTimeout) {
+            requestTimeoutMillis = RELAY_REQUEST_TIMEOUT_MS
+            connectTimeoutMillis = RELAY_CONNECT_TIMEOUT_MS
+            socketTimeoutMillis = RELAY_SOCKET_TIMEOUT_MS
+        }
+    }
+}
+
+private const val RELAY_REQUEST_TIMEOUT_MS = 120_000L
+private const val RELAY_CONNECT_TIMEOUT_MS = 30_000L
+private const val RELAY_SOCKET_TIMEOUT_MS = 120_000L
+
+private fun defaultSystemTrustManagers(): Array<TrustManager> =
+    TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        .apply { init(null as java.security.KeyStore?) }
+        .trustManagers

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/RelayApiClientIntegrationTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/RelayApiClientIntegrationTest.kt
@@ -1,8 +1,11 @@
 package com.rousecontext.tunnel.integration
 
 import com.rousecontext.tunnel.CsrGenerator
+import com.rousecontext.tunnel.MtlsCertSource
+import com.rousecontext.tunnel.MtlsIdentity
 import com.rousecontext.tunnel.RelayApiClient
 import com.rousecontext.tunnel.RelayApiResult
+import com.rousecontext.tunnel.createMtlsRelayHttpClient
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.HttpTimeout
@@ -420,6 +423,97 @@ class RelayApiClientIntegrationTest {
     }
 
     /**
+     * Regression test for issue #237. The app wires [RelayApiClient] through
+     * [createMtlsRelayHttpClient] with a lazy [MtlsCertSource] so a single
+     * long-lived client can issue both the unauthenticated onboarding calls
+     * (`/register`, `/register/certs`) and the mTLS-required follow-up calls
+     * (`/rotate-secret`). This test asserts that specific wiring works
+     * end-to-end against the real relay — not a hand-rolled mTLS Ktor client
+     * sitting alongside the production factory.
+     *
+     * Pre-bug reproduction: [RelayApiClient.createDefaultClient] had no
+     * KeyManager, so the TLS handshake for `/rotate-secret` presented no
+     * client cert and the relay returned 401 "Valid client certificate
+     * required". The flow here uses the production factory exclusively; a
+     * regression on that wiring (e.g. someone reverting AppModule to the
+     * default client or removing the lazy KM) fails this test deterministically
+     * on the `updateSecrets` call.
+     */
+    @Test
+    fun `createMtlsRelayHttpClient succeeds on register then updateSecrets`(): Unit = runBlocking {
+        // Lazy cert holder. Starts empty: the first /register call must still
+        // succeed because the relay runs its API TLS in allow_unauthenticated
+        // mode, accepting handshakes with no client cert. Onboarding writes
+        // into this holder between /register and /rotate-secret.
+        val identityHolder = AtomicMtlsIdentityHolder()
+        val (trustingSsl, trustingTm) = buildTrustingSslContext(ca.caCert)
+        val httpClient = createMtlsRelayHttpClient(
+            certSource = identityHolder,
+            trustManagers = arrayOf(trustingTm),
+            configureOkHttp = {
+                hostnameVerifier { _, _ -> true }
+                dns(Ipv4OnlyDns)
+            }
+        )
+
+        // Discard the SSLContext we built only for the trust manager — the
+        // factory constructs its own from the cert source.
+        @Suppress("UNUSED_VARIABLE")
+        val unusedSsl = trustingSsl
+        val scopedApi = RelayApiClient(baseUrl = baseUrl, httpClient = httpClient)
+
+        try {
+            // Phase 1: unauthenticated /register must work with no cert in
+            // the source (simulating fresh onboarding).
+            val firebaseToken = DUMMY_FIREBASE_TOKEN + "-lazy-wiring"
+            val initialIntegrations = listOf("health")
+            val reg = assertSuccess(
+                scopedApi.register(
+                    firebaseToken = firebaseToken,
+                    fcmToken = DUMMY_FCM_TOKEN,
+                    integrationIds = initialIntegrations
+                )
+            )
+            val healthSecret = reg.secrets.getValue("health")
+            val subdomain = reg.subdomain
+            assertTrue(
+                identityHolder.current() == null,
+                "Phase 1 must run with no client cert present in the source"
+            )
+
+            // Phase 2: mint a cert via the test CA and install it in the
+            // cert source. No HttpClient rebuild. Connection pooling is
+            // disabled by the factory so the next request forces a fresh
+            // TLS handshake.
+            val keyStoreForSubdomain = ca.createDeviceKeyStore(subdomain)
+            identityHolder.set(mtlsIdentityFrom(keyStoreForSubdomain))
+
+            // Phase 3: /rotate-secret must succeed — the LazyMtlsKeyManager
+            // now hands the cert to the TLS engine on the next handshake.
+            val requestedIntegrations = listOf("health", "notifications")
+            val result = scopedApi.updateSecrets(
+                subdomain = subdomain,
+                integrationIds = requestedIntegrations
+            )
+
+            val body = assertSuccess(result)
+            assertTrue(body.success, "response.success must be true")
+            assertEquals(
+                requestedIntegrations.toSet(),
+                body.secrets.keys,
+                "secrets map must mirror requested integrations after merge-missing"
+            )
+            assertEquals(
+                healthSecret,
+                body.secrets["health"],
+                "existing 'health' secret must be preserved on merge-missing rotation"
+            )
+        } finally {
+            httpClient.close()
+        }
+    }
+
+    /**
      * Full success-shape /renew over the mTLS-equivalent (signature-only) path.
      *
      * Holds onto the private key generated for the registration CSR so it can sign the
@@ -638,5 +732,42 @@ class RelayApiClientIntegrationTest {
     private object Ipv4OnlyDns : Dns {
         override fun lookup(hostname: String): List<InetAddress> =
             listOf(InetAddress.getByName("127.0.0.1"))
+    }
+
+    /**
+     * Thread-safe mutable [MtlsCertSource] for driving the #237 regression
+     * test through the "no cert → cert present" transition inside a single
+     * HttpClient. Writes from the test coroutine are picked up on the next
+     * TLS handshake since the OkHttp factory is configured with no idle
+     * connection pool.
+     */
+    private class AtomicMtlsIdentityHolder : MtlsCertSource {
+        @Volatile
+        private var identity: MtlsIdentity? = null
+
+        override fun current(): MtlsIdentity? = identity
+
+        fun set(value: MtlsIdentity) {
+            identity = value
+        }
+    }
+
+    /**
+     * Convert a PKCS12 [KeyStore] (as produced by
+     * [TestCertificateAuthority.createDeviceKeyStore]) into an
+     * [MtlsIdentity] suitable for the [MtlsCertSource]. Mirrors what
+     * `FileMtlsCertSource` does at runtime: extract the private key + cert
+     * chain and hand them to the KeyManager verbatim.
+     */
+    private fun mtlsIdentityFrom(keyStore: KeyStore): MtlsIdentity {
+        val alias = keyStore.aliases().toList()
+            .firstOrNull { keyStore.isKeyEntry(it) }
+            ?: fail("Key store has no key entry: ${keyStore.aliases().toList()}")
+        val privateKey = keyStore.getKey(alias, TestCertificateAuthority.STORE_PASS.toCharArray())
+            as? java.security.PrivateKey
+            ?: fail("Expected private key entry at alias '$alias'")
+        val chain = keyStore.getCertificateChain(alias)?.map { it as X509Certificate }
+            ?: fail("No certificate chain for alias '$alias'")
+        return MtlsIdentity(privateKey = privateKey, certChain = chain)
     }
 }


### PR DESCRIPTION
## Summary
- RelayApiClient was constructed with Ktor's default HttpClient (no KeyManager), so every `/rotate-secret` call during onboarding returned 401 "Valid client certificate required". The relay extracts the device subdomain from the mTLS client cert CN (#202); the default client never presented one.
- Wire a single long-lived HttpClient that transparently handles both the unauthenticated onboarding calls (`/register`, `/register/certs`, `/request-subdomain`) and the mTLS-required follow-ups (`/rotate-secret`, `/renew`). `LazyMtlsKeyManager` resolves the cert via `MtlsCertSource` on every TLS handshake, so the same client moves from "no cert" to "present cert" as soon as provisioning writes the PEM to disk — no rebuild, no restart.
- OkHttp engine (JSSE-based) matches the #226 WebSocket mTLS fix. Ktor CIO silently drops client certs. Connection pooling is disabled and TLS session cache is shrunk so a session negotiated pre-cert can't be resumed post-cert without re-consulting the KeyManager.

## Pieces
- `:core:tunnel` — `MtlsCertSource` + `LazyMtlsKeyManager` + `createMtlsRelayHttpClient`. Pure JVM.
- `:app` — `FileMtlsCertSource` reads `rouse_client_cert.pem` + `rouse_relay_ca.pem` from `filesDir` and combines with `DeviceKeyManager` (Android Keystore). `AppModule` wires it.

## Test plan
- [x] `RelayApiClientIntegrationTest.createMtlsRelayHttpClient succeeds on register then updateSecrets` — exercises the production factory end-to-end against the real relay binary. Phase 1 calls `/register` with empty cert source (simulating fresh onboarding); phase 2 installs a cert; phase 3 calls `/rotate-secret` on the same HttpClient. Without this patch phase 3 401s.
- [x] All existing `RelayApiClientIntegrationTest` tests still green.
- [x] `:app:testDebugUnitTest` green.
- [x] `:core:tunnel:jvmTest` green.
- [x] `ktlintCheck` green.
- [ ] Fresh onboarding on a real device succeeds past `updateSecrets` without 401.

Fixes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)