### PR TITLE
Fix #249: TestRelayFixture test-mode admin hooks

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -38,7 +38,11 @@ jobs:
           workspaces: relay
       - name: Build relay binary (for :core:tunnel:integrationTest)
         working-directory: relay
-        run: cargo build
+        # `--features test-mode` compiles in the test-admin surface used by
+        # the `:core:tunnel:integrationTest` fixture (issue #249). The feature
+        # is compile-time excluded from release builds (deploy workflow runs
+        # `cargo build --release` WITHOUT this flag).
+        run: cargo build --features test-mode
       - name: Generate debug keystore
         run: |
           mkdir -p .signing

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/TestRelayAdminSmokeTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/TestRelayAdminSmokeTest.kt
@@ -1,0 +1,187 @@
+package com.rousecontext.tunnel.integration
+
+import com.rousecontext.tunnel.TunnelClientImpl
+import com.rousecontext.tunnel.TunnelState
+import java.io.File
+import java.security.KeyStore
+import java.security.cert.X509Certificate
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+
+/**
+ * Smoke tests for the test-mode admin surface exposed by [TestRelayAdmin]
+ * (see issue #249).
+ *
+ * Coverage:
+ *  - Relay starts cleanly with `--test-mode <port>`.
+ *  - `/test/stats` is reachable and reports zero counters initially.
+ *  - `/test/fcm-wake` captures synthetic wake events.
+ *  - `/test/kill-ws` aborts the active mux WebSocket; the device-side
+ *    `TunnelClient.healthCheck()` detects the drop and returns `false`.
+ *
+ * This test is lightweight by design — deeper coverage of the scenarios
+ * enabled by the admin surface lives in #251 / #252 / #253.
+ */
+@Tag("integration")
+@Timeout(value = 120, unit = TimeUnit.SECONDS)
+class TestRelayAdminSmokeTest {
+
+    companion object {
+        private const val RELAY_HOSTNAME = "localhost"
+        private const val DEVICE_SUBDOMAIN = "smoke-admin"
+
+        /** Accelerated keepalive so we detect the kill within the test window. */
+        private const val KEEPALIVE_INTERVAL_MS = 2_000L
+        private const val KEEPALIVE_TIMEOUT_MS = 1_000L
+        private const val KEEPALIVE_MAX_MISSES = 3
+
+        private const val SESSION_REGISTRATION_DELAY_MS = 500L
+    }
+
+    private lateinit var tempDir: File
+    private lateinit var ca: TestCertificateAuthority
+    private lateinit var relayManager: TestRelayManager
+    private var relayPort: Int = 0
+
+    private val caCert: X509Certificate get() = ca.caCert
+    private val deviceKeyStore: KeyStore get() = ca.deviceKeyStore
+
+    @BeforeEach
+    fun setUp() {
+        val relayBinary = findRelayBinary()
+        assumeTrue(
+            relayBinary.exists() && relayBinary.canExecute(),
+            "Relay binary not found. Build with: cd relay && cargo build --features test-mode"
+        )
+
+        tempDir = File.createTempFile("admin-smoke-", "")
+        tempDir.delete()
+        tempDir.mkdirs()
+
+        ca = TestCertificateAuthority(tempDir, RELAY_HOSTNAME, DEVICE_SUBDOMAIN)
+        ca.generate()
+
+        relayManager = TestRelayManager(
+            tempDir = tempDir,
+            relayHostname = RELAY_HOSTNAME,
+            enableTestMode = true
+        )
+        relayPort = findFreePort()
+        relayManager.start(relayPort)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        if (::relayManager.isInitialized) {
+            relayManager.stop()
+        }
+        if (::tempDir.isInitialized && tempDir.exists()) {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    /**
+     * The admin server answers, initial counters are zero, and the smoke-test
+     * fake-wake hook records entries as expected.
+     *
+     * If the binary was built without `--features test-mode`, the relay
+     * prints a warning and ignores `--test-mode`, the admin readiness poll
+     * fails, and `start()` fails — skip this test in that case.
+     */
+    @Test
+    fun `admin server serves stats and captures synthetic wakes`() {
+        val admin = assertNotNull(
+            relayManager.admin,
+            "test-mode admin should be live when enableTestMode = true"
+        )
+
+        val initial = admin.stats()
+        assertEquals(0, initial.registerCalls)
+        assertEquals(0, initial.renewCalls)
+        assertEquals(0, initial.rotateSecretCalls)
+
+        relayManager.sendFcmWake("alpha")
+        relayManager.sendFcmWake("beta")
+
+        val captured = admin.capturedWakes()
+        assertTrue(
+            captured.containsAll(listOf("alpha", "beta")),
+            "captured wakes should include both subdomains, got=$captured"
+        )
+    }
+
+    /**
+     * After a tunnel is established and `killActiveWebsocket()` is invoked,
+     * `TunnelClient.healthCheck()` must return `false` — the transport is dead
+     * and the next ping exchange will time out. This is the #243 regression
+     * guard that scenario tests (#253) will build on.
+     */
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun `killActiveWebsocket drives healthCheck false within 5s`() = runBlocking {
+        val tunnelClient = connectTunnelClient()
+
+        try {
+            assertEquals(
+                TunnelState.CONNECTED,
+                tunnelClient.state.value,
+                "Tunnel should be CONNECTED before kill"
+            )
+
+            val killed = relayManager.killActiveWebsocket(DEVICE_SUBDOMAIN)
+            assertTrue(killed, "relay should have had a live session to kill")
+
+            // Within ~5s the keepalive should drive healthCheck to false.
+            // We poll so transient retries don't flake the assertion.
+            val healthy = withTimeoutOrNull(8.seconds) {
+                while (tunnelClient.healthCheck(5.seconds)) {
+                    delay(200)
+                }
+                false
+            }
+            assertFalse(
+                healthy ?: true,
+                "healthCheck should return false after relay-side kill"
+            )
+
+            // Final state should reflect disconnect (or actively disconnecting).
+            val state = withTimeoutOrNull(10_000) {
+                tunnelClient.state.first { it == TunnelState.DISCONNECTED }
+            }
+            assertEquals(TunnelState.DISCONNECTED, state)
+        } finally {
+            runCatching { tunnelClient.disconnect() }
+        }
+    }
+
+    private suspend fun connectTunnelClient(): TunnelClientImpl {
+        val sslContext = TestSslContexts.buildMtls(deviceKeyStore, caCert)
+        val wsFactory = MtlsWebSocketFactory(sslContext)
+        val client = TunnelClientImpl(
+            scope = CoroutineScope(Dispatchers.IO),
+            webSocketFactory = wsFactory,
+            keepaliveIntervalMillis = KEEPALIVE_INTERVAL_MS,
+            keepaliveTimeoutMillis = KEEPALIVE_TIMEOUT_MS,
+            keepaliveMaxMisses = KEEPALIVE_MAX_MISSES
+        )
+        client.connect("wss://$RELAY_HOSTNAME:$relayPort/ws")
+        delay(SESSION_REGISTRATION_DELAY_MS)
+        return client
+    }
+}

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/TestRelayFixture.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/TestRelayFixture.kt
@@ -1,6 +1,9 @@
 package com.rousecontext.tunnel.integration
 
 import java.io.File
+import java.net.HttpURLConnection
+import java.net.URI
+import java.net.URL
 import java.security.KeyStore
 import java.security.cert.X509Certificate
 import java.util.concurrent.TimeUnit
@@ -331,9 +334,26 @@ class TestRelayManager(
      * convention (e.g. when tests use a non-literal local hostname so SNI
      * isn't suppressed).
      */
-    private val baseDomainOverride: String? = null
+    private val baseDomainOverride: String? = null,
+    /**
+     * When `true`, start the relay with `--test-mode <port>` so the test-admin
+     * HTTP surface (see [TestRelayAdmin]) is available for killing WebSockets,
+     * recording synthetic FCM wakes, and reading per-endpoint counters.
+     *
+     * Requires the relay binary to have been built with the `test-mode` Cargo
+     * feature. CI's `android-ci.yml` passes `--features test-mode` in the
+     * `cargo build` step for that reason. See issue #249.
+     */
+    private val enableTestMode: Boolean = false
 ) {
     var process: Process? = null
+        private set
+
+    /**
+     * Admin client for the test-mode HTTP surface, or `null` when test-mode
+     * was disabled at construction. Populated by [start].
+     */
+    var admin: TestRelayAdmin? = null
         private set
 
     /**
@@ -342,21 +362,98 @@ class TestRelayManager(
      */
     fun start(port: Int): Process {
         writeRelayConfig(port)
-        val relay = startRelay(port)
+        val adminPort = if (enableTestMode) findFreePort() else null
+        val relay = startRelay(port, adminPort)
         process = relay
+        if (adminPort != null) {
+            admin = TestRelayAdmin(adminPort)
+            admin?.waitUntilReady()
+        }
         return relay
     }
 
+    /**
+     * Gracefully stop the relay subprocess with a kill -9 fallback.
+     *
+     * We hit zombie subprocess issues in #223 when a parent holding the
+     * `Process` exited before the child actually died. The sequence is:
+     *   1. `destroy()` — SIGTERM; allow graceful shutdown
+     *   2. wait up to 3s
+     *   3. `destroyForcibly()` — SIGKILL; always succeeds on POSIX
+     *   4. wait up to 3s — on rare kernel/fs stalls this is the last line
+     *      of defense before we leak the handle
+     */
     fun stop() {
-        process?.let {
-            it.destroyForcibly()
-            it.waitFor(5, TimeUnit.SECONDS)
+        process?.let { p ->
+            // Phase 1: gentle SIGTERM.
+            p.destroy()
+            if (!p.waitFor(3, TimeUnit.SECONDS)) {
+                // Phase 2: SIGKILL-equivalent.
+                p.destroyForcibly()
+                if (!p.waitFor(3, TimeUnit.SECONDS)) {
+                    System.err.println(
+                        "TestRelayManager: relay subprocess (pid=${runCatching {
+                            p.pid()
+                        }.getOrDefault(-1)}) " +
+                            "did not exit after destroyForcibly(); leaking handle"
+                    )
+                }
+            }
         }
         process = null
+        admin = null
     }
 
     /** Snapshot of the relay subprocess's captured stdout/stderr so far. */
     fun capturedOutput(): String = synchronized(capturedStdout) { capturedStdout.toString() }
+
+    /**
+     * Drop the active mux WebSocket for [subdomain] on the relay side without
+     * sending a close frame. Simulates a relay-side crash or network drop; the
+     * device-side half-open detector should fire via ping timeout.
+     *
+     * Requires [enableTestMode] = true. Throws if test-mode is disabled.
+     *
+     * Returns `true` if a live session existed and was killed, `false` if no
+     * session was registered.
+     */
+    fun killActiveWebsocket(subdomain: String): Boolean =
+        requireAdmin().killActiveWebsocket(subdomain)
+
+    /**
+     * Record a synthetic FCM wake for [subdomain] on the relay. This does NOT
+     * actually wake a device — it populates the relay-side test metrics so
+     * assertions in integration tests can confirm a wake was requested. The
+     * app-wired harness (#250) is responsible for injecting the wake into the
+     * device-side FCM receiver.
+     *
+     * Requires [enableTestMode] = true.
+     */
+    fun sendFcmWake(subdomain: String) {
+        requireAdmin().sendFcmWake(subdomain)
+    }
+
+    /** Count of `/register/certs` calls observed by the relay. */
+    fun registerCertsCalls(): Int = requireAdmin().registerCertsCalls()
+
+    /** Count of `/rotate-secret` calls observed by the relay. */
+    fun rotateSecretCalls(): Int = requireAdmin().rotateSecretCalls()
+
+    /** Count of `/renew` calls observed by the relay. */
+    fun renewCalls(): Int = requireAdmin().renewCalls()
+
+    /**
+     * Whether the most recent request to [endpoint] (e.g. `"/renew"`) carried
+     * a valid mTLS client certificate. Returns `null` if no request to that
+     * endpoint has been observed yet.
+     */
+    fun lastRequestHadClientCert(endpoint: String): Boolean? =
+        requireAdmin().lastRequestHadClientCert(endpoint)
+
+    private fun requireAdmin(): TestRelayAdmin = admin ?: fail(
+        "TestRelayManager: test-mode admin not available — " +
+            "construct with enableTestMode = true"
+    )
 
     private val capturedStdout = StringBuilder()
 
@@ -412,10 +509,14 @@ class TestRelayManager(
         File(tempDir, "relay.toml").writeText(config)
     }
 
-    private fun startRelay(port: Int): Process {
+    private fun startRelay(port: Int, testAdminPort: Int? = null): Process {
         val relayBinary = findRelayBinary()
         val configPath = File(tempDir, "relay.toml").absolutePath
-        val pb = ProcessBuilder(relayBinary.absolutePath, configPath)
+        val cmd = mutableListOf(relayBinary.absolutePath, configPath)
+        if (testAdminPort != null) {
+            cmd += listOf("--test-mode", testAdminPort.toString())
+        }
+        val pb = ProcessBuilder(cmd)
             .redirectErrorStream(true)
         pb.environment()["RUST_LOG"] = "debug"
 
@@ -462,6 +563,202 @@ class TestRelayManager(
 
     companion object {
         private const val RELAY_STARTUP_TIMEOUT_MS = 10_000L
+    }
+}
+
+/**
+ * Thin HTTP client against the relay's test-mode admin surface.
+ *
+ * The relay exposes these endpoints on a separate plain-HTTP listener bound to
+ * `127.0.0.1:<port>` when launched with `--test-mode <port>` (requires the
+ * `test-mode` Cargo feature). See `relay/src/test_mode.rs` for the server-side
+ * handlers.
+ *
+ * This client is intentionally tiny — no OkHttp, no serialisation library,
+ * just JDK URLConnection + naive JSON parsing — so it can be used without
+ * adding test dependencies and won't interact with the OkHttp MockWebServer
+ * instances that integration tests set up.
+ *
+ * Fixture lifetime mirrors the relay subprocess: created in [TestRelayManager.start],
+ * cleared in [TestRelayManager.stop].
+ *
+ * Issue #249.
+ */
+@Suppress("TooManyFunctions")
+class TestRelayAdmin(private val port: Int) {
+    private val baseUrl = "http://127.0.0.1:$port"
+
+    /**
+     * Poll `/test/stats` until the admin server answers (or a short deadline
+     * elapses). Called by [TestRelayManager.start] so fixture code can assume
+     * the admin is ready as soon as `start()` returns.
+     */
+    fun waitUntilReady(deadlineMs: Long = 5_000) {
+        val deadline = System.currentTimeMillis() + deadlineMs
+        var lastErr: Exception? = null
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                stats()
+                return
+            } catch (e: Exception) {
+                lastErr = e
+                Thread.sleep(READY_POLL_MS)
+            }
+        }
+        fail("test-mode admin did not become ready within ${deadlineMs}ms: $lastErr")
+    }
+
+    /**
+     * Abort the active mux WebSocket for [subdomain] without sending a close
+     * frame. The device-side ping loop should notice the dead socket within
+     * one ping interval.
+     *
+     * Returns `true` if the relay had a live session to kill, `false` if no
+     * session was registered for that subdomain.
+     */
+    fun killActiveWebsocket(subdomain: String): Boolean {
+        val body = post("/test/kill-ws?subdomain=${subdomain.urlEncoded()}", "")
+        return parseBoolField(body, "killed")
+    }
+
+    /**
+     * Record a synthetic FCM wake for [subdomain]. The relay accumulates the
+     * call in its test metrics; callers that need to actually invoke the
+     * device-side FCM receiver must supply their own `onWake` callback (this
+     * hook just tells the relay-side fake that a wake was requested so
+     * [stats] assertions see it).
+     */
+    fun sendFcmWake(subdomain: String) {
+        post("/test/fcm-wake?subdomain=${subdomain.urlEncoded()}", "")
+    }
+
+    /** Number of `/register` calls observed since the relay started. */
+    fun registerCalls(): Int = parseIntField(statsRaw(), "register_calls")
+
+    /** Number of `/register/certs` calls observed since the relay started. */
+    fun registerCertsCalls(): Int = parseIntField(statsRaw(), "register_certs_calls")
+
+    /** Number of `/rotate-secret` calls observed since the relay started. */
+    fun rotateSecretCalls(): Int = parseIntField(statsRaw(), "rotate_secret_calls")
+
+    /** Number of `/renew` calls observed since the relay started. */
+    fun renewCalls(): Int = parseIntField(statsRaw(), "renew_calls")
+
+    /** Number of `/ws` upgrade requests observed since the relay started. */
+    fun wsCalls(): Int = parseIntField(statsRaw(), "ws_calls")
+
+    /**
+     * Whether the most recent request to [endpoint] (e.g. `"/renew"`) carried
+     * a valid mTLS client certificate. Returns `null` if no such request has
+     * been observed.
+     */
+    fun lastRequestHadClientCert(endpoint: String): Boolean? {
+        val body = statsRaw()
+        val marker = "\"$endpoint\":"
+        val idx = body.indexOf(marker)
+        if (idx < 0) return null
+        val after = body.substring(idx + marker.length).trimStart()
+        return when {
+            after.startsWith("true") -> true
+            after.startsWith("false") -> false
+            else -> null
+        }
+    }
+
+    /** Subdomains captured by synthetic `/test/fcm-wake` calls, in arrival order. */
+    fun capturedWakes(): List<String> {
+        val body = statsRaw()
+        val marker = "\"captured_wakes\":"
+        val idx = body.indexOf(marker)
+        if (idx < 0) return emptyList()
+        val open = body.indexOf('[', idx)
+        val close = body.indexOf(']', open)
+        if (open < 0 || close < 0) return emptyList()
+        val inner = body.substring(open + 1, close).trim()
+        if (inner.isEmpty()) return emptyList()
+        return inner.split(",").map { it.trim().trim('"') }.filter { it.isNotEmpty() }
+    }
+
+    /** Structured stats snapshot. */
+    data class Stats(
+        val registerCalls: Int,
+        val registerCertsCalls: Int,
+        val rotateSecretCalls: Int,
+        val renewCalls: Int,
+        val wsCalls: Int
+    )
+
+    /** Convenience accessor that returns a typed snapshot. */
+    fun stats(): Stats {
+        val body = statsRaw()
+        return Stats(
+            registerCalls = parseIntField(body, "register_calls"),
+            registerCertsCalls = parseIntField(body, "register_certs_calls"),
+            rotateSecretCalls = parseIntField(body, "rotate_secret_calls"),
+            renewCalls = parseIntField(body, "renew_calls"),
+            wsCalls = parseIntField(body, "ws_calls")
+        )
+    }
+
+    private fun statsRaw(): String = get("/test/stats")
+
+    private fun get(path: String): String {
+        val conn = openConnection(path).apply {
+            requestMethod = "GET"
+        }
+        return readBody(conn)
+    }
+
+    private fun post(path: String, body: String): String {
+        val conn = openConnection(path).apply {
+            requestMethod = "POST"
+            doOutput = true
+        }
+        conn.outputStream.use { it.write(body.toByteArray()) }
+        return readBody(conn)
+    }
+
+    private fun openConnection(path: String): HttpURLConnection {
+        val url: URL = URI.create(baseUrl + path).toURL()
+        return (url.openConnection() as HttpURLConnection).apply {
+            connectTimeout = HTTP_TIMEOUT_MS
+            readTimeout = HTTP_TIMEOUT_MS
+        }
+    }
+
+    private fun readBody(conn: HttpURLConnection): String {
+        val code = conn.responseCode
+        val stream = if (code in 200..299) conn.inputStream else conn.errorStream
+        val body = stream?.bufferedReader()?.use { it.readText() }.orEmpty()
+        if (code !in 200..299) {
+            fail("test-mode admin returned HTTP $code: $body")
+        }
+        return body
+    }
+
+    private fun String.urlEncoded(): String = java.net.URLEncoder.encode(this, "UTF-8")
+
+    private fun parseIntField(json: String, key: String): Int {
+        val marker = "\"$key\":"
+        val idx = json.indexOf(marker)
+        if (idx < 0) fail("stats JSON missing field '$key': $json")
+        val after = json.substring(idx + marker.length).trimStart()
+        val end = after.indexOfAny(charArrayOf(',', '}', ' ', '\n', '\r'))
+        val numStr = if (end < 0) after else after.substring(0, end)
+        return numStr.trim().toInt()
+    }
+
+    private fun parseBoolField(json: String, key: String): Boolean {
+        val marker = "\"$key\":"
+        val idx = json.indexOf(marker)
+        if (idx < 0) fail("JSON missing field '$key': $json")
+        val after = json.substring(idx + marker.length).trimStart()
+        return after.startsWith("true")
+    }
+
+    companion object {
+        private const val HTTP_TIMEOUT_MS = 3_000
+        private const val READY_POLL_MS = 50L
     }
 }
 

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -3,6 +3,17 @@ name = "rouse-relay"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+# Compile-time opt-in for test-mode admin endpoints and instrumentation.
+# When enabled, the relay exposes a separate HTTP admin port (configured via
+# `--test-mode <port>` or `TEST_MODE_PORT=<port>`) for integration tests:
+#   - POST /test/kill-ws?subdomain=X   drop the active mux for the device
+#   - POST /test/fcm-wake?subdomain=X  record a synthetic FCM wake
+#   - GET  /test/stats                 per-endpoint request counters
+# This feature MUST NOT be enabled in release builds — it bypasses auth on
+# the admin port and exposes internal state. See issue #249.
+test-mode = []
+
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 rustls = { version = "0.23", features = ["ring"] }

--- a/relay/src/api/mod.rs
+++ b/relay/src/api/mod.rs
@@ -186,6 +186,13 @@ pub struct AppState {
     pub request_subdomain_rate_limiter: crate::rate_limit::RateLimiter,
     pub config: crate::config::RelayConfig,
     pub device_ca: Option<crate::device_ca::DeviceCa>,
+    /// Optional test-mode instrumentation. `None` in production. When `Some`,
+    /// every HTTP request that flows through the relay API router is counted
+    /// in the shared metrics store (see `test_mode::record_api_request`).
+    /// Only populated when the binary is built with `--features test-mode`
+    /// and launched with `--test-mode <port>`.
+    #[cfg(feature = "test-mode")]
+    pub test_metrics: Option<std::sync::Arc<crate::test_mode::TestMetrics>>,
 }
 
 /// Tower middleware that rejects requests without a `DeviceIdentity`
@@ -249,5 +256,20 @@ pub fn build_router(state: std::sync::Arc<AppState>) -> axum::Router {
         .route("/ws", axum::routing::get(ws::handle_ws))
         .layer(axum::middleware::from_fn(require_device_identity));
 
-    public_router.merge(authed_router).with_state(state)
+    let merged = public_router.merge(authed_router).with_state(state.clone());
+
+    // In test-mode, wrap every request with the instrumentation middleware
+    // that records call counts + client-cert presence. In release builds
+    // (feature disabled) this branch is compiled out entirely.
+    #[cfg(feature = "test-mode")]
+    let merged = if let Some(metrics) = state.test_metrics.clone() {
+        merged.layer(axum::middleware::from_fn_with_state(
+            metrics,
+            crate::test_mode::record_api_request,
+        ))
+    } else {
+        merged
+    };
+
+    merged
 }

--- a/relay/src/api/ws.rs
+++ b/relay/src/api/ws.rs
@@ -152,11 +152,23 @@ async fn handle_mux_session(socket: WebSocket, params: SessionParams) {
     // Channel for passthrough code to request new streams
     let (open_stream_tx, mut open_stream_rx) = mpsc::channel::<OpenStreamRequest>(16);
 
+    // Channel for test-mode admin to abort this ws session without sending a
+    // close frame. Capacity 1 since one kill is sufficient; extra triggers are
+    // coalesced via try_send. In production this sender is never fired.
+    //
+    // We keep `_kill_tx_keepalive` as a local clone so that the receiver side
+    // never sees `None` when the SessionEntry is replaced (e.g. a second
+    // connection for the same subdomain evicts the first). Without this, the
+    // `kill_rx.recv()` branch in the session select below would fire on
+    // entry-replacement and incorrectly abort the surviving session.
+    let (kill_tx, mut kill_rx) = mpsc::channel::<()>(1);
+    let _kill_tx_keepalive = kill_tx.clone();
+
     // Register the session so passthrough can find it.
     // Order matters: insert into registry FIRST so try_open_stream() works,
     // THEN signal waiters via register_mux_connection(). Otherwise, FCM
     // waiters wake up but find no session entry and get StreamRefused.
-    session_registry.insert(&subdomain, open_stream_tx);
+    session_registry.insert(&subdomain, open_stream_tx, kill_tx);
     relay_state.register_mux_connection(&subdomain);
 
     info!(subdomain = %subdomain, "Mux session registered");
@@ -264,13 +276,36 @@ async fn handle_mux_session(socket: WebSocket, params: SessionParams) {
     //
     // We use select! to handle both in the same task, which owns the MuxSession
     // without needing a mutex.
-    run_session_loop(&mut session, incoming_rx, &mut open_stream_rx, &relay_state).await;
+    //
+    // If `kill_rx` receives an explicit kill message (test-mode admin invoked
+    // `POST /test/kill-ws`), abort the read/write tasks so the WebSocket
+    // sockets are dropped mid-frame. `_kill_tx_keepalive` above ensures the
+    // receiver never observes `None` from a dropped sender, so the only way
+    // we enter this branch with `Some(())` is an explicit kill.
+    tokio::select! {
+        _ = run_session_loop(
+            &mut session,
+            incoming_rx,
+            &mut open_stream_rx,
+            &relay_state,
+        ) => {}
+        kill_signal = kill_rx.recv() => {
+            if kill_signal.is_some() {
+                warn!(
+                    subdomain = %subdomain,
+                    "test-mode: killing ws session without close frame"
+                );
+                read_task.abort();
+                write_task.abort();
+            }
+        }
+    }
 
     // Clean up
     session_registry.remove(&subdomain);
     relay_state.remove_mux_connection(&subdomain);
 
-    // Wait for read/write tasks to finish
+    // Wait for read/write tasks to finish (abort() causes them to return Err)
     let _ = read_task.await;
     let _ = write_task.await;
 
@@ -582,6 +617,8 @@ mod tests {
             ),
             config: RelayConfig::default(),
             device_ca: None,
+            #[cfg(feature = "test-mode")]
+            test_metrics: None,
         })
     }
 
@@ -689,6 +726,8 @@ mod tests {
             ),
             config,
             device_ca: None,
+            #[cfg(feature = "test-mode")]
+            test_metrics: None,
         })
     }
 

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -19,5 +19,7 @@ pub mod shutdown;
 pub mod sni;
 pub mod state;
 pub mod subdomain;
