### PR TITLE
Fix #232: Drop #200 legacy-PEM migration code

### DIFF
--- a/app/src/main/java/com/rousecontext/app/cert/FileCertificateStore.kt
+++ b/app/src/main/java/com/rousecontext/app/cert/FileCertificateStore.kt
@@ -10,7 +10,6 @@ import java.nio.channels.FileChannel
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
-import java.security.GeneralSecurityException
 import java.security.KeyStore
 import java.security.MessageDigest
 import java.security.cert.CertificateFactory
@@ -28,9 +27,9 @@ import kotlinx.serialization.json.jsonPrimitive
  *
  * Issue #200: the device identity keypair is owned by
  * [com.rousecontext.tunnel.DeviceKeyManager] (hardware-backed Android Keystore, see
- * `AndroidKeystoreDeviceKeyManager`). FileCertificateStore is no longer in the key
- * path -- it only holds PEM certs, subdomain metadata, integration secrets, and
- * fingerprints. The historical PEM-key hooks on [CertificateStore] now inherit
+ * `AndroidKeystoreDeviceKeyManager`). FileCertificateStore is not in the key path --
+ * it only holds PEM certs, subdomain metadata, integration secrets, and
+ * fingerprints. The historical PEM-key hooks on [CertificateStore] inherit
  * deprecated no-op / null defaults.
  */
 class FileCertificateStore(private val context: Context) : CertificateStore {
@@ -43,57 +42,6 @@ class FileCertificateStore(private val context: Context) : CertificateStore {
     private val fingerprintsFile get() = File(filesDir, FINGERPRINTS_FILE)
     private val fingerprintBootstrapMarkerFile get() =
         File(filesDir, FINGERPRINT_BOOTSTRAP_MARKER_FILE)
-    private val keyMigrationMarkerFile get() = File(filesDir, KEY_MIGRATION_MARKER_FILE)
-    private val keyPemFile get() = File(filesDir, KEY_PEM_FILE)
-
-    /**
-     * Issue #200: detect devices upgraded from a software-key build.
-     *
-     * Signal: the legacy `rouse_key.pem` file exists on disk AND the hardware-backed
-     * device-identity alias (`rouse_device_key`) is not yet provisioned in the Android
-     * Keystore. The upgraded code path mints its identity exclusively via
-     * [com.rousecontext.tunnel.DeviceKeyManager]; the stale PEM can never be used to
-     * sign a fresh CSR that the relay will accept because the public key it represents
-     * is now orphaned from the signing key the Keystore will produce.
-     *
-     * Action: drop all cert-related state ([clearCertificates]) so the next integration
-     * setup run triggers a fresh CSR under the Keystore key. The subdomain and
-     * onboarding state survive — we do not want to bounce the user back to the Welcome
-     * screen on the upgrade path (regression guard for issue #163).
-     *
-     * Idempotent: once the PEM is gone, subsequent calls are no-ops.
-     *
-     * Callers should invoke this at app start (before the cert provisioning / renewal
-     * flows run) so the migration completes before any code path that would otherwise
-     * try to consume the stale key bytes. Not called from init so tests that exercise
-     * the PEM file itself (pre-migration state) can assert the file's contents first.
-     */
-    suspend fun migrateLegacyPrivateKeyFileIfNeeded() {
-        val legacy = keyPemFile
-        if (!legacy.exists()) return
-        val keyStore = try {
-            androidKeyStore()
-        } catch (e: GeneralSecurityException) {
-            Log.w(TAG, "Keystore unavailable during legacy PEM migration; deferring", e)
-            return
-        } catch (e: IOException) {
-            Log.w(TAG, "Keystore unavailable during legacy PEM migration; deferring", e)
-            return
-        }
-        if (keyStore.containsAlias(KEY_ALIAS)) {
-            // A previous migration run already seeded the Keystore alongside the PEM
-            // (unlikely but defensive). Nothing to do.
-            return
-        }
-        Log.w(
-            TAG,
-            "Legacy software-key PEM detected with no Keystore alias; clearing cert " +
-                "state so issue #200 onboarding re-runs with a hardware-backed key"
-        )
-        // clearCertificates deletes keyPemFile and keyMigrationMarkerFile plus any
-        // cert files, leaves subdomain + integration secrets intact.
-        clearCertificates()
-    }
 
     override suspend fun storeCertificate(pemChain: String) {
         certFile.writeText(pemChain)
@@ -172,10 +120,7 @@ class FileCertificateStore(private val context: Context) : CertificateStore {
 
     // Issue #200: the device identity key is owned by DeviceKeyManager (Android
     // Keystore, StrongBox/TEE). storePrivateKey/getPrivateKey inherit the
-    // deprecated default no-op/null implementations on the interface. We still
-    // sweep any legacy rouse_key.pem file at init time via
-    // [migrateLegacyPrivateKeyFileIfNeeded] so stale plaintext/encrypted PEMs do
-    // not linger on disk after the upgrade.
+    // deprecated default no-op/null implementations on the interface.
 
     override suspend fun getCertChain(): List<ByteArray>? {
         val pem = getCertificate() ?: return null
@@ -267,14 +212,10 @@ class FileCertificateStore(private val context: Context) : CertificateStore {
         certFile.delete()
         File(filesDir, CLIENT_CERT_PEM_FILE).delete()
         File(filesDir, RELAY_CA_PEM_FILE).delete()
-        // Issue #200: the KEY_PEM_FILE is legacy-only (pre-hardware-key software
-        // PEM). The hardware-backed device identity key lives in the Android
-        // Keystore and MUST survive cert rotation/rollback -- the relay pins its
-        // public half at registration time and rejects any CSR signed by a
-        // different key. We therefore only delete the legacy PEM file here and
-        // leave the Keystore alias intact.
-        keyPemFile.delete()
-        keyMigrationMarkerFile.delete()
+        // Issue #200: the hardware-backed device identity key lives in the
+        // Android Keystore and MUST survive cert rotation/rollback -- the relay
+        // pins its public half at registration time and rejects any CSR signed
+        // by a different key. We therefore leave the Keystore alias intact here.
         fingerprintsFile.delete()
         // The bootstrap marker is tied to the current install's fingerprint
         // state. When we roll back cert provisioning we also reset this so a
@@ -429,8 +370,6 @@ class FileCertificateStore(private val context: Context) : CertificateStore {
         private const val CERT_PEM_FILE = "rouse_cert.pem"
         private const val CLIENT_CERT_PEM_FILE = "rouse_client_cert.pem"
         private const val RELAY_CA_PEM_FILE = "rouse_relay_ca.pem"
-        private const val KEY_PEM_FILE = "rouse_key.pem"
-        private const val KEY_MIGRATION_MARKER_FILE = "rouse_key_migrated.flag"
         private const val SUBDOMAIN_FILE = "rouse_subdomain.txt"
         private const val INTEGRATION_SECRETS_FILE = "rouse_integration_secrets.json"
         private const val LEGACY_SECRET_PREFIX_FILE = "rouse_secret_prefix.txt"

--- a/app/src/main/java/com/rousecontext/app/di/AppModule.kt
+++ b/app/src/main/java/com/rousecontext/app/di/AppModule.kt
@@ -178,14 +178,8 @@ val appModule = module {
     single { BugReportUriBuilder(androidContext()) }
 
     // --- Certificate store ---
-    // Issue #200: run the legacy-PEM migration sweep once at startup so any lingering
-    // software-key PEM from pre-hardware-key builds is cleared before the first cert
-    // provisioning / renewal attempt. The sweep is idempotent.
     single {
-        val store = FileCertificateStore(androidContext())
-        val appScope: CoroutineScope = get(named("appScope"))
-        appScope.launch { store.migrateLegacyPrivateKeyFileIfNeeded() }
-        store
+        FileCertificateStore(androidContext())
     } bind CertificateStore::class
 
     // --- Device identity key (Android Keystore, StrongBox/TEE) ---

--- a/app/src/test/java/com/rousecontext/app/cert/FileCertificateStoreTest.kt
+++ b/app/src/test/java/com/rousecontext/app/cert/FileCertificateStoreTest.kt
@@ -11,7 +11,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,11 +19,10 @@ import org.robolectric.RobolectricTestRunner
 /**
  * FileCertificateStore unit tests (Robolectric).
  *
- * Issue #200: the store no longer holds private-key material -- the device identity key
+ * Issue #200: the store does not hold private-key material -- the device identity key
  * is owned by `AndroidKeystoreDeviceKeyManager` and lives in the hardware-backed Android
  * Keystore. These tests cover the remaining responsibilities: cert PEM storage,
- * fingerprint tracking, subdomain/integration-secrets atomic writes, and the legacy-key
- * migration hook.
+ * fingerprint tracking, and subdomain/integration-secrets atomic writes.
  */
 @RunWith(RobolectricTestRunner::class)
 class FileCertificateStoreTest {
@@ -303,84 +301,6 @@ class FileCertificateStoreTest {
             tmps.isEmpty()
         )
         assertEquals(mapOf("foo" to "bar"), store.getIntegrationSecrets())
-    }
-
-    @Test
-    fun `migrateLegacyPrivateKeyFileIfNeeded wipes cert state when PEM present, alias missing`() =
-        runBlocking {
-            assumeTrue(
-                "AndroidKeyStore provider not available in this Robolectric runtime",
-                isAndroidKeyStoreAvailable()
-            )
-            // Issue #200: the pre-hardware-key software PEM is orphaned when the user upgrades
-            // to the hardware-key build -- the stored public key on the relay will no longer
-            // match any key the new Keystore alias can sign with. Migration detects this state
-            // (PEM file present, rouse_device_key alias absent) and wipes cert-related files so
-            // the next integration setup run triggers a clean re-provision.
-            //
-            // Write files directly (bypassing storeCertificate) so the test does not depend on
-            // the PEM parser accepting stub contents.
-            val keyFile = File(context.filesDir, "rouse_key.pem")
-            keyFile.writeText(
-                "-----BEGIN PRIVATE KEY-----\nlegacy-plaintext\n-----END PRIVATE KEY-----\n"
-            )
-            val certFile = File(context.filesDir, "rouse_cert.pem")
-            certFile.writeText("stub-server-cert")
-            val clientCertFile = File(context.filesDir, "rouse_client_cert.pem")
-            clientCertFile.writeText("stub-client-cert")
-            val relayCaFile = File(context.filesDir, "rouse_relay_ca.pem")
-            relayCaFile.writeText("stub-ca-cert")
-            // Onboarding state must survive migration (regression guard for issue #163).
-            store.storeSubdomain("abc123")
-            store.storeIntegrationSecrets(mapOf("health" to "swift-health"))
-
-            // Sanity check: AndroidKeyStore is available in Robolectric and has no alias yet.
-            val ks = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
-            assertFalse(
-                "Precondition: device key alias must NOT exist before migration",
-                ks.containsAlias("rouse_device_key")
-            )
-
-            store.migrateLegacyPrivateKeyFileIfNeeded()
-
-            assertFalse(
-                "Legacy PEM file must be deleted after migration",
-                keyFile.exists()
-            )
-            assertFalse("Cert file must be cleared", certFile.exists())
-            assertFalse("Client cert file must be cleared", clientCertFile.exists())
-            assertFalse("Relay CA file must be cleared", relayCaFile.exists())
-            assertEquals(
-                "Subdomain must survive migration",
-                "abc123",
-                store.getSubdomain()
-            )
-            assertEquals(
-                "Integration secrets must survive migration",
-                mapOf("health" to "swift-health"),
-                store.getIntegrationSecrets()
-            )
-        }
-
-    @Test
-    fun `migrateLegacyPrivateKeyFileIfNeeded is a no-op when no legacy PEM exists`() = runBlocking {
-        // Fresh install path: nothing to migrate. Write the cert file directly so the
-        // assertion below is not coupled to the PEM parser accepting stub contents.
-        store.storeSubdomain("abc123")
-        val certFile = File(context.filesDir, "rouse_cert.pem")
-        certFile.writeText("stub-server-cert")
-
-        store.migrateLegacyPrivateKeyFileIfNeeded()
-
-        assertEquals("abc123", store.getSubdomain())
-        assertEquals("stub-server-cert", store.getCertificate())
-    }
-
-    private fun isAndroidKeyStoreAvailable(): Boolean = try {
-        KeyStore.getInstance("AndroidKeyStore").load(null)
-        true
-    } catch (_: Throwable) {
-        false
     }
 
     private fun derToPem(der: ByteArray): String {


### PR DESCRIPTION
## Summary

- No users ever crossed the pre-#200 -> post-#200 boundary (the one device that did has been cleared and re-onboarded), so the migration scaffold in FileCertificateStore is dormant code. Remove it.
- Drops FileCertificateStore.migrateLegacyPrivateKeyFileIfNeeded and its appScope.launch invocation in AppModule, the KEY_PEM_FILE / KEY_MIGRATION_MARKER_FILE constants and their handling in clearCertificates, and the two migration tests plus their isAndroidKeyStoreAvailable helper.
- Keeps AndroidKeystoreDeviceKeyManager and all hardware-key machinery, the file-based cert store for PEMs, and #200 doc comments that still describe current behaviour.

## Test plan

- [x] `:app:testDebugUnitTest` passes (minus the deleted migration tests).
- [x] `:core:tunnel:jvmTest` passes.
- [x] `ktlintCheck` passes.
- [x] `grep -r migrateLegacyPrivateKeyFileIfNeeded` returns nothing.
- [x] `grep -r rouse_key.pem` returns nothing.

Closes #232.

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>