### PR TITLE
Fix #238: Serialize CertProvisioningFlow to stop duplicate /register/certs

### DIFF
--- a/app/src/main/java/com/rousecontext/app/ui/viewmodels/IntegrationSetupViewModel.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/viewmodels/IntegrationSetupViewModel.kt
@@ -87,6 +87,14 @@ class IntegrationSetupViewModel(
     private var lastFailureStage: IntegrationSetupFailureStage? = null
 
     fun startSetup(id: String) {
+        // Issue #238: IntegrationSetupDestination fires startSetup from a
+        // LaunchedEffect that can re-run on recomposition/navigation. Without
+        // this guard a second invocation spawns a duplicate viewModelScope
+        // coroutine, which would race the first past CertProvisioningFlow's
+        // already-provisioned check and issue two /register/certs requests.
+        // CertProvisioningFlow also serializes via Mutex as defense-in-depth,
+        // but bailing here avoids even starting the work.
+        if (_state.value is IntegrationSetupState.Provisioning) return
         integrationId = id
         _state.value = IntegrationSetupState.Provisioning(
             SettingUpState(variant = SettingUpVariant.Requesting)

--- a/app/src/test/java/com/rousecontext/app/ui/viewmodels/IntegrationSetupViewModelTest.kt
+++ b/app/src/test/java/com/rousecontext/app/ui/viewmodels/IntegrationSetupViewModelTest.kt
@@ -479,6 +479,74 @@ class IntegrationSetupViewModelTest {
     }
 
     @Test
+    fun `duplicate startSetup while provisioning only invokes cert flow once`() =
+        runTest(testDispatcher) {
+            // Issue #238: IntegrationSetupDestination fires startSetup from a
+            // LaunchedEffect that can re-run during recomposition/navigation,
+            // leading to two viewModelScope coroutines each calling
+            // CertProvisioningFlow.execute. The Provisioning-state guard at
+            // the top of startSetup must short-circuit the second call so
+            // execute() is never invoked twice.
+            val stateStore = mockk<IntegrationStateStore>(relaxed = true)
+            val gate = kotlinx.coroutines.CompletableDeferred<Unit>()
+            val certProvisioningFlow = mockk<CertProvisioningFlow> {
+                coEvery { execute(any()) } coAnswers {
+                    // Suspend so the second startSetup call arrives while the
+                    // first is still in flight, reproducing the recomposition
+                    // race.
+                    gate.await()
+                    CertProvisioningResult.AlreadyProvisioned
+                }
+            }
+            val webSocketFactory = mockk<LazyWebSocketFactory>(relaxed = true)
+            val registrationStatus = DeviceRegistrationStatus(initiallyRegistered = true)
+            val relayApiClient = mockk<RelayApiClient> {
+                coEvery { updateSecrets(any(), any()) } returns
+                    RelayApiResult.Success(
+                        UpdateSecretsResponse(
+                            success = true,
+                            secrets = mapOf("health" to "brave-health")
+                        )
+                    )
+            }
+            val certStore = mockk<CertificateStore> {
+                coEvery { getSubdomain() } returns "cool-penguin"
+                coEvery { getIntegrationSecrets() } returns mapOf("health" to "brave-health")
+                coEvery { storeIntegrationSecrets(any()) } just Runs
+            }
+
+            val vm = IntegrationSetupViewModel(
+                stateStore = stateStore,
+                certProvisioningFlow = certProvisioningFlow,
+                lazyWebSocketFactory = webSocketFactory,
+                registrationStatus = registrationStatus,
+                relayApiClient = relayApiClient,
+                certStore = certStore,
+                integrationIds = listOf("health"),
+                firebaseTokenProvider = { "test-firebase-token" }
+            )
+
+            vm.startSetup("health")
+            // Let the first call reach certProvisioningFlow.execute and suspend.
+            advanceUntilIdle()
+            assertTrue(
+                "First startSetup should have moved state to Provisioning",
+                vm.state.value is IntegrationSetupState.Provisioning
+            )
+
+            // Second call lands while first is still mid-flight. Must be
+            // rejected by the Provisioning-state guard.
+            vm.startSetup("health")
+            advanceUntilIdle()
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+
+            assertEquals(IntegrationSetupState.Complete, vm.state.value)
+            coVerify(exactly = 1) { certProvisioningFlow.execute(any()) }
+        }
+
+    @Test
     fun `updateSecrets succeeds on second attempt`() = runTest(testDispatcher) {
         val stateStore = mockk<IntegrationStateStore>(relaxed = true)
         val certProvisioningFlow = mockk<CertProvisioningFlow> {

--- a/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/CertProvisioningFlow.kt
+++ b/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/CertProvisioningFlow.kt
@@ -1,5 +1,8 @@
 package com.rousecontext.tunnel
 
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
 /**
  * Provisions ACME server + relay CA client certificates for a device that has
  * already completed onboarding (has a subdomain assigned).
@@ -12,6 +15,12 @@ package com.rousecontext.tunnel
  * Issue #200: the device identity keypair is owned by [DeviceKeyManager] (hardware-backed
  * on Android). The private key never leaves the keystore; `CertProvisioningFlow` only
  * reads the public key (via [DeviceKeyManager.getOrCreateKeyPair]) to build the CSR.
+ *
+ * Issue #238: [execute] is serialized by an internal [Mutex] so that concurrent callers
+ * (e.g. a Compose `LaunchedEffect` that re-runs during recomposition) do not each race
+ * past the already-provisioned check and issue duplicate `/register/certs` requests,
+ * which forces the relay to start two concurrent ACME orders and ends up 400-ing the
+ * second one when GTS deduplicates challenges.
  */
 class CertProvisioningFlow(
     private val csrGenerator: CsrGenerator,
@@ -20,6 +29,8 @@ class CertProvisioningFlow(
     private val deviceKeyManager: DeviceKeyManager,
     private val defaultBaseDomain: String = "rousecontext.com"
 ) {
+
+    private val mutex = Mutex()
 
     /**
      * Provisions certificates if not already present.
@@ -33,16 +44,18 @@ class CertProvisioningFlow(
     suspend fun execute(
         firebaseToken: String,
         baseDomain: String = defaultBaseDomain
-    ): CertProvisioningResult {
-        // Already provisioned?
+    ): CertProvisioningResult = mutex.withLock {
+        // Already provisioned? Re-checked under the lock so that a second caller
+        // who arrived while the first call was in flight sees the freshly-stored
+        // certificates and short-circuits instead of re-issuing the CSR.
         if (certificateStore.getCertificate() != null &&
             certificateStore.getClientCertificate() != null
         ) {
-            return CertProvisioningResult.AlreadyProvisioned
+            return@withLock CertProvisioningResult.AlreadyProvisioned
         }
 
         val subdomain = certificateStore.getSubdomain()
-            ?: return CertProvisioningResult.NotOnboarded
+            ?: return@withLock CertProvisioningResult.NotOnboarded
 
         // Obtain (or generate) the hardware-backed device keypair and build the CSR.
         val fqdn = "*.$subdomain.$baseDomain"
@@ -50,11 +63,11 @@ class CertProvisioningFlow(
             val keyPair = deviceKeyManager.getOrCreateKeyPair()
             csrGenerator.generate(fqdn, keyPair)
         } catch (e: Exception) {
-            return CertProvisioningResult.KeyGenerationFailed(e)
+            return@withLock CertProvisioningResult.KeyGenerationFailed(e)
         }
 
         // Submit CSR to get both certs
-        return when (
+        when (
             val certResponse = relayApiClient.registerCerts(
                 csrPem = csrResult.csrPem,
                 firebaseToken = firebaseToken

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/CertProvisioningFlowTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/CertProvisioningFlowTest.kt
@@ -1,5 +1,6 @@
 package com.rousecontext.tunnel
 
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -7,6 +8,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 
 class CertProvisioningFlowTest {
@@ -150,6 +155,73 @@ class CertProvisioningFlowTest {
             actual = store.getSubdomain(),
             message = "Subdomain (onboarding state) must survive cert provisioning rollback"
         )
+    }
+
+    @Test
+    fun `concurrent execute calls serialize and issue exactly one registerCerts`() {
+        runBlocking { runConcurrentExecuteSerializationTest() }
+    }
+
+    private suspend fun runConcurrentExecuteSerializationTest(): Unit = coroutineScope {
+        // Issue #238: a Compose LaunchedEffect can re-run the ViewModel's
+        // startSetup during onboarding, causing two coroutines to call
+        // CertProvisioningFlow.execute concurrently. Before the Mutex, both
+        // callers raced past the already-provisioned check and each issued a
+        // /register/certs POST, which in turn triggered two ACME orders and
+        // the GTS deduplicator 400-ed the second one. The Mutex inside
+        // execute() must serialize callers so only one POST is made.
+        store.storeSubdomain("abc123")
+
+        val releaseFirst = CompletableDeferred<Unit>()
+        val firstCallStarted = CompletableDeferred<Unit>()
+        val certRequests = AtomicInteger(0)
+
+        mockServer.certHandler = { _ ->
+            val ordinal = certRequests.incrementAndGet()
+            if (ordinal == 1) {
+                // Signal that the first handler is running, then block until
+                // the test explicitly releases it. This pins execute() inside
+                // its critical section long enough for the second call to
+                // contend on the Mutex. If serialization is broken, the second
+                // caller races through and this counter will advance past 1
+                // before releaseFirst completes.
+                firstCallStarted.complete(Unit)
+                releaseFirst.await()
+            }
+            MockCertResponse(
+                status = 201,
+                body = CertResponse(
+                    subdomain = "abc123",
+                    serverCert = MockRelayServer.MOCK_CERT_PEM,
+                    clientCert = MockRelayServer.MOCK_CLIENT_CERT_PEM,
+                    relayCaCert = MockRelayServer.MOCK_RELAY_CA_PEM,
+                    relayHost = "relay.rousecontext.com"
+                )
+            )
+        }
+
+        val firstCall = async { flow.execute(FAKE_FIREBASE_TOKEN) }
+        // Wait for the first call to reach the server before launching the
+        // second one. This guarantees the second caller arrives while the
+        // first still holds the Mutex, which is the race we are protecting
+        // against.
+        firstCallStarted.await()
+
+        val secondCall = async { flow.execute(FAKE_FIREBASE_TOKEN) }
+
+        releaseFirst.complete(Unit)
+
+        val results = listOf(firstCall, secondCall).awaitAll()
+
+        assertEquals(
+            expected = 1,
+            actual = certRequests.get(),
+            message = "Concurrent execute() calls must issue exactly one /register/certs"
+        )
+        // One caller wins and receives Success; the other must observe the
+        // freshly-stored certs under the lock and return AlreadyProvisioned.
+        assertTrue(results.any { it is CertProvisioningResult.Success })
+        assertTrue(results.any { it is CertProvisioningResult.AlreadyProvisioned })
     }
 
     @Test


### PR DESCRIPTION
## Summary

- During onboarding two coroutines could concurrently call `CertProvisioningFlow.execute`: `IntegrationSetupDestination` fires `startSetup` from a `LaunchedEffect` that re-runs on recomposition/navigation, and `startSetup` had no in-flight guard. Both callers raced past the already-provisioned check and each POSTed `/register/certs`, triggering two ACME orders. GTS now deduplicates DNS-01 challenges, so the second order 400-ed with `Only pending challenges may be validated` and onboarding failed end-to-end.
- Defense 1: wrap `CertProvisioningFlow.execute` in a `Mutex` so a second caller waits for the first; by the time it acquires the lock, certs are stored and the existing already-provisioned check returns `AlreadyProvisioned`.
- Defense 2: bail out of `IntegrationSetupViewModel.startSetup` when state is already `Provisioning`, so recomposition-triggered `LaunchedEffect` replays do not launch a duplicate `viewModelScope` coroutine.

Closes #238.

## Test plan

- [x] `CertProvisioningFlowTest` - new `concurrent execute calls serialize and issue exactly one registerCerts` test fires two `execute()` calls while the first is pinned inside the mock `/register/certs` handler and asserts the handler runs exactly once; one caller gets `Success`, the other `AlreadyProvisioned`.
- [x] `IntegrationSetupViewModelTest` - new `duplicate startSetup while provisioning only invokes cert flow once` calls `startSetup` twice while the cert flow is suspended on a gate and asserts `execute` is only invoked once.
- [x] `./gradlew :app:testDebugUnitTest :core:tunnel:jvmTest ktlintCheck` all green locally (detekt shows only pre-existing issues outside changed files; CI treats detekt as `continue-on-error`).

Generated with [Claude Code](https://claude.com/claude-code)