+#[cfg(feature = "test-mode")]
+pub mod test_mode;
 pub mod tls;
 pub mod words;

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -1049,12 +1049,8 @@ async fn start_test_admin_if_enabled(
 ) -> Option<Arc<rouse_relay::test_mode::TestMetrics>> {
     let port = port?;
     let metrics = Arc::new(rouse_relay::test_mode::TestMetrics::new());
-    if let Err(e) = rouse_relay::test_mode::spawn_admin_server(
-        port,
-        metrics.clone(),
-        session_registry,
-    )
-    .await
+    if let Err(e) =
+        rouse_relay::test_mode::spawn_admin_server(port, metrics.clone(), session_registry).await
     {
         error!(port, "Failed to start test-mode admin server: {e}");
         std::process::exit(1);

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -39,9 +39,13 @@ async fn main() {
         )
         .init();
 
-    let config_path = std::env::args()
-        .nth(1)
-        .unwrap_or_else(|| "relay.toml".to_string());
+    // Parse CLI args. Layout is positional:
+    //   rouse-relay [config_path] [--test-mode <port>]
+    // The `--test-mode` flag is only recognised when the binary was built with
+    // the `test-mode` feature; in release builds the flag is silently ignored
+    // (and warned about) so a misconfigured systemd unit can't accidentally
+    // enable the admin surface.
+    let (config_path, test_admin_port) = parse_cli_args();
 
     let config = if Path::new(&config_path).exists() {
         match RelayConfig::from_file_with_env(Path::new(&config_path)) {
@@ -124,6 +128,11 @@ async fn main() {
     ));
     let session_registry = Arc::new(SessionRegistry::new());
 
+    // Start the test-mode admin server (no-op unless the binary was built
+    // with `--features test-mode` AND --test-mode <port> was passed).
+    let _test_metrics =
+        start_test_admin_if_enabled(test_admin_port, session_registry.clone()).await;
+
     // Build external service clients — use real implementations when a service account is available
     let firestore: Arc<dyn rouse_relay::firestore::FirestoreClient> =
         build_firestore_client(&config);
@@ -158,6 +167,8 @@ async fn main() {
         ),
         config: config.clone(),
         device_ca,
+        #[cfg(feature = "test-mode")]
+        test_metrics: _test_metrics.clone(),
     });
 
     // Shutdown controller
@@ -972,4 +983,99 @@ fn stable_uid_hash(token: &str) -> String {
     let mut hasher = DefaultHasher::new();
     token.hash(&mut hasher);
     format!("{:016x}", hasher.finish())
+}
+
+/// Parse CLI args into `(config_path, test_admin_port)`. See issue #249.
+fn parse_cli_args() -> (String, Option<u16>) {
+    let mut config_path = "relay.toml".to_string();
+    let mut test_admin_port: Option<u16> = None;
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut i = 0;
+    let mut config_set = false;
+    while i < args.len() {
+        let arg = &args[i];
+        if arg == "--test-mode" {
+            // Accept `--test-mode <port>` or `--test-mode=<port>`. We
+            // deliberately do NOT error on unknown flags after this for
+            // forward-compat.
+            let port_str = args.get(i + 1).cloned();
+            match port_str.as_deref().and_then(|s| s.parse::<u16>().ok()) {
+                Some(port) => {
+                    test_admin_port = Some(port);
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    error!("--test-mode requires a port number argument");
+                    std::process::exit(2);
+                }
+            }
+        }
+        if let Some(value) = arg.strip_prefix("--test-mode=") {
+            match value.parse::<u16>() {
+                Ok(port) => test_admin_port = Some(port),
+                Err(_) => {
+                    error!("--test-mode=<port> could not be parsed");
+                    std::process::exit(2);
+                }
+            }
+            i += 1;
+            continue;
+        }
+        if !arg.starts_with("--") && !config_set {
+            config_path = arg.clone();
+            config_set = true;
+        }
+        i += 1;
+    }
+
+    // Env-var fallback so CI can pass TEST_MODE_PORT without touching argv.
+    if test_admin_port.is_none() {
+        if let Ok(v) = std::env::var("TEST_MODE_PORT") {
+            if let Ok(port) = v.parse::<u16>() {
+                test_admin_port = Some(port);
+            }
+        }
+    }
+
+    (config_path, test_admin_port)
+}
+
+#[cfg(feature = "test-mode")]
+async fn start_test_admin_if_enabled(
+    port: Option<u16>,
+    session_registry: Arc<SessionRegistry>,
+) -> Option<Arc<rouse_relay::test_mode::TestMetrics>> {
+    let port = port?;
+    let metrics = Arc::new(rouse_relay::test_mode::TestMetrics::new());
+    if let Err(e) = rouse_relay::test_mode::spawn_admin_server(
+        port,
+        metrics.clone(),
+        session_registry,
+    )
+    .await
+    {
+        error!(port, "Failed to start test-mode admin server: {e}");
+        std::process::exit(1);
+    }
+    warn!(
+        port,
+        "test-mode admin server started — DO NOT ENABLE IN PRODUCTION"
+    );
+    Some(metrics)
+}
+
+#[cfg(not(feature = "test-mode"))]
+async fn start_test_admin_if_enabled(
+    port: Option<u16>,
+    _session_registry: Arc<SessionRegistry>,
+) -> Option<()> {
+    if port.is_some() {
+        warn!(
+            "--test-mode / TEST_MODE_PORT set but binary built without the \
+             `test-mode` feature; ignoring"
+        );
+    }
+    None
 }

--- a/relay/src/passthrough.rs
+++ b/relay/src/passthrough.rs
@@ -72,6 +72,11 @@ pub struct OpenStreamRequest {
 /// Contains a channel sender for requesting stream opens from the session owner.
 pub struct SessionEntry {
     pub open_stream_tx: mpsc::Sender<OpenStreamRequest>,
+    /// Signals the ws mux task to abort immediately without sending a close
+    /// frame. Used by the test-mode admin endpoint `POST /test/kill-ws` to
+    /// simulate a relay-side network drop (see issue #249). In production the
+    /// sender is never fired; the channel sits idle.
+    pub kill_tx: mpsc::Sender<()>,
 }
 
 /// Registry of active mux sessions, keyed by subdomain.
@@ -95,9 +100,34 @@ impl SessionRegistry {
     }
 
     /// Register a mux session for a subdomain.
-    pub fn insert(&self, subdomain: &str, open_stream_tx: mpsc::Sender<OpenStreamRequest>) {
-        self.sessions
-            .insert(subdomain.to_string(), SessionEntry { open_stream_tx });
+    pub fn insert(
+        &self,
+        subdomain: &str,
+        open_stream_tx: mpsc::Sender<OpenStreamRequest>,
+        kill_tx: mpsc::Sender<()>,
+    ) {
+        self.sessions.insert(
+            subdomain.to_string(),
+            SessionEntry {
+                open_stream_tx,
+                kill_tx,
+            },
+        );
+    }
+
+    /// Signal the mux session for `subdomain` to abort without sending a close
+    /// frame. Returns `true` if a session existed and was signaled. Test-only.
+    pub fn kill(&self, subdomain: &str) -> bool {
+        match self.sessions.get(subdomain) {
+            Some(entry) => {
+                // `try_send` is used because `kill_tx` has capacity 1 and the
+                // ws task drains it immediately on receipt. If it's already
+                // full, the kill is already pending.
+                let _ = entry.kill_tx.try_send(());
+                true
+            }
+            None => false,
+        }
     }
 
     /// Remove a mux session.

--- a/relay/src/test_mode.rs
+++ b/relay/src/test_mode.rs
@@ -183,7 +183,11 @@ pub async fn handle_stats(State(state): State<AdminState>) -> Response {
             .lock()
             .map(|g| g.clone())
             .unwrap_or_default(),
-        captured_wakes: m.captured_wakes.lock().map(|g| g.clone()).unwrap_or_default(),
+        captured_wakes: m
+            .captured_wakes
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_default(),
     };
     (StatusCode::OK, Json(snapshot)).into_response()
 }

--- a/relay/src/test_mode.rs
+++ b/relay/src/test_mode.rs
@@ -1,0 +1,224 @@
+//! Test-mode admin HTTP server + instrumentation.
+//!
+//! Compiled under `#[cfg(feature = "test-mode")]` so it is excluded from
+//! release builds. When the `--test-mode <port>` CLI flag (or `TEST_MODE_PORT`
+//! env var) is set, the relay binds a second, unauthenticated HTTP listener
+//! on `127.0.0.1:<port>` that exposes hooks the integration-test fixture in
+//! `core/tunnel/src/jvmTest/...` uses to drive failure scenarios:
+//!
+//! - `POST /test/kill-ws?subdomain=<sub>` — abort the active mux WebSocket
+//!   for a device without sending a close frame. Simulates relay-side crash
+//!   or network drop so the device-side half-open detector fires.
+//! - `POST /test/fcm-wake?subdomain=<sub>` — record a synthetic FCM wake in
+//!   the in-memory fake. The test harness reads this via `/test/stats`.
+//! - `GET  /test/stats` — per-endpoint request counters + synthetic-wake log.
+//!
+//! See issue #249 for the motivating scenarios (#247 integration tier).
+//!
+//! # Security
+//!
+//! This admin server has zero authentication. It MUST NEVER be enabled in a
+//! release build. The `test-mode` feature guard is the compile-time barrier;
+//! the `--test-mode` CLI flag is the runtime barrier.
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use tokio::net::TcpListener;
+use tracing::{info, warn};
+
+use crate::passthrough::SessionRegistry;
+
+/// Per-endpoint request counters and captured synthetic wake events.
+///
+/// Populated by:
+/// - `record_api_request` middleware for each inbound relay-API request
+/// - `/test/fcm-wake` admin handler
+///
+/// Read back via `/test/stats`.
+#[derive(Default)]
+pub struct TestMetrics {
+    pub register_calls: AtomicU64,
+    pub register_certs_calls: AtomicU64,
+    pub rotate_secret_calls: AtomicU64,
+    pub renew_calls: AtomicU64,
+    pub ws_calls: AtomicU64,
+    /// Last-seen client-cert presence flag per endpoint path.
+    /// Indexed by normalised path (e.g. "/renew"). `true` means the request
+    /// carried a `DeviceIdentity` extension (mTLS client cert validated).
+    pub last_client_cert_seen: Mutex<std::collections::HashMap<String, bool>>,
+    /// Synthetic FCM wake events captured via `POST /test/fcm-wake`.
+    pub captured_wakes: Mutex<Vec<String>>,
+}
+
+impl TestMetrics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record_endpoint(&self, path: &str, had_client_cert: bool) {
+        match path {
+            "/register" => {
+                self.register_calls.fetch_add(1, Ordering::Relaxed);
+            }
+            "/register/certs" => {
+                self.register_certs_calls.fetch_add(1, Ordering::Relaxed);
+            }
+            "/rotate-secret" => {
+                self.rotate_secret_calls.fetch_add(1, Ordering::Relaxed);
+            }
+            "/renew" => {
+                self.renew_calls.fetch_add(1, Ordering::Relaxed);
+            }
+            "/ws" => {
+                self.ws_calls.fetch_add(1, Ordering::Relaxed);
+            }
+            _ => {}
+        }
+        if let Ok(mut map) = self.last_client_cert_seen.lock() {
+            map.insert(path.to_string(), had_client_cert);
+        }
+    }
+}
+
+/// Axum middleware that records each request's path + mTLS identity presence
+/// into the shared `TestMetrics`. Attached via
+/// `axum::middleware::from_fn_with_state(metrics, record_api_request)` so the
+/// non-test-mode router has zero overhead (it never inserts this layer).
+pub async fn record_api_request(
+    State(metrics): State<Arc<TestMetrics>>,
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> Response {
+    let path = req.uri().path().to_string();
+    let has_ident = req
+        .extensions()
+        .get::<crate::api::ws::DeviceIdentity>()
+        .is_some();
+    metrics.record_endpoint(&path, has_ident);
+    next.run(req).await
+}
+
+#[derive(Clone)]
+pub struct AdminState {
+    pub metrics: Arc<TestMetrics>,
+    pub session_registry: Arc<SessionRegistry>,
+}
+
+#[derive(Deserialize)]
+pub struct SubdomainQuery {
+    subdomain: String,
+}
+
+#[derive(Serialize)]
+pub struct KillResponse {
+    killed: bool,
+    subdomain: String,
+}
+
+pub async fn handle_kill_ws(
+    State(state): State<AdminState>,
+    Query(q): Query<SubdomainQuery>,
+) -> Response {
+    let killed = state.session_registry.kill(&q.subdomain);
+    warn!(
+        subdomain = %q.subdomain,
+        killed,
+        "test-mode: kill-ws triggered"
+    );
+    (
+        StatusCode::OK,
+        Json(KillResponse {
+            killed,
+            subdomain: q.subdomain,
+        }),
+    )
+        .into_response()
+}
+
+#[derive(Serialize)]
+pub struct WakeResponse {
+    captured: usize,
+}
+
+pub async fn handle_fcm_wake(
+    State(state): State<AdminState>,
+    Query(q): Query<SubdomainQuery>,
+) -> Response {
+    let captured = {
+        let mut guard = state.metrics.captured_wakes.lock().unwrap();
+        guard.push(q.subdomain.clone());
+        guard.len()
+    };
+    info!(subdomain = %q.subdomain, "test-mode: synthetic FCM wake captured");
+    (StatusCode::OK, Json(WakeResponse { captured })).into_response()
+}
+
+#[derive(Serialize)]
+pub struct StatsResponse {
+    pub register_calls: u64,
+    pub register_certs_calls: u64,
+    pub rotate_secret_calls: u64,
+    pub renew_calls: u64,
+    pub ws_calls: u64,
+    pub last_client_cert_seen: std::collections::HashMap<String, bool>,
+    pub captured_wakes: Vec<String>,
+}
+
+pub async fn handle_stats(State(state): State<AdminState>) -> Response {
+    let m = &state.metrics;
+    let snapshot = StatsResponse {
+        register_calls: m.register_calls.load(Ordering::Relaxed),
+        register_certs_calls: m.register_certs_calls.load(Ordering::Relaxed),
+        rotate_secret_calls: m.rotate_secret_calls.load(Ordering::Relaxed),
+        renew_calls: m.renew_calls.load(Ordering::Relaxed),
+        ws_calls: m.ws_calls.load(Ordering::Relaxed),
+        last_client_cert_seen: m
+            .last_client_cert_seen
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_default(),
+        captured_wakes: m.captured_wakes.lock().map(|g| g.clone()).unwrap_or_default(),
+    };
+    (StatusCode::OK, Json(snapshot)).into_response()
+}
+
+pub fn build_admin_router(admin_state: AdminState) -> axum::Router {
+    axum::Router::new()
+        .route("/test/kill-ws", axum::routing::post(handle_kill_ws))
+        .route("/test/fcm-wake", axum::routing::post(handle_fcm_wake))
+        .route("/test/stats", axum::routing::get(handle_stats))
+        .with_state(admin_state)
+}
+
+/// Bind a plain-HTTP admin listener on `127.0.0.1:<port>`. Spawned as a
+/// detached tokio task. Intentionally does not participate in graceful
+/// shutdown: the relay subprocess is SIGKILL'd by the test fixture.
+pub async fn spawn_admin_server(
+    port: u16,
+    metrics: Arc<TestMetrics>,
+    session_registry: Arc<SessionRegistry>,
+) -> std::io::Result<()> {
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let listener = TcpListener::bind(addr).await?;
+    let actual_addr = listener.local_addr()?;
+    info!(addr = %actual_addr, "test-mode admin server listening");
+
+    let router = build_admin_router(AdminState {
+        metrics,
+        session_registry,
+    });
+
+    tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, router).await {
+            warn!(error = %e, "test-mode admin server exited");
+        }
+    });
+
+    Ok(())
+}

