### PR TITLE
Fix #242: short-circuit Registering flash for onboarded device

### DIFF
--- a/app/src/main/java/com/rousecontext/app/ui/viewmodels/IntegrationSetupViewModel.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/viewmodels/IntegrationSetupViewModel.kt
@@ -132,6 +132,18 @@ class IntegrationSetupViewModel(
      * tapped "Get Started"), show a registering indicator and wait.
      */
     private suspend fun awaitRegistrationIfNeeded() {
+        // Issue #242: The DeviceRegistrationStatus StateFlow is initialized
+        // with `false` and only flipped to `true` asynchronously after the
+        // Koin graph reads the subdomain from disk. On an already-onboarded
+        // device there's a small window where `complete.value == false`
+        // despite the subdomain being present. Consult the cert store
+        // directly as the authoritative source of truth so we don't flash
+        // the "Registering" indicator on launches of a registered device.
+        if (certStore.getSubdomain() != null) {
+            // Keep StateFlow consumers in sync with the authoritative check.
+            registrationStatus.markComplete()
+            return
+        }
         if (!registrationStatus.complete.value) {
             _state.value = IntegrationSetupState.Provisioning(
                 SettingUpState(variant = SettingUpVariant.Registering)

--- a/app/src/test/java/com/rousecontext/app/ui/viewmodels/IntegrationSetupViewModelTest.kt
+++ b/app/src/test/java/com/rousecontext/app/ui/viewmodels/IntegrationSetupViewModelTest.kt
@@ -1,10 +1,12 @@
 package com.rousecontext.app.ui.viewmodels
 
 import android.app.Application
+import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
 import com.rousecontext.api.IntegrationStateStore
 import com.rousecontext.app.cert.LazyWebSocketFactory
 import com.rousecontext.app.state.DeviceRegistrationStatus
+import com.rousecontext.app.ui.screens.SettingUpVariant
 import com.rousecontext.tunnel.CertProvisioningFlow
 import com.rousecontext.tunnel.CertProvisioningResult
 import com.rousecontext.tunnel.CertificateStore
@@ -545,6 +547,124 @@ class IntegrationSetupViewModelTest {
             assertEquals(IntegrationSetupState.Complete, vm.state.value)
             coVerify(exactly = 1) { certProvisioningFlow.execute(any()) }
         }
+
+    @Test
+    fun `onboarded device with stale registration status skips Registering state`() =
+        runTest(testDispatcher) {
+            // Issue #242: DeviceRegistrationStatus starts `false` and flips
+            // async. If the subdomain is already on disk the VM must short-
+            // circuit rather than flashing "Registering" on a returning user.
+            val registrationStatus = DeviceRegistrationStatus(initiallyRegistered = false)
+            val vm = buildVm(
+                registrationStatus = registrationStatus,
+                subdomain = "cool-penguin"
+            )
+
+            vm.state.test {
+                assertEquals(IntegrationSetupState.Idle, awaitItem())
+                vm.startSetup("health")
+                awaitNoRegisteringUntilComplete()
+            }
+
+            assertTrue(
+                "awaitRegistrationIfNeeded must sync DeviceRegistrationStatus via markComplete",
+                registrationStatus.complete.value
+            )
+        }
+
+    @Test
+    fun `not-onboarded device with false registration still shows Registering`() =
+        runTest(testDispatcher) {
+            // Guardrail for the #242 fix: when the cert store has no
+            // subdomain AND DeviceRegistrationStatus is false, the VM must
+            // still display Registering and wait for markComplete().
+            var subdomainOnDisk: String? = null
+            val registrationStatus = DeviceRegistrationStatus(initiallyRegistered = false)
+            val vm = buildVm(
+                registrationStatus = registrationStatus,
+                subdomainProvider = { subdomainOnDisk }
+            )
+
+            vm.state.test {
+                assertEquals(IntegrationSetupState.Idle, awaitItem())
+                vm.startSetup("health")
+                awaitRegistering()
+                // Onboarding completes asynchronously: subdomain lands on disk
+                // and DeviceRegistrationStatus flips, VM proceeds to Complete.
+                subdomainOnDisk = "cool-penguin"
+                registrationStatus.markComplete()
+                advanceUntilIdle()
+                while (vm.state.value != IntegrationSetupState.Complete) awaitItem()
+                cancelAndIgnoreRemainingEvents()
+            }
+            assertEquals(IntegrationSetupState.Complete, vm.state.value)
+        }
+
+    /** Asserts the VM never emits Provisioning(Registering) on its way to Complete. */
+    private suspend fun ReceiveTurbine<IntegrationSetupState>.awaitNoRegisteringUntilComplete() {
+        while (true) {
+            val next = awaitItem()
+            if (next is IntegrationSetupState.Provisioning) {
+                assertTrue(
+                    "Must not pass through Registering for onboarded device; got $next",
+                    next.settingUpState.variant != SettingUpVariant.Registering
+                )
+            }
+            if (next == IntegrationSetupState.Complete) {
+                cancelAndIgnoreRemainingEvents()
+                return
+            }
+        }
+    }
+
+    /** Waits until the VM emits Provisioning(Registering). Fails on terminal state first. */
+    private suspend fun ReceiveTurbine<IntegrationSetupState>.awaitRegistering() {
+        while (true) {
+            val next = awaitItem()
+            if (next is IntegrationSetupState.Provisioning &&
+                next.settingUpState.variant == SettingUpVariant.Registering
+            ) {
+                return
+            }
+            assertTrue(
+                "Must pass through Registering when no subdomain + false registration; got $next",
+                next !is IntegrationSetupState.Complete && next !is IntegrationSetupState.Failed
+            )
+        }
+    }
+
+    private fun buildVm(
+        registrationStatus: DeviceRegistrationStatus,
+        subdomain: String? = null,
+        subdomainProvider: suspend () -> String? = { subdomain }
+    ): IntegrationSetupViewModel {
+        val certStore = mockk<CertificateStore> {
+            coEvery { getSubdomain() } coAnswers { subdomainProvider() }
+            coEvery { getIntegrationSecrets() } returns mapOf("health" to "brave-health")
+            coEvery { storeIntegrationSecrets(any()) } just Runs
+        }
+        val relayApiClient = mockk<RelayApiClient> {
+            coEvery { updateSecrets(any(), any()) } returns RelayApiResult.Success(
+                UpdateSecretsResponse(
+                    success = true,
+                    secrets = mapOf("health" to "brave-health")
+                )
+            )
+        }
+        val certProvisioningFlow = mockk<CertProvisioningFlow> {
+            coEvery { execute(any()) } returns CertProvisioningResult.AlreadyProvisioned
+        }
+        return IntegrationSetupViewModel(
+            stateStore = mockk(relaxed = true),
+            certProvisioningFlow = certProvisioningFlow,
+            lazyWebSocketFactory = mockk(relaxed = true),
+            registrationStatus = registrationStatus,
+            relayApiClient = relayApiClient,
+            certStore = certStore,
+            integrationIds = listOf("health"),
+            firebaseTokenProvider = { "test-firebase-token" }
+        )
+    }
 
     @Test
     fun `updateSecrets succeeds on second attempt`() = runTest(testDispatcher) {


### PR DESCRIPTION
## Summary

- `DeviceRegistrationStatus` is initialized with `false` and only flipped async after the Koin graph reads the subdomain from disk. On an already-onboarded device the StateFlow briefly reports `false` despite the subdomain being present, causing the IntegrationSetup UI to flash "Registering" on returning users.
- Fix: in `IntegrationSetupViewModel.awaitRegistrationIfNeeded`, consult `certStore.getSubdomain()` directly (authoritative, on-disk check). When the subdomain is present, sync the StateFlow via `markComplete()` and skip the Registering emission.
- Option C from the issue (narrowest fix, no changes to `DeviceRegistrationStatus` or `AppModule` wiring).

## Test plan

- [x] New unit test: `onboarded device with stale registration status skips Registering state` — VM built with `DeviceRegistrationStatus(initiallyRegistered = false)` plus a cert store returning a subdomain. Verifies state never passes through `SettingUpVariant.Registering` on its way to `Complete`, and that `registrationStatus.complete.value` ends up `true` (sync'd via `markComplete`).
- [x] New guardrail test: `not-onboarded device with false registration still shows Registering` — no subdomain on disk + registration status `false`. Verifies state DOES pass through Registering and waits for `markComplete()` before proceeding.
- [x] Verified fix by reverting main source and re-running: new test fails without the change, passes with it.
- [x] Existing 10 IntegrationSetupViewModel tests still pass.
- [x] `./gradlew :app:testDebugUnitTest ktlintCheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)