### PR TITLE
Fix #256: Retry transient 5xx in HttpCtLogFetcher and debounce Warning notifications

### DIFF
--- a/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/HttpCtLogFetcher.kt
+++ b/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/HttpCtLogFetcher.kt
@@ -6,6 +6,7 @@ import io.ktor.client.request.parameter
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.isSuccess
 import java.io.IOException
+import kotlinx.coroutines.delay
 
 /**
  * Production [CtLogFetcher] that queries crt.sh over HTTPS for certificates
@@ -19,36 +20,90 @@ import java.io.IOException
  * [CtLogMonitor] classifies the outage as "Could not reach CT log service"
  * rather than letting the HTML body flow into the JSON parser and producing
  * a misleading "Malformed CT log response" warning.
+ *
+ * Issue #256: a single 5xx from crt.sh is almost always transient (the service
+ * is community-run and flaps under load). Before surfacing a user-visible
+ * warning we retry with exponential backoff: 1s, 3s, 9s -> total wall time
+ * ~13s, bounded under the 30s budget for the security-check worker. 4xx stays
+ * a hard failure because retrying a bad query will never succeed.
  */
 class HttpCtLogFetcher(
     private val httpClient: HttpClient = RelayApiClient.createDefaultClient(),
-    private val baseUrl: String = DEFAULT_CRT_SH_URL
+    private val baseUrl: String = DEFAULT_CRT_SH_URL,
+    private val retryDelaysMs: List<Long> = DEFAULT_RETRY_DELAYS_MS
 ) : CtLogFetcher {
 
     override suspend fun fetch(domain: String): String {
+        // Total attempts = 1 initial + retryDelaysMs.size retries. Each retry
+        // is preceded by the matching entry from [retryDelaysMs]. Cancellation
+        // is respected via kotlinx.coroutines.delay, never Thread.sleep.
+        var lastError: IOException? = null
+        val totalAttempts = retryDelaysMs.size + 1
+        for (attempt in 0 until totalAttempts) {
+            if (attempt > 0) {
+                delay(retryDelaysMs[attempt - 1])
+            }
+            try {
+                return attemptFetch(domain)
+            } catch (e: RetryableHttpException) {
+                lastError = e.asIoException()
+                // fall through to retry
+            } catch (e: IOException) {
+                // Network-level failures (connection reset, DNS flap, ...) are
+                // transient by nature -- retry them on the same schedule as 5xx.
+                lastError = e
+            } catch (e: NonRetryableHttpException) {
+                // 4xx indicates a query-shape bug; no amount of retry helps.
+                throw e.asIoException()
+            }
+        }
+        throw lastError ?: IOException("crt.sh request failed after $totalAttempts attempts")
+    }
+
+    private suspend fun attemptFetch(domain: String): String {
         val response = httpClient.get(baseUrl) {
             parameter("q", domain)
             parameter("output", "json")
         }
-        if (!response.status.isSuccess()) {
-            // Include a short body preview for diagnosability: crt.sh's HTML
-            // outage pages typically lead with the error number and are useful
-            // context in the worker log without bloating the notification text.
-            val preview = runCatching { response.bodyAsText() }
-                .getOrDefault("")
-                .take(MAX_ERROR_BODY_PREVIEW)
-                .replace('\n', ' ')
-                .replace('\r', ' ')
-                .trim()
-            val suffix = if (preview.isEmpty()) "" else " body=\"$preview\""
-            throw IOException("crt.sh returned HTTP ${response.status.value}$suffix")
+        if (response.status.isSuccess()) {
+            return response.bodyAsText()
         }
-        return response.bodyAsText()
+        // Include a short body preview for diagnosability: crt.sh's HTML
+        // outage pages typically lead with the error number and are useful
+        // context in the worker log without bloating the notification text.
+        val preview = runCatching { response.bodyAsText() }
+            .getOrDefault("")
+            .take(MAX_ERROR_BODY_PREVIEW)
+            .replace('\n', ' ')
+            .replace('\r', ' ')
+            .trim()
+        val suffix = if (preview.isEmpty()) "" else " body=\"$preview\""
+        val statusCode = response.status.value
+        val message = "crt.sh returned HTTP $statusCode$suffix"
+        if (statusCode in 500..599) {
+            throw RetryableHttpException(message)
+        }
+        throw NonRetryableHttpException(message)
+    }
+
+    private class RetryableHttpException(message: String) : RuntimeException(message) {
+        fun asIoException(): IOException = IOException(message)
+    }
+
+    private class NonRetryableHttpException(message: String) : RuntimeException(message) {
+        fun asIoException(): IOException = IOException(message)
     }
 
     companion object {
         /** Public crt.sh JSON query endpoint. */
         const val DEFAULT_CRT_SH_URL = "https://crt.sh/"
+
+        /**
+         * Backoff schedule between retry attempts: 1s, 3s, 9s. Four total
+         * attempts (1 initial + 3 retries), ~13s total wall time, well under
+         * the 30s per-check budget. See issue #256.
+         */
+        val DEFAULT_RETRY_DELAYS_MS: List<Long> = listOf(1_000L, 3_000L, 9_000L)
 
         /**
          * Cap on how much of an error body we echo back into the exception

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/HttpCtLogFetcherTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/HttpCtLogFetcherTest.kt
@@ -8,7 +8,9 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.utils.io.ByteReadChannel
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
@@ -37,7 +39,10 @@ class HttpCtLogFetcherTest {
                 }
             }
         }
-        val fetcher = HttpCtLogFetcher(httpClient = httpClient)
+        val fetcher = HttpCtLogFetcher(
+            httpClient = httpClient,
+            retryDelaysMs = listOf(0L, 0L, 0L)
+        )
 
         val thrown = assertFailsWith<IOException> {
             fetcher.fetch("abc123.rousecontext.com")
@@ -64,7 +69,10 @@ class HttpCtLogFetcherTest {
                 }
             }
         }
-        val fetcher = HttpCtLogFetcher(httpClient = httpClient)
+        val fetcher = HttpCtLogFetcher(
+            httpClient = httpClient,
+            retryDelaysMs = listOf(0L, 0L, 0L)
+        )
 
         val thrown = assertFailsWith<IOException> {
             fetcher.fetch("abc123.rousecontext.com")
@@ -99,6 +107,195 @@ class HttpCtLogFetcherTest {
         httpClient.close()
     }
 
+    @Test
+    fun `fetch retries on transient 502 and succeeds on third attempt`(): Unit = runBlocking {
+        // Issue #256: crt.sh routinely 502s under load. A single failure is
+        // nearly always transient, so the fetcher MUST retry on 5xx with
+        // backoff before surfacing the failure as a warning.
+        val attempts = AtomicInteger(0)
+        val successBody = "[]"
+        val httpClient = HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    val n = attempts.incrementAndGet()
+                    if (n < 3) {
+                        respond(
+                            content = ByteReadChannel("<html>502 Bad Gateway</html>"),
+                            status = HttpStatusCode.BadGateway,
+                            headers = headersOf(HttpHeaders.ContentType, "text/html")
+                        )
+                    } else {
+                        respond(
+                            content = ByteReadChannel(successBody),
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, "application/json")
+                        )
+                    }
+                }
+            }
+        }
+        // Zero-delay retry schedule keeps the test fast while still exercising
+        // the retry loop. Production defaults are exercised by the companion
+        // constant assertions in `retry schedule is bounded under 30s`.
+        val fetcher = HttpCtLogFetcher(
+            httpClient = httpClient,
+            retryDelaysMs = listOf(0L, 0L, 0L)
+        )
+
+        val result = fetcher.fetch("abc123.rousecontext.com")
+
+        assertEquals(successBody, result)
+        assertEquals(3, attempts.get())
+        httpClient.close()
+    }
+
+    @Test
+    fun `fetch observes backoff between retries`(): Unit = runBlocking {
+        val attempts = AtomicInteger(0)
+        val httpClient = HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    val n = attempts.incrementAndGet()
+                    if (n < 2) {
+                        respond(
+                            content = ByteReadChannel("<html>502</html>"),
+                            status = HttpStatusCode.BadGateway,
+                            headers = headersOf(HttpHeaders.ContentType, "text/html")
+                        )
+                    } else {
+                        respond(
+                            content = ByteReadChannel("[]"),
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, "application/json")
+                        )
+                    }
+                }
+            }
+        }
+        // A single 150ms delay between attempt 1 and attempt 2.
+        val fetcher = HttpCtLogFetcher(
+            httpClient = httpClient,
+            retryDelaysMs = listOf(150L, 150L, 150L)
+        )
+
+        val start = System.nanoTime()
+        fetcher.fetch("abc123.rousecontext.com")
+        val elapsedMs = (System.nanoTime() - start) / 1_000_000
+
+        assertEquals(2, attempts.get())
+        assertTrue(
+            elapsedMs >= 140L,
+            "Expected backoff >= 140ms, got ${elapsedMs}ms"
+        )
+        httpClient.close()
+    }
+
+    @Test
+    fun `fetch throws after exhausting retries on persistent 502`(): Unit = runBlocking {
+        val attempts = AtomicInteger(0)
+        val httpClient = HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    attempts.incrementAndGet()
+                    respond(
+                        content = ByteReadChannel("<html>502 Bad Gateway</html>"),
+                        status = HttpStatusCode.BadGateway,
+                        headers = headersOf(HttpHeaders.ContentType, "text/html")
+                    )
+                }
+            }
+        }
+        val retryDelays = listOf(0L, 0L, 0L)
+        val fetcher = HttpCtLogFetcher(
+            httpClient = httpClient,
+            retryDelaysMs = retryDelays
+        )
+
+        val thrown = assertFailsWith<IOException> {
+            fetcher.fetch("abc123.rousecontext.com")
+        }
+        // 1 initial attempt + 3 retries = 4 total attempts.
+        assertEquals(retryDelays.size + 1, attempts.get())
+        assertTrue(
+            thrown.message!!.contains("502"),
+            "Final error must include the last-seen status, was: ${thrown.message}"
+        )
+        httpClient.close()
+    }
+
+    @Test
+    fun `fetch does not retry on 4xx client error`(): Unit = runBlocking {
+        // 4xx indicates a query-shape bug (e.g. malformed domain). Retrying
+        // will never succeed, so we MUST fail fast instead of spending 13s
+        // backing off before surfacing the same error.
+        val attempts = AtomicInteger(0)
+        val httpClient = HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    attempts.incrementAndGet()
+                    respond(
+                        content = ByteReadChannel("bad request"),
+                        status = HttpStatusCode.BadRequest,
+                        headers = headersOf(HttpHeaders.ContentType, "text/plain")
+                    )
+                }
+            }
+        }
+        val fetcher = HttpCtLogFetcher(
+            httpClient = httpClient,
+            retryDelaysMs = listOf(10_000L, 10_000L, 10_000L) // would make test slow if retried
+        )
+
+        val thrown = assertFailsWith<IOException> {
+            fetcher.fetch("abc123.rousecontext.com")
+        }
+        assertEquals(1, attempts.get())
+        assertTrue(
+            thrown.message!!.contains("400"),
+            "Expected 400 in message, was: ${thrown.message}"
+        )
+        httpClient.close()
+    }
+
+    @Test
+    fun `fetch retries on network IOException and succeeds on recovery`(): Unit = runBlocking {
+        val attempts = AtomicInteger(0)
+        val httpClient = HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    val n = attempts.incrementAndGet()
+                    if (n < 2) {
+                        throw IOException("connection reset by peer")
+                    }
+                    respond(
+                        content = ByteReadChannel("[]"),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+            }
+        }
+        val fetcher = HttpCtLogFetcher(
+            httpClient = httpClient,
+            retryDelaysMs = listOf(0L, 0L, 0L)
+        )
+
+        val result = fetcher.fetch("abc123.rousecontext.com")
+
+        assertEquals("[]", result)
+        assertEquals(2, attempts.get())
+        httpClient.close()
+    }
+
+    @Test
+    fun `default retry schedule stays within 30s total wall time`() {
+        val total = HttpCtLogFetcher.DEFAULT_RETRY_DELAYS_MS.sum()
+        assertTrue(
+            total <= 30_000L,
+            "Default retry schedule must not exceed 30s wall time, was ${total}ms"
+        )
+    }
+
     /**
      * Integration-level check (no real network): routes an HTML 5xx body through
      * the full [HttpCtLogFetcher] + [CtLogMonitor] stack and asserts the final
@@ -119,7 +316,10 @@ class HttpCtLogFetcherTest {
                 }
             }
         }
-        val fetcher = HttpCtLogFetcher(httpClient = httpClient)
+        val fetcher = HttpCtLogFetcher(
+            httpClient = httpClient,
+            retryDelaysMs = listOf(0L, 0L, 0L)
+        )
         val store = SecurityCertificateStore(subdomain = "abc123")
         val monitor = CtLogMonitor(
             certificateStore = store,

--- a/work/src/main/kotlin/com/rousecontext/work/SecurityCheckPreferences.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/SecurityCheckPreferences.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -58,19 +59,57 @@ class SecurityCheckPreferences(private val context: Context) {
         }
     }
 
+    /**
+     * Issue #256: per-source consecutive-warning counter used by
+     * [SecurityCheckWorker] to debounce notification noise. A notification
+     * only fires after the same [sourceName] returns [SecurityCheckResult.Warning]
+     * on [SecurityCheckWorker.WARNING_NOTIFICATION_THRESHOLD] consecutive runs.
+     * Any non-Warning result resets the counter via [resetWarningStreak].
+     */
+    suspend fun warningStreak(sourceName: String): Int =
+        dataStore.data.first()[warningStreakKey(sourceName)] ?: 0
+
+    suspend fun incrementWarningStreak(sourceName: String): Int {
+        val key = warningStreakKey(sourceName)
+        var newValue = 0
+        dataStore.edit { prefs ->
+            newValue = (prefs[key] ?: 0) + 1
+            prefs[key] = newValue
+        }
+        return newValue
+    }
+
+    suspend fun resetWarningStreak(sourceName: String) {
+        dataStore.edit { prefs ->
+            prefs[warningStreakKey(sourceName)] = 0
+        }
+    }
+
     /** Clears the acknowledgeable alert/warning fields (used by "Acknowledge"). */
     suspend fun clearResults() {
         dataStore.edit { prefs ->
             prefs[KEY_SELF_CERT_RESULT] = ""
             prefs[KEY_CT_LOG_RESULT] = ""
             prefs[KEY_LAST_CHECK_TIME] = 0L
+            prefs[warningStreakKey(SOURCE_SELF_CERT)] = 0
+            prefs[warningStreakKey(SOURCE_CT_LOG)] = 0
         }
     }
 
     companion object {
+        /**
+         * Stable source names used as DataStore key suffixes. Must stay in sync
+         * with the sources passed in by [SecurityCheckWorker].
+         */
+        const val SOURCE_SELF_CERT = "self_cert"
+        const val SOURCE_CT_LOG = "ct_log"
+
         private val KEY_LAST_CHECK_TIME = longPreferencesKey("last_check_time")
         private val KEY_SELF_CERT_RESULT = stringPreferencesKey("self_cert_result")
         private val KEY_CT_LOG_RESULT = stringPreferencesKey("ct_log_result")
         private val KEY_CERT_FINGERPRINT = stringPreferencesKey("cert_fingerprint")
+
+        private fun warningStreakKey(sourceName: String) =
+            intPreferencesKey("warning_streak_$sourceName")
     }
 }

--- a/work/src/main/kotlin/com/rousecontext/work/SecurityCheckWorker.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/SecurityCheckWorker.kt
@@ -28,6 +28,13 @@ interface SecurityCheckSource {
  * Alerts and warnings are posted by [SecurityCheckNotifier] using stable ids per
  * (check, severity) pair, so repeated runs replace the existing notification rather
  * than stacking or clobbering prior runs' unrelated notifications.
+ *
+ * Issue #256: a [SecurityCheckResult.Warning] now debounces across runs -- a
+ * notification only surfaces when the SAME source returns Warning on
+ * [WARNING_NOTIFICATION_THRESHOLD] consecutive runs. Any non-Warning result
+ * (Verified, Alert, Skipped) resets the counter for that source. Alerts still
+ * fire immediately: the debounce applies only to Warning.
+ *
  * Always returns [Result.success] since the checks handle their own graceful degradation.
  */
 class SecurityCheckWorker(context: Context, params: WorkerParameters) :
@@ -53,39 +60,75 @@ class SecurityCheckWorker(context: Context, params: WorkerParameters) :
 
         val selfCertResult = selfCertVerifier.check()
         val ctResult = ctLogMonitor.check()
+        val prefs = preferences ?: injectedPreferences
 
-        (preferences ?: injectedPreferences).recordCheck(
+        prefs.recordCheck(
             lastCheckAt = System.currentTimeMillis(),
             selfCertResult = resultToString(selfCertResult),
             ctLogResult = resultToString(ctResult)
         )
 
-        handleResult(SecurityCheck.SELF_CERT, "Self-cert verification", selfCertResult)
-        handleResult(SecurityCheck.CT_LOG, "CT log check", ctResult)
+        handleResult(
+            prefs,
+            SecurityCheck.SELF_CERT,
+            SecurityCheckPreferences.SOURCE_SELF_CERT,
+            "Self-cert verification",
+            selfCertResult
+        )
+        handleResult(
+            prefs,
+            SecurityCheck.CT_LOG,
+            SecurityCheckPreferences.SOURCE_CT_LOG,
+            "CT log check",
+            ctResult
+        )
 
         Log.d(TAG, "Security checks complete: self=$selfCertResult, ct=$ctResult")
         return Result.success()
     }
 
-    private fun handleResult(check: SecurityCheck, checkName: String, result: SecurityCheckResult) {
+    private suspend fun handleResult(
+        prefs: SecurityCheckPreferences,
+        check: SecurityCheck,
+        sourceName: String,
+        checkName: String,
+        result: SecurityCheckResult
+    ) {
         when (result) {
             is SecurityCheckResult.Verified -> {
                 Log.d(TAG, "$checkName: verified")
+                prefs.resetWarningStreak(sourceName)
             }
 
             is SecurityCheckResult.Skipped -> {
                 // Issue #228: pre-onboarding / "not yet configured" states log
                 // for diagnostics but MUST NOT fire a user notification.
                 Log.d(TAG, "$checkName: skipped - ${result.reason}")
+                prefs.resetWarningStreak(sourceName)
             }
 
             is SecurityCheckResult.Warning -> {
-                Log.w(TAG, "$checkName: warning - ${result.reason}")
-                notifier.postInfo(check, result.reason)
+                val streak = prefs.incrementWarningStreak(sourceName)
+                if (streak >= WARNING_NOTIFICATION_THRESHOLD) {
+                    Log.w(TAG, "$checkName: warning (streak=$streak) - ${result.reason}")
+                    notifier.postInfo(check, result.reason)
+                } else {
+                    // Below threshold -- single/transient flaps are absorbed
+                    // silently. Issue #256: crt.sh 5xx hiccups should not
+                    // notify on first occurrence.
+                    Log.d(
+                        TAG,
+                        "$checkName: warning (streak=$streak, below threshold) - " +
+                            result.reason
+                    )
+                }
             }
 
             is SecurityCheckResult.Alert -> {
                 Log.e(TAG, "$checkName: ALERT - ${result.reason}")
+                // Alerts bypass debouncing entirely, but any accumulated
+                // warning streak is no longer meaningful.
+                prefs.resetWarningStreak(sourceName)
                 notifier.postAlert(check, result.reason)
             }
         }
@@ -94,6 +137,14 @@ class SecurityCheckWorker(context: Context, params: WorkerParameters) :
     companion object {
         const val TAG = "SecurityCheckWorker"
         const val WORK_NAME = "security_check"
+
+        /**
+         * Minimum consecutive Warning runs from the same source before a user
+         * notification fires. Issue #256: covers persistent-but-intermittent
+         * outages that the per-request retry in [com.rousecontext.tunnel.HttpCtLogFetcher]
+         * cannot absorb on its own.
+         */
+        const val WARNING_NOTIFICATION_THRESHOLD = 3
 
         private fun resultToString(result: SecurityCheckResult): String = when (result) {
             is SecurityCheckResult.Verified -> "verified"

--- a/work/src/test/kotlin/com/rousecontext/work/SecurityCheckWorkerTest.kt
+++ b/work/src/test/kotlin/com/rousecontext/work/SecurityCheckWorkerTest.kt
@@ -104,7 +104,11 @@ class SecurityCheckWorkerTest {
         }
 
     @Test
-    fun `ct check warning - notifier postInfo invoked for CT_LOG`() = runBlocking {
+    fun `ct check warning below threshold - no notification`() = runBlocking {
+        // Issue #256: a single Warning from a source MUST NOT surface a user
+        // notification. crt.sh routinely flaps, and the adjacent retry loop in
+        // HttpCtLogFetcher will absorb most transients -- but a genuine flap
+        // that survives retries should still debounce across worker runs.
         val worker = buildWorker(
             selfCertResult = SecurityCheckResult.Verified,
             ctResult = SecurityCheckResult.Warning("could not reach CT log")
@@ -116,12 +120,129 @@ class SecurityCheckWorkerTest {
         assertEquals("verified", prefs.selfCertResult())
         assertEquals("warning", prefs.ctLogResult())
         assertEquals(
+            "Single warning MUST NOT fire a notification",
+            emptyList<FakeSecurityCheckNotifier.Call>(),
+            fakeNotifier.calls
+        )
+    }
+
+    @Test
+    fun `ct check warning fires notification only after threshold consecutive runs`() =
+        runBlocking {
+            // Three consecutive Warning runs must fire exactly one notification
+            // (on the third run). Runs 1 and 2 stay silent.
+            repeat(2) {
+                val worker = buildWorker(
+                    selfCertResult = SecurityCheckResult.Verified,
+                    ctResult = SecurityCheckResult.Warning("could not reach CT log")
+                )
+                worker.doWork()
+            }
+            assertEquals(
+                "Runs below threshold must stay silent",
+                emptyList<FakeSecurityCheckNotifier.Call>(),
+                fakeNotifier.calls
+            )
+
+            val worker = buildWorker(
+                selfCertResult = SecurityCheckResult.Verified,
+                ctResult = SecurityCheckResult.Warning("could not reach CT log")
+            )
+            worker.doWork()
+
+            assertEquals(
+                listOf(
+                    FakeSecurityCheckNotifier.Call.Info(
+                        SecurityCheck.CT_LOG,
+                        "could not reach CT log"
+                    )
+                ),
+                fakeNotifier.calls
+            )
+        }
+
+    @Test
+    fun `warning counter resets on verified result`() = runBlocking {
+        // Two warning runs, then a verified run -- counter MUST reset so the
+        // NEXT two warnings do not cross the threshold.
+        repeat(2) {
+            val w = buildWorker(
+                selfCertResult = SecurityCheckResult.Verified,
+                ctResult = SecurityCheckResult.Warning("flap")
+            )
+            w.doWork()
+        }
+
+        val verifiedWorker = buildWorker(
+            selfCertResult = SecurityCheckResult.Verified,
+            ctResult = SecurityCheckResult.Verified
+        )
+        verifiedWorker.doWork()
+
+        // After the reset, one more warning should not fire (counter back to 1).
+        val afterResetWorker = buildWorker(
+            selfCertResult = SecurityCheckResult.Verified,
+            ctResult = SecurityCheckResult.Warning("flap")
+        )
+        afterResetWorker.doWork()
+
+        assertEquals(
+            "Counter must have reset; single warning post-reset MUST NOT fire",
+            emptyList<FakeSecurityCheckNotifier.Call>(),
+            fakeNotifier.calls
+        )
+    }
+
+    @Test
+    fun `alert fires immediately regardless of warning debounce state`() = runBlocking {
+        // Alerts are a different severity -- they MUST fire immediately even
+        // when no prior warnings have accumulated. Debouncing applies only to
+        // Warning, never to Alert.
+        val worker = buildWorker(
+            selfCertResult = SecurityCheckResult.Verified,
+            ctResult = SecurityCheckResult.Alert("unexpected issuer Evil CA")
+        )
+
+        val result = worker.doWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+        assertEquals(
             listOf(
-                FakeSecurityCheckNotifier.Call.Info(
+                FakeSecurityCheckNotifier.Call.Alert(
                     SecurityCheck.CT_LOG,
-                    "could not reach CT log"
+                    "unexpected issuer Evil CA"
                 )
             ),
+            fakeNotifier.calls
+        )
+    }
+
+    @Test
+    fun `warning counter is per-source - self cert warnings do not block ct log`() = runBlocking {
+        // Source counters MUST be independent: two self-cert warnings should
+        // not push the ct-log counter toward its threshold.
+        repeat(2) {
+            val w = buildWorker(
+                selfCertResult = SecurityCheckResult.Warning("self cert flap"),
+                ctResult = SecurityCheckResult.Verified
+            )
+            w.doWork()
+        }
+        assertEquals(
+            "Two self-cert warnings alone must stay below threshold",
+            emptyList<FakeSecurityCheckNotifier.Call>(),
+            fakeNotifier.calls
+        )
+
+        val worker = buildWorker(
+            selfCertResult = SecurityCheckResult.Verified,
+            ctResult = SecurityCheckResult.Warning("ct flap")
+        )
+        worker.doWork()
+
+        assertEquals(
+            "Fresh ct-log warning must not fire just because self-cert had two",
+            emptyList<FakeSecurityCheckNotifier.Call>(),
             fakeNotifier.calls
         )
     }
@@ -150,31 +271,35 @@ class SecurityCheckWorkerTest {
     }
 
     @Test
-    fun `network warning on both - notifier postInfo invoked for each check`() = runBlocking {
-        val worker = buildWorker(
-            selfCertResult = SecurityCheckResult.Warning("network unreachable"),
-            ctResult = SecurityCheckResult.Warning("could not reach CT log")
-        )
-
-        val result = worker.doWork()
-
-        assertEquals(ListenableWorker.Result.success(), result)
-        assertEquals("warning", prefs.selfCertResult())
-        assertEquals("warning", prefs.ctLogResult())
-        assertEquals(
-            listOf(
-                FakeSecurityCheckNotifier.Call.Info(
-                    SecurityCheck.SELF_CERT,
-                    "network unreachable"
-                ),
-                FakeSecurityCheckNotifier.Call.Info(
-                    SecurityCheck.CT_LOG,
-                    "could not reach CT log"
+    fun `network warning on both - both fire once threshold reached on each source`() =
+        runBlocking {
+            // Repeat three times: both sources cross their warning threshold on
+            // the third run and each fires its own notification. Earlier runs
+            // stay silent.
+            repeat(3) {
+                val worker = buildWorker(
+                    selfCertResult = SecurityCheckResult.Warning("network unreachable"),
+                    ctResult = SecurityCheckResult.Warning("could not reach CT log")
                 )
-            ),
-            fakeNotifier.calls
-        )
-    }
+                worker.doWork()
+            }
+
+            assertEquals("warning", prefs.selfCertResult())
+            assertEquals("warning", prefs.ctLogResult())
+            assertEquals(
+                listOf(
+                    FakeSecurityCheckNotifier.Call.Info(
+                        SecurityCheck.SELF_CERT,
+                        "network unreachable"
+                    ),
+                    FakeSecurityCheckNotifier.Call.Info(
+                        SecurityCheck.CT_LOG,
+                        "could not reach CT log"
+                    )
+                ),
+                fakeNotifier.calls
+            )
+        }
 
     private fun buildWorker(
         selfCertResult: SecurityCheckResult,


### PR DESCRIPTION
## Summary

Closes #256. Two complementary fixes so a single crt.sh 5xx hiccup no longer surfaces as a user-visible notification.

- `HttpCtLogFetcher` now retries 5xx responses and network `IOException`s with exponential backoff (1s / 3s / 9s, ~13s total wall, bounded under the 30s security-check budget). 4xx stays a hard failure because a malformed query will never succeed on retry. Uses `kotlinx.coroutines.delay` so cancellation is respected; never `Thread.sleep`.
- `SecurityCheckWorker` debounces `Warning` notifications: a notification fires only after the same source returns `Warning` on `WARNING_NOTIFICATION_THRESHOLD = 3` consecutive runs. Any non-Warning result (`Verified` / `Alert` / `Skipped`) resets the counter for that source. `Alert` still fires immediately; debouncing applies only to `Warning`. Counter persisted per-source in `SecurityCheckPreferences`.

## Test plan

- [x] `:core:tunnel:jvmTest` green (new retry/backoff/4xx-no-retry/IOException-retry tests plus existing #227 coverage)
- [x] `:work:testDebugUnitTest` green (new tests for below-threshold silence, threshold cross, reset-on-verified, per-source isolation, Alert-bypasses-debounce)
- [x] `:notifications:testDebugUnitTest` green
- [x] `./gradlew ktlintCheck` clean
- [x] `./gradlew detekt` unchanged from main (77 pre-existing weighted issues, none new)

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>