--- a/relay/tests/api_status_test.rs
+++ b/relay/tests/api_status_test.rs
@@ -26,6 +26,8 @@ fn make_app(relay_state: Arc<RelayState>) -> axum::Router {
         ),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: None,
+        #[cfg(feature = "test-mode")]
+        test_metrics: None,
     });
     build_router(state)
 }

--- a/relay/tests/api_wake_test.rs
+++ b/relay/tests/api_wake_test.rs
@@ -46,6 +46,8 @@ fn make_app_with_state(
         ),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: None,
+        #[cfg(feature = "test-mode")]
+        test_metrics: None,
     });
     build_router(state)
 }
@@ -172,6 +174,8 @@ async fn wake_rate_limit_returns_429() {
         ),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: None,
+        #[cfg(feature = "test-mode")]
+        test_metrics: None,
     });
 
     // First two requests should succeed

--- a/relay/tests/integration_test.rs
+++ b/relay/tests/integration_test.rs
@@ -154,6 +154,8 @@ async fn ws_upgrade_with_device_identity() {
         ),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: None,
+        #[cfg(feature = "test-mode")]
+        test_metrics: None,
     });
 
     // Build router WITH a DeviceIdentity layer to simulate mTLS
@@ -270,6 +272,8 @@ async fn mux_frame_round_trip_through_ws() {
         ),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: None,
