### PR TITLE
Fix #244: suspend AuditListener to close session-summary race

### DIFF
--- a/app/src/main/java/com/rousecontext/app/di/AppModule.kt
+++ b/app/src/main/java/com/rousecontext/app/di/AppModule.kt
@@ -351,7 +351,6 @@ val appModule = module {
     single<AuditListener> {
         RoomAuditListener(
             dao = get(),
-            scope = get(named("appScope")),
             fieldEncryptor = get(),
             perCallObserver = get(),
             mcpRequestDao = get()

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/AuditListener.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/AuditListener.kt
@@ -8,7 +8,13 @@ import kotlinx.serialization.json.JsonElement
  * Implemented by :app to persist a per-tool-call history log.
  */
 interface AuditListener {
-    fun onToolCall(event: ToolCallEvent)
+    /**
+     * Called for every `tools/call` completion. Suspending so implementations
+     * can persist the event before returning — the post-session summary
+     * notifier queries the audit DAO on stream drain and races any
+     * fire-and-forget insert that returns early. See issue #244.
+     */
+    suspend fun onToolCall(event: ToolCallEvent)
 
     /**
      * Called when a client completes OAuth and receives an access token.
@@ -24,9 +30,13 @@ interface AuditListener {
      * tool-call UI stays intact while the broader message log receives every
      * request.
      *
+     * Suspending for the same reason as [onToolCall]: implementations must be
+     * able to persist synchronously from the caller's perspective so the
+     * summary notifier doesn't race an in-flight insert (#244).
+     *
      * Default no-op so existing implementations don't break.
      */
-    fun onRequest(event: McpRequestEvent) {}
+    suspend fun onRequest(event: McpRequestEvent) {}
 }
 
 data class ToolCallEvent(

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/McpRouting.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/McpRouting.kt
@@ -1039,7 +1039,7 @@ internal fun buildAuthorizePage(
  * request to fail.
  */
 @Suppress("TooGenericExceptionCaught", "LongParameterList")
-private fun emitAuditEvent(
+private suspend fun emitAuditEvent(
     auditListener: AuditListener,
     request: JsonObject,
     responseJson: String,
@@ -1081,7 +1081,7 @@ private fun emitAuditEvent(
 }
 
 @Suppress("TooGenericExceptionCaught", "LongParameterList")
-private fun emitRequestEvent(
+private suspend fun emitRequestEvent(
     auditListener: AuditListener,
     request: JsonObject,
     responseJson: String,
@@ -1111,7 +1111,7 @@ private fun emitRequestEvent(
 }
 
 @Suppress("TooGenericExceptionCaught", "ReturnCount", "LongParameterList")
-private fun emitToolCallEvent(
+private suspend fun emitToolCallEvent(
     auditListener: AuditListener,
     request: JsonObject,
     responseJson: String,

--- a/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/core/McpProtocolTest.kt
+++ b/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/core/McpProtocolTest.kt
@@ -453,7 +453,7 @@ class McpProtocolTest {
             registry,
             tokenStore,
             auditListener = object : AuditListener {
-                override fun onToolCall(event: ToolCallEvent) {
+                override suspend fun onToolCall(event: ToolCallEvent) {
                     events.add(event)
                 }
             },
@@ -489,7 +489,7 @@ class McpProtocolTest {
             registry,
             tokenStore,
             auditListener = object : AuditListener {
-                override fun onToolCall(event: ToolCallEvent) {
+                override suspend fun onToolCall(event: ToolCallEvent) {
                     events.add(event)
                 }
             }
@@ -513,7 +513,7 @@ class McpProtocolTest {
             registry,
             tokenStore,
             auditListener = object : AuditListener {
-                override fun onToolCall(event: ToolCallEvent) {
+                override suspend fun onToolCall(event: ToolCallEvent) {
                     events.add(event)
                 }
             }
@@ -592,7 +592,7 @@ class McpProtocolTest {
                 hostname = "brave-health.abc123.rousecontext.com",
                 integration = "health",
                 auditListener = object : AuditListener {
-                    override fun onToolCall(event: ToolCallEvent) {
+                    override suspend fun onToolCall(event: ToolCallEvent) {
                         events.add(event)
                     }
                 }
@@ -662,10 +662,10 @@ class McpProtocolTest {
     private class CollectingAuditListener : AuditListener {
         val toolCalls = mutableListOf<ToolCallEvent>()
         val requests = mutableListOf<McpRequestEvent>()
-        override fun onToolCall(event: ToolCallEvent) {
+        override suspend fun onToolCall(event: ToolCallEvent) {
             toolCalls.add(event)
         }
-        override fun onRequest(event: McpRequestEvent) {
+        override suspend fun onRequest(event: McpRequestEvent) {
             requests.add(event)
         }
     }

--- a/notifications/src/main/java/com/rousecontext/notifications/audit/RoomAuditListener.kt
+++ b/notifications/src/main/java/com/rousecontext/notifications/audit/RoomAuditListener.kt
@@ -5,8 +5,6 @@ import com.rousecontext.mcp.core.McpRequestEvent
 import com.rousecontext.mcp.core.ToolCallEvent
 import com.rousecontext.notifications.FieldEncryptor
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 
@@ -17,41 +15,63 @@ import kotlinx.serialization.json.JsonObject
  * provided.
  *
  * When a [perCallObserver] is supplied, it is invoked for every tool call
- * after the DB insert is launched. This drives the per-tool-call notification
- * path ([com.rousecontext.notifications.PerToolCallNotifier]) for
+ * after the DB insert has committed. This drives the per-tool-call
+ * notification path
+ * ([com.rousecontext.notifications.PerToolCallNotifier]) for
  * [com.rousecontext.api.PostSessionMode.EACH_USAGE].
  *
  * When [mcpRequestDao] is supplied (see issue #105), every MCP JSON-RPC
  * request is also persisted to a parallel `mcp_request_entries` table so
  * the user can opt in to a complete message log from Settings.
+ *
+ * ## Why suspend/inline inserts (issue #244)
+ *
+ * Inserts run on the caller's coroutine context (no internal `launch`).
+ * Once [onToolCall] or [onRequest] returns, the row is committed. The
+ * post-session summary notifier queries the audit DAO on the
+ * ACTIVE -> CONNECTED stream-drain transition, which would otherwise race
+ * a fire-and-forget insert and lose on fast hardware.
  */
 class RoomAuditListener(
     private val dao: AuditDao,
-    private val scope: CoroutineScope,
     private val fieldEncryptor: FieldEncryptor? = null,
     private val perCallObserver: PerCallObserver? = null,
     private val mcpRequestDao: McpRequestDao? = null
 ) : AuditListener {
 
-    override fun onToolCall(event: ToolCallEvent) {
-        scope.launch {
-            val argsJson = JsonObject(event.arguments).toString()
-            val resultJson = auditJson.encodeToString(CallToolResult.serializer(), event.result)
-            dao.insert(
-                AuditEntry(
-                    sessionId = event.sessionId,
-                    toolName = event.toolName,
-                    provider = event.providerId,
-                    timestampMillis = event.timestamp,
-                    durationMillis = event.durationMs,
-                    success = true,
-                    errorMessage = fieldEncryptor?.encrypt(null),
-                    argumentsJson = fieldEncryptor?.encrypt(argsJson) ?: argsJson,
-                    resultJson = fieldEncryptor?.encrypt(resultJson) ?: resultJson
-                )
+    override suspend fun onToolCall(event: ToolCallEvent) {
+        val argsJson = JsonObject(event.arguments).toString()
+        val resultJson = auditJson.encodeToString(CallToolResult.serializer(), event.result)
+        dao.insert(
+            AuditEntry(
+                sessionId = event.sessionId,
+                toolName = event.toolName,
+                provider = event.providerId,
+                timestampMillis = event.timestamp,
+                durationMillis = event.durationMs,
+                success = true,
+                errorMessage = fieldEncryptor?.encrypt(null),
+                argumentsJson = fieldEncryptor?.encrypt(argsJson) ?: argsJson,
+                resultJson = fieldEncryptor?.encrypt(resultJson) ?: resultJson
             )
-            perCallObserver?.onToolCallRecorded(event)
-        }
+        )
+        perCallObserver?.onToolCallRecorded(event)
+    }
+
+    override suspend fun onRequest(event: McpRequestEvent) {
+        val requestDao = mcpRequestDao ?: return
+        val paramsJson = event.params?.toString()
+        requestDao.insert(
+            McpRequestEntry(
+                sessionId = event.sessionId,
+                provider = event.providerId,
+                method = event.method,
+                timestampMillis = event.timestamp,
+                durationMillis = event.durationMs,
+                resultBytes = event.resultBytes,
+                paramsJson = fieldEncryptor?.encrypt(paramsJson) ?: paramsJson
+            )
+        )
     }
 
     private companion object {
@@ -63,24 +83,6 @@ class RoomAuditListener(
         private val auditJson = Json {
             encodeDefaults = true
             explicitNulls = false
-        }
-    }
-
-    override fun onRequest(event: McpRequestEvent) {
-        val requestDao = mcpRequestDao ?: return
-        scope.launch {
-            val paramsJson = event.params?.toString()
-            requestDao.insert(
-                McpRequestEntry(
-                    sessionId = event.sessionId,
-                    provider = event.providerId,
-                    method = event.method,
-                    timestampMillis = event.timestamp,
-                    durationMillis = event.durationMs,
-                    resultBytes = event.resultBytes,
-                    paramsJson = fieldEncryptor?.encrypt(paramsJson) ?: paramsJson
-                )
-            )
         }
     }
 }

--- a/notifications/src/test/java/com/rousecontext/notifications/SessionSummaryNotifierTest.kt
+++ b/notifications/src/test/java/com/rousecontext/notifications/SessionSummaryNotifierTest.kt
@@ -6,9 +6,13 @@ import androidx.test.core.app.ApplicationProvider
 import com.rousecontext.api.NotificationSettings
 import com.rousecontext.api.NotificationSettingsProvider
 import com.rousecontext.api.PostSessionMode
+import com.rousecontext.mcp.core.ToolCallEvent
 import com.rousecontext.notifications.audit.AuditDao
 import com.rousecontext.notifications.audit.AuditEntry
+import com.rousecontext.notifications.audit.RoomAuditListener
 import com.rousecontext.tunnel.TunnelState
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -292,6 +296,74 @@ class SessionSummaryNotifierTest {
             1,
             dao.queryCreatedAfterCount
         )
+
+        job.cancel()
+        coroutineContext.cancelChildren()
+    }
+
+    /**
+     * Regression test for issue #244: the session-summary query on the
+     * ACTIVE -> CONNECTED transition used to race a fire-and-forget insert
+     * started inside `RoomAuditListener.onToolCall`. On fast hardware the
+     * query won, found no entries, and the summary never fired.
+     *
+     * With the fix, `AuditListener.onToolCall` is `suspend` and the insert
+     * runs on the caller's coroutine context — by the time the method
+     * returns the row is committed. This test wires a real
+     * [RoomAuditListener] in front of the same [FakeAuditDao] the notifier
+     * observes, drives a single session through the state machine, and
+     * asserts the summary notification is posted.
+     */
+    @Test
+    fun `onToolCall insert is visible to summary query before state transition`() = runBlocking {
+        settings.mode = PostSessionMode.SUMMARY
+        val listener = RoomAuditListener(dao = dao)
+        val states = MutableSharedFlow<TunnelState>(replay = 16, extraBufferCapacity = 16)
+        val posted = CompletableDeferred<Unit>()
+        dao.onQueryCreatedAfter = { posted.complete(Unit) }
+
+        val job = launch { notifier.observe(states) }
+
+        states.emit(TunnelState.CONNECTING)
+        states.emit(TunnelState.CONNECTED)
+        states.emit(TunnelState.ACTIVE)
+
+        // Wait for the notifier to capture its cursor before we persist.
+        awaitLatestId()
+
+        // Persist via the real listener. Because onToolCall is now `suspend`
+        // and does NOT internally launch, this call returns only after the
+        // row has been inserted.
+        listener.onToolCall(
+            ToolCallEvent(
+                sessionId = "session-1",
+                providerId = "health",
+                timestamp = System.currentTimeMillis(),
+                toolName = "get_steps",
+                arguments = emptyMap(),
+                result = CallToolResult(content = listOf(TextContent("ok"))),
+                durationMs = 5L
+            )
+        )
+
+        // Immediately drain — this is the transition that used to race the
+        // in-flight insert. With the fix, the insert is already committed.
+        states.emit(TunnelState.CONNECTED)
+
+        withTimeout(TIMEOUT_MS) { posted.await() }
+
+        val shadow = Shadows.shadowOf(manager)
+        val notification = shadow.getNotification(SessionSummaryNotifier.NOTIFICATION_ID)
+        assertNotNull(
+            "Summary notification should be posted when the insert completes " +
+                "before the ACTIVE -> CONNECTED transition (issue #244)",
+            notification
+        )
+        val title = notification.extras.getCharSequence("android.title")?.toString() ?: ""
+        val text = notification.extras.getCharSequence("android.text")?.toString() ?: ""
+        val all = "$title $text"
+        assertTrue("Expected 1 tool call in summary text, was: $all", all.contains("1"))
+        assertTrue("Expected health provider in summary text, was: $all", all.contains("health"))
 
         job.cancel()
         coroutineContext.cancelChildren()

--- a/notifications/src/test/java/com/rousecontext/notifications/audit/RoomAuditListenerTest.kt
+++ b/notifications/src/test/java/com/rousecontext/notifications/audit/RoomAuditListenerTest.kt
@@ -4,13 +4,8 @@ import com.rousecontext.mcp.core.McpRequestEvent
 import com.rousecontext.mcp.core.ToolCallEvent
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -28,6 +23,7 @@ import org.junit.Test
  *
  * Verifies the listener persists tool call events to the DAO and forwards
  * them to the [PerCallObserver] hook that drives per-tool-call notifications.
+ * Inserts run synchronously from the caller's perspective (see issue #244).
  */
 class RoomAuditListenerTest {
 
@@ -35,18 +31,14 @@ class RoomAuditListenerTest {
     fun `onToolCall persists entry and invokes observer`() = runBlocking {
         val dao = FakeAuditDao()
         val observer = RecordingObserver()
-        val scope = CoroutineScope(coroutineContext + Dispatchers.Unconfined)
         val listener = RoomAuditListener(
             dao = dao,
-            scope = scope,
             fieldEncryptor = null,
             perCallObserver = observer
         )
 
         val event = makeEvent(provider = "health", toolName = "get_steps")
         listener.onToolCall(event)
-
-        withTimeout(TIMEOUT_MS) { observer.signal.await() }
 
         assertEquals("Entry should be inserted", 1, dao.entries.size)
         val entry = dao.entries.first()
@@ -56,15 +48,12 @@ class RoomAuditListenerTest {
         assertNotNull("Observer should be invoked with the event", observer.lastEvent)
         assertEquals("health", observer.lastEvent?.providerId)
         assertEquals("get_steps", observer.lastEvent?.toolName)
-
-        coroutineContext.cancelChildren()
     }
 
     @Test
     fun `onToolCall serializes result as valid JSON with content array`() = runBlocking {
         val dao = FakeAuditDao()
-        val scope = CoroutineScope(coroutineContext + Dispatchers.Unconfined)
-        val listener = RoomAuditListener(dao = dao, scope = scope)
+        val listener = RoomAuditListener(dao = dao)
 
         val event = ToolCallEvent(
             sessionId = "session-1",
@@ -76,7 +65,6 @@ class RoomAuditListenerTest {
             durationMs = 5L
         )
         listener.onToolCall(event)
-        kotlinx.coroutines.yield()
 
         assertEquals(1, dao.entries.size)
         val rawJson = dao.entries.first().resultJson
@@ -94,18 +82,14 @@ class RoomAuditListenerTest {
         // isError should be preserved (default false).
         val isError = parsed["isError"]?.jsonPrimitive?.content?.toBoolean() ?: false
         assertFalse("Default isError should be false", isError)
-
-        coroutineContext.cancelChildren()
     }
 
     @Test
     fun `onToolCall invokes observer for every event`() = runBlocking {
         val dao = FakeAuditDao()
-        val observer = RecordingObserver(expectedCount = 3)
-        val scope = CoroutineScope(coroutineContext + Dispatchers.Unconfined)
+        val observer = RecordingObserver()
         val listener = RoomAuditListener(
             dao = dao,
-            scope = scope,
             fieldEncryptor = null,
             perCallObserver = observer
         )
@@ -114,26 +98,20 @@ class RoomAuditListenerTest {
         listener.onToolCall(makeEvent(provider = "health", toolName = "get_hr"))
         listener.onToolCall(makeEvent(provider = "usage", toolName = "get_app_usage"))
 
-        withTimeout(TIMEOUT_MS) { observer.signal.await() }
-
         assertEquals(3, dao.entries.size)
         assertEquals(3, observer.calls.size)
         assertEquals(
             listOf("get_steps", "get_hr", "get_app_usage"),
             observer.calls.map { it.toolName }
         )
-
-        coroutineContext.cancelChildren()
     }
 
     @Test
     fun `onRequest persists to mcp request dao`() = runBlocking {
         val dao = FakeAuditDao()
         val requestDao = FakeMcpRequestDao()
-        val scope = CoroutineScope(coroutineContext + Dispatchers.Unconfined)
         val listener = RoomAuditListener(
             dao = dao,
-            scope = scope,
             fieldEncryptor = null,
             mcpRequestDao = requestDao
         )
@@ -149,8 +127,6 @@ class RoomAuditListenerTest {
         )
         listener.onRequest(event)
 
-        kotlinx.coroutines.yield()
-
         assertEquals("Request entry should be inserted", 1, requestDao.entries.size)
         val entry = requestDao.entries.first()
         assertEquals("health", entry.provider)
@@ -164,15 +140,12 @@ class RoomAuditListenerTest {
 
         // Tool-call DAO stays empty - onRequest is separate from onToolCall
         assertEquals(0, dao.entries.size)
-
-        coroutineContext.cancelChildren()
     }
 
     @Test
     fun `onRequest is a no-op when mcp request dao is absent`() = runBlocking {
         val dao = FakeAuditDao()
-        val scope = CoroutineScope(coroutineContext + Dispatchers.Unconfined)
-        val listener = RoomAuditListener(dao = dao, scope = scope)
+        val listener = RoomAuditListener(dao = dao)
 
         val event = McpRequestEvent(
             sessionId = "s",
@@ -185,26 +158,18 @@ class RoomAuditListenerTest {
         )
         // Does not throw
         listener.onRequest(event)
-        kotlinx.coroutines.yield()
 
         assertEquals(0, dao.entries.size)
-        coroutineContext.cancelChildren()
     }
 
     @Test
     fun `observer is optional — listener works without one`() = runBlocking {
         val dao = FakeAuditDao()
-        val scope = CoroutineScope(coroutineContext + Dispatchers.Unconfined)
-        val listener = RoomAuditListener(dao = dao, scope = scope)
+        val listener = RoomAuditListener(dao = dao)
 
         listener.onToolCall(makeEvent(provider = "health", toolName = "get_steps"))
 
-        // Let the scope drain.
-        kotlinx.coroutines.yield()
-
         assertEquals(1, dao.entries.size)
-
-        coroutineContext.cancelChildren()
     }
 
     private fun makeEvent(
@@ -221,17 +186,13 @@ class RoomAuditListenerTest {
         durationMs = 5L
     )
 
-    private class RecordingObserver(val expectedCount: Int = 1) : PerCallObserver {
+    private class RecordingObserver : PerCallObserver {
         val calls = mutableListOf<ToolCallEvent>()
         var lastEvent: ToolCallEvent? = null
-        val signal = CompletableDeferred<Unit>()
 
         override suspend fun onToolCallRecorded(event: ToolCallEvent) {
             calls.add(event)
             lastEvent = event
-            if (calls.size >= expectedCount && !signal.isCompleted) {
-                signal.complete(Unit)
-            }
         }
     }
 
@@ -302,9 +263,5 @@ class RoomAuditListenerTest {
 
         override suspend fun deleteOlderThan(cutoffMillis: Long): Int = 0
         override suspend fun count(): Int = entries.size
-    }
-
-    companion object {
-        private const val TIMEOUT_MS = 2_000L
     }
 }


### PR DESCRIPTION
## Summary

- `RoomAuditListener.onToolCall` used `scope.launch` fire-and-forget for the DB insert; `SessionSummaryNotifier` queried the DAO on `ACTIVE -> CONNECTED` stream drain and raced the in-flight insert, losing on fast hardware so no summary notification ever fired.
- Make `AuditListener.onToolCall` and `onRequest` `suspend`. Drop the `scope.launch` wrapper in `RoomAuditListener` so the insert runs on the caller's coroutine; once the listener returns, the row is committed.
- Update call sites in `McpRouting` (already suspend) and anonymous `AuditListener` implementations in tests to suspend overrides.

## Test plan

- [x] `:core:mcp:jvmTest` passes (`McpProtocolTest` covers `onToolCall` / `onRequest` firing).
- [x] `:notifications:testDebugUnitTest` passes; new test `onToolCall insert is visible to summary query before state transition` wires a real `RoomAuditListener` in front of the fake DAO, fires the tool call while ACTIVE, drives `CONNECTED` immediately, and asserts the summary notification is posted with the expected counts. Without the fix this would race; with the fix it is deterministic.
- [x] `:app:testDebugUnitTest` passes (Koin wiring updated to drop unused `scope` param).
- [x] `ktlintCheck` passes.
- Note: `detekt` shows the same 77 pre-existing weighted issues as `main` (none in files touched here).

Fixes #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)