+        #[cfg(feature = "test-mode")]
+        test_metrics: None,
     });
 
     let router = api::build_router(app_state).layer(axum::Extension(DeviceIdentity {

--- a/relay/tests/passthrough_test.rs
+++ b/relay/tests/passthrough_test.rs
@@ -38,9 +38,10 @@ fn setup_device(
     let frame_rx = session.take_frame_rx().unwrap();
 
     let (open_tx, mut open_rx) = mpsc::channel::<OpenStreamRequest>(16);
+    let (kill_tx, _kill_rx) = mpsc::channel::<()>(1);
 
     relay_state.register_mux_connection(subdomain);
-    registry.insert(subdomain, open_tx);
+    registry.insert(subdomain, open_tx, kill_tx);
 
     // Spawn a task to handle open-stream requests
     tokio::spawn(async move {
@@ -363,7 +364,8 @@ async fn cold_client_fcm_then_device_connects() {
         // Device wakes up and establishes mux
         let mut session = MuxSession::new("cold-dev".to_string(), 8);
         let (open_tx, mut open_rx) = mpsc::channel::<OpenStreamRequest>(16);
-        reg.insert("cold-dev", open_tx);
+        let (kill_tx, _kill_rx) = mpsc::channel::<()>(1);
+        reg.insert("cold-dev", open_tx, kill_tx);
         rs.register_mux_connection("cold-dev");
         // Handle open-stream requests
         while let Some(req) = open_rx.recv().await {
@@ -696,9 +698,10 @@ fn spawn_delayed_device(
     tokio::spawn(async move {
         tokio::time::sleep(delay).await;
         let (open_tx, mut open_rx) = mpsc::channel::<OpenStreamRequest>(16);
+        let (kill_tx, _kill_rx) = mpsc::channel::<()>(1);
         // Insert into registry BEFORE register_mux_connection so that
         // when subscribe_connect fires, the session is already available.
-        reg.insert(&sub, open_tx);
+        reg.insert(&sub, open_tx, kill_tx);
         rs.register_mux_connection(&sub);
         while let Some(req) = open_rx.recv().await {
             let result = session

--- a/relay/tests/test_helpers.rs
+++ b/relay/tests/test_helpers.rs
@@ -422,6 +422,8 @@ pub fn build_test_state_with_dns(
         ),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: None,
+        #[cfg(feature = "test-mode")]
+        test_metrics: None,
     })
 }
 
@@ -462,5 +464,7 @@ pub fn build_test_state_with_ca(
         ),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: Some(ca),
+        #[cfg(feature = "test-mode")]
+        test_metrics: None,
     })
 }

--- a/relay/tests/valid_secrets_cache_test.rs
+++ b/relay/tests/valid_secrets_cache_test.rs
@@ -49,8 +49,9 @@ fn setup_device(
     let mut session = MuxSession::new(subdomain.to_string(), 8);
     let frame_rx = session.take_frame_rx().unwrap();
     let (open_tx, mut open_rx) = mpsc::channel::<OpenStreamRequest>(16);
+    let (kill_tx, _kill_rx) = mpsc::channel::<()>(1);
     relay_state.register_mux_connection(subdomain);
-    registry.insert(subdomain, open_tx);
+    registry.insert(subdomain, open_tx, kill_tx);
     tokio::spawn(async move {
         while let Some(req) = open_rx.recv().await {
             let result = session
@@ -121,6 +122,8 @@ async fn rotate_secret_updates_cache_and_passthrough_accepts_new_secret() {
         ),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: Some(ca),
+        #[cfg(feature = "test-mode")]
+        test_metrics: None,
     });
 
     // Hit /rotate-secret asking the relay to generate a fresh secret for
@@ -227,6 +230,8 @@ async fn rotate_secret_cache_rejects_secrets_not_in_list() {
         ),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: Some(ca),
+        #[cfg(feature = "test-mode")]
+        test_metrics: None,
     });
 
     // Rotate the "usage" integration (not "health"). After this call the


### PR DESCRIPTION
## Summary

- Adds a feature-gated `--test-mode <port>` admin surface to the relay (`POST /test/kill-ws`, `POST /test/fcm-wake`, `GET /test/stats`) so the upcoming #247 integration-test tier can drive failure scenarios deterministically.
- Extends `TestRelayManager` with matching Kotlin hooks (`killActiveWebsocket`, `sendFcmWake`, `registerCertsCalls`, `rotateSecretCalls`, `renewCalls`, `lastRequestHadClientCert`) plus a hardened `stop()` with SIGTERM -> 3s -> SIGKILL fallback to prevent zombie relays (#223 pattern).
- CI `android-ci.yml` now builds relay with `--features test-mode`. Release deploy path (`relay-deploy.yml`) is unchanged; the feature is compile-time excluded from production binaries.

Part of #247. Blocks #250, #251, #252, #253.

## Test plan

- [x] `cd relay && cargo test` — 103 unit + all integration tests pass
- [x] `cd relay && cargo build --features test-mode` — clean
- [x] `cd relay && cargo build` (default) — clean (feature excluded)
- [x] `cd relay && cargo clippy --all-targets -- -D warnings` — clean
- [x] `./gradlew :core:tunnel:jvmTest` — pass
- [x] `./gradlew :core:tunnel:integrationTest` — 51 pass (49 existing + 2 new smoke tests). Pre-existing 50 tests still green.
- [x] `./gradlew ktlintCheck` — clean
- [x] detekt — 77 weighted issues, matches main baseline (no regression). CI runs with `continue-on-error: true`.
- [x] New `TestRelayAdminSmokeTest` covers:
    - admin server reachability + `capturedWakes` via `POST /test/fcm-wake`
    - `killActiveWebsocket` drives `TunnelClient.healthCheck()` to `false` + state to `DISCONNECTED` within keepalive window (#243 regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)