### PR TITLE
Fix #252: Integration scenarios batch B (audit + notification + MCP session)

### DIFF
--- a/app/src/test/java/com/rousecontext/app/integration/AuditRaceRegressionTest.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/AuditRaceRegressionTest.kt
@@ -1,0 +1,134 @@
+package com.rousecontext.app.integration
+
+import android.app.NotificationManager
+import androidx.test.core.app.ApplicationProvider
+import com.rousecontext.app.integration.harness.AppIntegrationTestHarness
+import com.rousecontext.app.integration.harness.TestEchoMcpIntegration
+import com.rousecontext.mcp.core.McpSession
+import com.rousecontext.mcp.core.TokenStore
+import com.rousecontext.notifications.SessionSummaryNotifier
+import com.rousecontext.notifications.audit.AuditDao
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Regression guard for issue #244 (batch B scenario 2).
+ *
+ * Before #244, [com.rousecontext.notifications.audit.RoomAuditListener]
+ * launched the DB insert on a separate scope (`scope.launch { insert }`).
+ * That meant `onToolCall` could return before the row committed, so the
+ * immediately-following ACTIVE → CONNECTED transition fired
+ * [SessionSummaryNotifier.observe]'s DAO query against an empty table
+ * and skipped the notification.
+ *
+ * With #244's fix the listener is `suspend`, the insert runs inline on
+ * the caller's dispatcher, and the row is durable before the HTTP
+ * response reaches the AI client. The assertion here is:
+ *
+ *   - do one tool call,
+ *   - drive the stream-drain transition on the *same* turn,
+ *   - then assert (within the observer's settle window) that the summary
+ *     notification IS posted. If #244 regresses the row lands after the
+ *     cursor query, the notification is silently skipped, and this test
+ *     fails.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class AuditRaceRegressionTest {
+
+    private val harness = AppIntegrationTestHarness(
+        integrationsFactory = { listOf(TestEchoMcpIntegration()) }
+    )
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var observerJob: Job? = null
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+        harness.start()
+    }
+
+    @After
+    fun tearDown() {
+        observerJob?.cancel()
+        scope.cancel()
+        harness.stop()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `summary notification fires when drain happens immediately after tool call`() =
+        runBlocking {
+            harness.provisionDevice()
+            harness.enableIntegrations(listOf(TestEchoMcpIntegration.ID))
+            harness.koin.get<com.rousecontext.api.NotificationSettingsProvider>()
+                .setPostSessionMode(com.rousecontext.api.PostSessionMode.SUMMARY)
+
+            val mcpSession: McpSession = harness.koin.get()
+            mcpSession.resolvePort()
+            val tokenStore: TokenStore = harness.koin.get()
+            val tokenPair = tokenStore.createTokenPair(
+                integrationId = TestEchoMcpIntegration.ID,
+                clientId = "race-test",
+                clientName = null
+            )
+
+            val summaryNotifier: SessionSummaryNotifier = harness.koin.get()
+            val tunnelState = TestTunnelState()
+            observerJob = scope.launch {
+                summaryNotifier.observe(tunnelState.tunnelStateFlow)
+            }
+            tunnelState.markActive()
+
+            McpTestDriver(
+                session = mcpSession,
+                hostHeader = "synth-${TestEchoMcpIntegration.ID}.example.test",
+                bearerToken = tokenPair.accessToken
+            ).use { driver ->
+                driver.initialize()
+                driver.callTool("echo", """{"message":"race"}""")
+            }
+            // Stream drains on the same turn the tool call returned. Pre-#244
+            // the insert would race the cursor and the notification would be
+            // silently dropped.
+            tunnelState.markDrained()
+            delay(OBSERVER_SETTLE_MS)
+
+            val auditDao: AuditDao = harness.koin.get()
+            assertEquals(
+                "exactly one audit row should be recorded",
+                1,
+                auditDao.count()
+            )
+
+            val nm = ApplicationProvider.getApplicationContext<android.app.Application>()
+                .getSystemService(NotificationManager::class.java)
+            val posted = shadowOf(nm).activeNotifications
+            assertTrue(
+                "session summary must be posted on the same cycle the tool call returned; " +
+                    "posted ids=${posted.map { it.id }}",
+                posted.any { it.id == SessionSummaryNotifier.NOTIFICATION_ID }
+            )
+        }
+
+    private companion object {
+        private const val OBSERVER_SETTLE_MS = 300L
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/integration/HealthToolSmokeTest.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/HealthToolSmokeTest.kt
@@ -1,0 +1,132 @@
+package com.rousecontext.app.integration
+
+import com.rousecontext.api.McpIntegration
+import com.rousecontext.app.integration.harness.AppIntegrationTestHarness
+import com.rousecontext.integrations.health.HealthConnectMcpServer
+import com.rousecontext.integrations.health.HealthConnectRepository
+import com.rousecontext.mcp.core.McpServerProvider
+import com.rousecontext.mcp.core.McpSession
+import com.rousecontext.mcp.core.TokenStore
+import com.rousecontext.notifications.audit.AuditDao
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Batch B scenario 6 (issue #252): Health Connect integration smoke.
+ *
+ * Proves the plumbing: a `tools/list` call on the real
+ * [HealthConnectIntegration] lights up against the harness's
+ * [com.rousecontext.app.integration.harness.HarnessFakeHealthConnectRepository],
+ * the request routes through [McpSession], and the audit listener
+ * records the call. Does NOT test every health tool — one round-trip is
+ * enough to catch wiring regressions (Koin missing the repository
+ * binding, [McpIntegration.path] typo, DSL tool registration failure).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class HealthToolSmokeTest {
+
+    // Held across the test so we can reach the underlying
+    // [com.rousecontext.app.integration.harness.HarnessFakeHealthConnectRepository]
+    // via the integration's provider.
+    private var fakeRepository: HealthConnectRepository? = null
+
+    private val harness = AppIntegrationTestHarness(
+        integrationsFactory = {
+            // The shipping `HealthConnectIntegration` hard-wires
+            // `RealHealthConnectRepository(context)` into its `McpServerProvider`,
+            // bypassing the Koin override. Construct the integration directly
+            // here with the harness fake so the health tool answers
+            // deterministically instead of short-circuiting on
+            // `HealthConnectUnavailableException`.
+            val repo = com.rousecontext.app.integration.harness.HarnessFakeHealthConnectRepository()
+            fakeRepository = repo
+            listOf(
+                object : McpIntegration {
+                    override val id = HEALTH_ID
+                    override val displayName = "Health Connect"
+                    override val description = "Test Health integration"
+                    override val path = "/health"
+                    override val provider: McpServerProvider = HealthConnectMcpServer(repo)
+                    override val onboardingRoute = "setup"
+                    override val settingsRoute = "settings"
+                    override suspend fun isAvailable(): Boolean = true
+                }
+            )
+        }
+    )
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+        harness.start()
+    }
+
+    @After
+    fun tearDown() {
+        harness.stop()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `list_record_types on HealthConnect round-trips and audits`() = runBlocking {
+        harness.provisionDevice()
+        harness.enableIntegrations(listOf(HEALTH_ID))
+
+        // Give the fake repo a non-trivial permission set so the tool's
+        // output is deterministic without being empty. `fakeRepository`
+        // is populated by [integrationsFactory] on harness start().
+        val fake = fakeRepository
+            as com.rousecontext.app.integration.harness.HarnessFakeHealthConnectRepository
+        fake.grantedPermissions = mutableSetOf("Steps", "HeartRate")
+
+        val mcpSession: McpSession = harness.koin.get()
+        mcpSession.resolvePort()
+        val tokenStore: TokenStore = harness.koin.get()
+        val tokenPair = tokenStore.createTokenPair(
+            integrationId = HEALTH_ID,
+            clientId = "health-smoke",
+            clientName = null
+        )
+
+        McpTestDriver(
+            session = mcpSession,
+            hostHeader = "synth-$HEALTH_ID.example.test",
+            bearerToken = tokenPair.accessToken
+        ).use { driver ->
+            driver.initialize()
+            val response = driver.callTool(
+                name = "list_record_types",
+                argumentsJson = buildJsonObject {
+                    put("include_granted_only", JsonPrimitive(false))
+                }.toString()
+            )
+            assertTrue(
+                "list_record_types must name at least one known record type " +
+                    "in the response JSON: $response",
+                response.contains("Steps") || response.contains("HeartRate")
+            )
+        }
+
+        val auditDao: AuditDao = harness.koin.get()
+        assertEquals("health smoke call must audit exactly one row", 1, auditDao.count())
+        val entry = auditDao.getById(auditDao.latestId()!!)!!
+        assertEquals("list_record_types", entry.toolName)
+    }
+
+    private companion object {
+        private const val HEALTH_ID = "health"
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/integration/McpSessionTestHarness.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/McpSessionTestHarness.kt
@@ -1,0 +1,234 @@
+package com.rousecontext.app.integration
+
+import com.rousecontext.api.IntegrationStateStore
+import com.rousecontext.app.integration.harness.AppIntegrationTestHarness
+import com.rousecontext.mcp.core.INTERNAL_TOKEN_HEADER
+import com.rousecontext.mcp.core.McpSession
+import com.rousecontext.tunnel.TunnelState
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.Socket
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Batch B (issue #252) drivers that feed an MCP conversation into the
+ * device's real [McpSession] Ktor server over loopback TCP.
+ *
+ * ## Why loopback instead of the relay?
+ *
+ * The "AI client → fixture relay → mux → [com.rousecontext.bridge.SessionHandler]
+ *  → [McpSession]" path is the production shape, and the scenarios in #252
+ * are *about* what happens on the device side of that pipe: audit DB
+ * rows, session-summary notifications, per-call notifications, tool
+ * dispatch. That's all downstream of the TLS + mux + bridge layers.
+ *
+ * Robolectric ships Conscrypt as the default TLS provider, and its client
+ * sockets silently drop the SNI extension from the ClientHello (see
+ * #262). The relay's passthrough router rejects connections without SNI,
+ * so a synthetic AI client can't reach the device's bridge at all under
+ * Robolectric — independently of `setHostname` /
+ * `SSLParameters.serverNames` / `Conscrypt.setHostname` / the
+ * `setUseEngineSocket(false)` legacy path.
+ *
+ * Batch B's assertions only care about the device-side half of the pipe,
+ * so we skip the relay + bridge layers entirely and call
+ * [McpSession]'s local HTTP server directly. The bridge layer is already
+ * end-to-end regression-guarded by the JVM-only
+ * [com.rousecontext.tunnel.integration.ClaudeFullFlowEndToEndTest] and
+ * [com.rousecontext.bridge.SessionHandlerTest]; batch C (#253) picks up
+ * the resilience scenarios once #262 is resolved.
+ *
+ * ## How it works
+ *
+ * The Koin graph's [McpSession] binds to an ephemeral loopback port at
+ * start and exposes its own [McpSession.internalToken] (see issue #177).
+ * The bridge normally injects that token on every inbound request as
+ * `X-Internal-Token`; here we do the same directly from the test.
+ *
+ * [McpTestDriver.doMcpCall] speaks raw HTTP/1.1 over [Socket] (no TLS,
+ * no SNI — the server is already plaintext on `127.0.0.1`) and returns
+ * the body + headers. Each call shares the same socket so the
+ * `Mcp-Session-Id` captured from `initialize` round-trips correctly.
+ */
+class McpTestDriver(
+    private val session: McpSession,
+    private val hostHeader: String,
+    private val bearerToken: String
+) : AutoCloseable {
+
+    private val socket: Socket = Socket("127.0.0.1", session.port)
+    private val input = socket.inputStream
+    private val output = socket.outputStream
+    private var mcpSessionId: String? = null
+
+    init {
+        socket.soTimeout = DEFAULT_SO_TIMEOUT_MS
+    }
+
+    /** Initialize the MCP session and capture `mcp-session-id`. */
+    fun initialize() {
+        val body = """{"jsonrpc":"2.0","id":1,"method":"initialize","params":""" +
+            """{"protocolVersion":"2025-03-26","capabilities":{},""" +
+            """"clientInfo":{"name":"synth","version":"1.0"}}}"""
+        val response = doMcpCall("/mcp", body)
+        require(response.statusCode == 200) {
+            "initialize should be 200, got ${response.statusCode}: ${response.body}"
+        }
+        mcpSessionId = response.headers["mcp-session-id"]
+            ?: error("initialize must set mcp-session-id header")
+        val notified = doMcpCall(
+            "/mcp",
+            """{"jsonrpc":"2.0","method":"notifications/initialized"}"""
+        )
+        require(notified.statusCode in 200..299) {
+            "notifications/initialized should succeed, got ${notified.statusCode}"
+        }
+    }
+
+    /** Call a tool by name. Returns the raw response body. */
+    fun callTool(name: String, argumentsJson: String = "{}", id: Int = 2): String {
+        val body = """{"jsonrpc":"2.0","id":$id,"method":"tools/call",""" +
+            """"params":{"name":"$name","arguments":$argumentsJson}}"""
+        val response = doMcpCall("/mcp", body)
+        require(response.statusCode == 200) {
+            "tools/call should be 200, got ${response.statusCode}: ${response.body}"
+        }
+        return response.body
+    }
+
+    override fun close() {
+        runCatching { socket.close() }
+    }
+
+    private data class McpHttpResponse(
+        val statusCode: Int,
+        val headers: Map<String, String>,
+        val body: String
+    )
+
+    @Suppress("LongMethod", "CyclomaticComplexMethod", "LoopWithTooManyJumpStatements")
+    private fun doMcpCall(path: String, body: String): McpHttpResponse {
+        val bodyBytes = body.toByteArray(Charsets.UTF_8)
+        val sb = StringBuilder()
+        sb.append("POST $path HTTP/1.1\r\n")
+        sb.append("Host: $hostHeader\r\n")
+        sb.append("Content-Type: application/json\r\n")
+        sb.append("Content-Length: ${bodyBytes.size}\r\n")
+        sb.append("Connection: keep-alive\r\n")
+        sb.append("$INTERNAL_TOKEN_HEADER: ${session.internalToken}\r\n")
+        sb.append("Authorization: Bearer $bearerToken\r\n")
+        mcpSessionId?.let { sb.append("Mcp-Session-Id: $it\r\n") }
+        sb.append("\r\n")
+        output.write(sb.toString().toByteArray(Charsets.UTF_8))
+        output.write(bodyBytes)
+        output.flush()
+
+        val reader = BufferedReader(InputStreamReader(input, Charsets.UTF_8))
+        val statusLine = reader.readLine() ?: error("no status line for $path")
+        require(statusLine.startsWith("HTTP/1.1")) { "bad status line: $statusLine" }
+        val statusCode = statusLine.split(" ")[1].toInt()
+
+        val headers = mutableMapOf<String, String>()
+        var contentLength = -1
+        var chunked = false
+        while (true) {
+            val line = reader.readLine() ?: break
+            if (line.isEmpty()) break
+            val colonIdx = line.indexOf(':')
+            if (colonIdx > 0) {
+                headers[line.substring(0, colonIdx).lowercase()] =
+                    line.substring(colonIdx + 1).trim()
+            }
+            val lc = line.lowercase()
+            if (lc.startsWith("content-length:")) {
+                contentLength = lc.substringAfter(":").trim().toInt()
+            }
+            if (lc.startsWith("transfer-encoding:") && lc.contains("chunked")) {
+                chunked = true
+            }
+        }
+
+        val body = when {
+            contentLength > 0 -> {
+                val buf = CharArray(contentLength)
+                var read = 0
+                while (read < contentLength) {
+                    val n = reader.read(buf, read, contentLength - read)
+                    if (n == -1) break
+                    read += n
+                }
+                String(buf, 0, read)
+            }
+            chunked -> readChunkedBody(reader)
+            else -> ""
+        }
+        return McpHttpResponse(statusCode, headers, body)
+    }
+
+    @Suppress("LoopWithTooManyJumpStatements")
+    private fun readChunkedBody(reader: BufferedReader): String {
+        val sb = StringBuilder()
+        while (true) {
+            val sizeLine = reader.readLine() ?: break
+            val chunkSize = sizeLine.trim().toInt(16)
+            if (chunkSize == 0) {
+                reader.readLine()
+                break
+            }
+            val buf = CharArray(chunkSize)
+            var read = 0
+            while (read < chunkSize) {
+                val n = reader.read(buf, read, chunkSize - read)
+                if (n == -1) break
+                read += n
+            }
+            sb.append(buf, 0, read)
+            reader.readLine()
+        }
+        return sb.toString()
+    }
+
+    companion object {
+        private const val DEFAULT_SO_TIMEOUT_MS = 15_000
+    }
+}
+
+/**
+ * Convenience: enable every integration in [integrationIds] on the real
+ * [IntegrationStateStore] so [com.rousecontext.app.registry.IntegrationProviderRegistry]
+ * returns a non-null provider for each.
+ */
+suspend fun AppIntegrationTestHarness.enableIntegrations(integrationIds: List<String>) {
+    val stateStore: IntegrationStateStore = koin.get()
+    integrationIds.forEach { stateStore.setUserEnabled(it, true) }
+    // Give the registry's reactive combine() one dispatcher tick to observe.
+    kotlinx.coroutines.yield()
+}
+
+/**
+ * Drive [com.rousecontext.tunnel.TunnelState] transitions to the notifier
+ * observers.
+ *
+ * - [tunnelStateFlow] feeds [com.rousecontext.notifications.SessionSummaryNotifier.observe]
+ *   so scenarios can drive ACTIVE → CONNECTED (stream drain) in the exact
+ *   moment the assertions need, without depending on a real tunnel.
+ */
+class TestTunnelState {
+    val tunnelStateFlow: MutableStateFlow<TunnelState> =
+        MutableStateFlow(TunnelState.DISCONNECTED)
+
+    /** Simulate "tunnel fully up, stream opened". */
+    fun markActive() {
+        tunnelStateFlow.value = TunnelState.CONNECTED
+        tunnelStateFlow.value = TunnelState.ACTIVE
+    }
+
+    /** Simulate "all streams drained while tunnel stays up". */
+    fun markDrained() {
+        tunnelStateFlow.value = TunnelState.CONNECTED
+    }
+
+    fun markDisconnected() {
+        tunnelStateFlow.value = TunnelState.DISCONNECTED
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/integration/MultiToolSessionTest.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/MultiToolSessionTest.kt
@@ -1,0 +1,126 @@
+package com.rousecontext.app.integration
+
+import android.app.NotificationManager
+import androidx.test.core.app.ApplicationProvider
+import com.rousecontext.api.NotificationSettingsProvider
+import com.rousecontext.api.PostSessionMode
+import com.rousecontext.app.integration.harness.AppIntegrationTestHarness
+import com.rousecontext.app.integration.harness.TestEchoMcpIntegration
+import com.rousecontext.mcp.core.McpSession
+import com.rousecontext.mcp.core.TokenStore
+import com.rousecontext.notifications.SessionSummaryNotifier
+import com.rousecontext.notifications.audit.AuditDao
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Batch B scenario 5 (issue #252): multiple tool calls in one session.
+ *
+ * Drives three `echo` calls back-to-back on the same HTTP connection
+ * (so the same `mcp-session-id`) and asserts the summary notification
+ * reports the correct count. Guards the "session summary aggregates per
+ * provider" behaviour when the AI client fires multiple tools before
+ * draining.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class MultiToolSessionTest {
+
+    private val harness = AppIntegrationTestHarness(
+        integrationsFactory = { listOf(TestEchoMcpIntegration()) }
+    )
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var observerJob: Job? = null
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+        harness.start()
+    }
+
+    @After
+    fun tearDown() {
+        observerJob?.cancel()
+        scope.cancel()
+        harness.stop()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `three tool calls in one session produce one summary with count 3`() = runBlocking {
+        harness.provisionDevice()
+        harness.enableIntegrations(listOf(TestEchoMcpIntegration.ID))
+        harness.koin.get<NotificationSettingsProvider>()
+            .setPostSessionMode(PostSessionMode.SUMMARY)
+
+        val mcpSession: McpSession = harness.koin.get()
+        mcpSession.resolvePort()
+        val tokenStore: TokenStore = harness.koin.get()
+        val tokenPair = tokenStore.createTokenPair(
+            integrationId = TestEchoMcpIntegration.ID,
+            clientId = "multi-test",
+            clientName = null
+        )
+
+        val summaryNotifier: SessionSummaryNotifier = harness.koin.get()
+        val tunnelState = TestTunnelState()
+        observerJob = scope.launch {
+            summaryNotifier.observe(tunnelState.tunnelStateFlow)
+        }
+        tunnelState.markActive()
+
+        McpTestDriver(
+            session = mcpSession,
+            hostHeader = "synth-${TestEchoMcpIntegration.ID}.example.test",
+            bearerToken = tokenPair.accessToken
+        ).use { driver ->
+            driver.initialize()
+            driver.callTool("echo", """{"message":"one"}""", id = 2)
+            driver.callTool("echo", """{"message":"two"}""", id = 3)
+            driver.callTool("echo", """{"message":"three"}""", id = 4)
+        }
+        tunnelState.markDrained()
+        delay(OBSERVER_SETTLE_MS)
+
+        val auditDao: AuditDao = harness.koin.get()
+        assertEquals("exactly three audit rows recorded", 3, auditDao.count())
+
+        val nm = ApplicationProvider.getApplicationContext<android.app.Application>()
+            .getSystemService(NotificationManager::class.java)
+        val posted = shadowOf(nm).activeNotifications
+        val summary = posted.firstOrNull { it.id == SessionSummaryNotifier.NOTIFICATION_ID }
+        assertTrue(
+            "session summary must be posted; got ids=${posted.map { it.id }}",
+            summary != null
+        )
+        // Title shape is "3 calls in 1 integration". The per-provider breakdown
+        // goes in the content text ("test 3"). Assert count reflects per-provider
+        // aggregation — one provider, three calls.
+        val text = summary!!.notification.extras.getCharSequence("android.text")?.toString() ?: ""
+        assertTrue(
+            "summary text should include the per-provider count; got '$text'",
+            text.contains("test") && text.contains("3")
+        )
+    }
+
+    private companion object {
+        private const val OBSERVER_SETTLE_MS = 300L
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/integration/PerCallNotifierModeTest.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/PerCallNotifierModeTest.kt
@@ -1,0 +1,143 @@
+package com.rousecontext.app.integration
+
+import android.app.NotificationManager
+import androidx.test.core.app.ApplicationProvider
+import com.rousecontext.api.NotificationSettingsProvider
+import com.rousecontext.api.PostSessionMode
+import com.rousecontext.app.integration.harness.AppIntegrationTestHarness
+import com.rousecontext.app.integration.harness.TestEchoMcpIntegration
+import com.rousecontext.mcp.core.McpSession
+import com.rousecontext.mcp.core.TokenStore
+import com.rousecontext.notifications.PerToolCallNotifier
+import com.rousecontext.notifications.SessionSummaryNotifier
+import com.rousecontext.notifications.audit.AuditDao
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Batch B scenario 3 (issue #252): `PostSessionMode.EACH_USAGE`.
+ *
+ * With per-call notifications enabled:
+ *   - [com.rousecontext.notifications.audit.RoomAuditListener] fires its
+ *     [com.rousecontext.notifications.audit.PerCallObserver] hook on each
+ *     insert; the observer is [PerToolCallNotifier] in production and
+ *     posts a notification per tool call.
+ *   - [SessionSummaryNotifier] sees the EACH_USAGE mode in its
+ *     `postForMode` switch and short-circuits, so no summary is posted
+ *     at drain.
+ *
+ * Audit rows are still recorded (per-call mode only changes user-facing
+ * notification shape, not storage).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class PerCallNotifierModeTest {
+
+    private val harness = AppIntegrationTestHarness(
+        integrationsFactory = { listOf(TestEchoMcpIntegration()) }
+    )
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var observerJob: Job? = null
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+        harness.start()
+    }
+
+    @After
+    fun tearDown() {
+        observerJob?.cancel()
+        scope.cancel()
+        harness.stop()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `each-usage mode posts per-call notification and skips session summary`() = runBlocking {
+        harness.provisionDevice()
+        harness.enableIntegrations(listOf(TestEchoMcpIntegration.ID))
+
+        // Ensure PerToolCallNotifier is resolved so RoomAuditListener's
+        // perCallObserver slot is populated at insert time.
+        harness.koin.get<PerToolCallNotifier>()
+
+        val settings: NotificationSettingsProvider = harness.koin.get()
+        settings.setPostSessionMode(PostSessionMode.EACH_USAGE)
+
+        val mcpSession: McpSession = harness.koin.get()
+        mcpSession.resolvePort()
+        val tokenStore: TokenStore = harness.koin.get()
+        val tokenPair = tokenStore.createTokenPair(
+            integrationId = TestEchoMcpIntegration.ID,
+            clientId = "per-call-test",
+            clientName = null
+        )
+
+        val summaryNotifier: SessionSummaryNotifier = harness.koin.get()
+        val tunnelState = TestTunnelState()
+        observerJob = scope.launch {
+            summaryNotifier.observe(tunnelState.tunnelStateFlow)
+        }
+        tunnelState.markActive()
+
+        McpTestDriver(
+            session = mcpSession,
+            hostHeader = "synth-${TestEchoMcpIntegration.ID}.example.test",
+            bearerToken = tokenPair.accessToken
+        ).use { driver ->
+            driver.initialize()
+            driver.callTool("echo", """{"message":"per-call"}""")
+        }
+        tunnelState.markDrained()
+        delay(OBSERVER_SETTLE_MS)
+
+        val auditDao: AuditDao = harness.koin.get()
+        assertEquals(
+            "audit row still recorded in EACH_USAGE mode",
+            1,
+            auditDao.count()
+        )
+
+        // Both notifiers share the same channel (SESSION_SUMMARY) but use
+        // disjoint id ranges: summary = 6000, per-call = 7000+. Shadow the
+        // NotificationManager to inspect posted ids.
+        val nm = ApplicationProvider.getApplicationContext<android.app.Application>()
+            .getSystemService(NotificationManager::class.java)
+        val posted = shadowOf(nm).activeNotifications
+        val summaryId = SessionSummaryNotifier.NOTIFICATION_ID
+        val perCallBase = PerToolCallNotifier.BASE_ID
+
+        assertTrue(
+            "per-call notification must be posted; got ids=${posted.map { it.id }}",
+            posted.any { it.id >= perCallBase }
+        )
+        assertFalse(
+            "session summary must NOT be posted in EACH_USAGE mode; " +
+                "got ids=${posted.map { it.id }}",
+            posted.any { it.id == summaryId }
+        )
+    }
+
+    private companion object {
+        private const val OBSERVER_SETTLE_MS = 300L
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/integration/SuppressedModeTest.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/SuppressedModeTest.kt
@@ -1,0 +1,121 @@
+package com.rousecontext.app.integration
+
+import android.app.NotificationManager
+import androidx.test.core.app.ApplicationProvider
+import com.rousecontext.api.NotificationSettingsProvider
+import com.rousecontext.api.PostSessionMode
+import com.rousecontext.app.integration.harness.AppIntegrationTestHarness
+import com.rousecontext.app.integration.harness.TestEchoMcpIntegration
+import com.rousecontext.mcp.core.McpSession
+import com.rousecontext.mcp.core.TokenStore
+import com.rousecontext.notifications.PerToolCallNotifier
+import com.rousecontext.notifications.SessionSummaryNotifier
+import com.rousecontext.notifications.audit.AuditDao
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Batch B scenario 4 (issue #252): `PostSessionMode.SUPPRESS`.
+ *
+ * Tool call completes, audit row is recorded, but neither the summary
+ * nor the per-call notifier should post anything. Guards the user
+ * preference "don't nag me" survives the full device-side pipeline.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class SuppressedModeTest {
+
+    private val harness = AppIntegrationTestHarness(
+        integrationsFactory = { listOf(TestEchoMcpIntegration()) }
+    )
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var observerJob: Job? = null
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+        harness.start()
+    }
+
+    @After
+    fun tearDown() {
+        observerJob?.cancel()
+        scope.cancel()
+        harness.stop()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `suppressed mode records audit but posts no notifications`() = runBlocking {
+        harness.provisionDevice()
+        harness.enableIntegrations(listOf(TestEchoMcpIntegration.ID))
+        harness.koin.get<PerToolCallNotifier>() // eager-init perCallObserver
+        harness.koin.get<NotificationSettingsProvider>()
+            .setPostSessionMode(PostSessionMode.SUPPRESS)
+
+        val mcpSession: McpSession = harness.koin.get()
+        mcpSession.resolvePort()
+        val tokenStore: TokenStore = harness.koin.get()
+        val tokenPair = tokenStore.createTokenPair(
+            integrationId = TestEchoMcpIntegration.ID,
+            clientId = "suppressed-test",
+            clientName = null
+        )
+
+        val summaryNotifier: SessionSummaryNotifier = harness.koin.get()
+        val tunnelState = TestTunnelState()
+        observerJob = scope.launch {
+            summaryNotifier.observe(tunnelState.tunnelStateFlow)
+        }
+        tunnelState.markActive()
+
+        McpTestDriver(
+            session = mcpSession,
+            hostHeader = "synth-${TestEchoMcpIntegration.ID}.example.test",
+            bearerToken = tokenPair.accessToken
+        ).use { driver ->
+            driver.initialize()
+            driver.callTool("echo", """{"message":"suppressed"}""")
+        }
+        tunnelState.markDrained()
+        delay(OBSERVER_SETTLE_MS)
+
+        val auditDao: AuditDao = harness.koin.get()
+        assertEquals("audit row still recorded in SUPPRESS mode", 1, auditDao.count())
+
+        val nm = ApplicationProvider.getApplicationContext<android.app.Application>()
+            .getSystemService(NotificationManager::class.java)
+        val posted = shadowOf(nm).activeNotifications
+        val summaryId = SessionSummaryNotifier.NOTIFICATION_ID
+        val perCallBase = PerToolCallNotifier.BASE_ID
+        val offending = posted.filter {
+            it.id == summaryId || it.id >= perCallBase
+        }
+        val offendingIds = offending.map { it.id }
+        assertTrue(
+            "no session-summary or per-call notifications in SUPPRESS mode; got ids=$offendingIds",
+            offending.isEmpty()
+        )
+    }
+
+    private companion object {
+        private const val OBSERVER_SETTLE_MS = 300L
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/integration/ToolCallHappyPathTest.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/ToolCallHappyPathTest.kt
@@ -1,0 +1,141 @@
+package com.rousecontext.app.integration
+
+import android.app.NotificationManager
+import androidx.test.core.app.ApplicationProvider
+import com.rousecontext.app.integration.harness.AppIntegrationTestHarness
+import com.rousecontext.app.integration.harness.TestEchoMcpIntegration
+import com.rousecontext.mcp.core.McpSession
+import com.rousecontext.mcp.core.TokenStore
+import com.rousecontext.notifications.SessionSummaryNotifier
+import com.rousecontext.notifications.audit.AuditDao
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Batch B happy-path scenario (issue #252, part 1).
+ *
+ * Drives an MCP tool call through the device-side half of the inbound
+ * path — exactly the surface the batch B assertions care about — and
+ * asserts the three seams this task tightens:
+ *
+ *   (a) the echo response round-trips end-to-end,
+ *   (b) a [com.rousecontext.notifications.audit.AuditEntry] row is
+ *       committed to the real Room DB via [RoomAuditListener], and
+ *   (c) ACTIVE → CONNECTED on the tunnel-state flow posts a
+ *       session-summary notification through the real
+ *       [SessionSummaryNotifier].
+ *
+ * See [McpSessionTestHarness] for why we skip the relay + bridge + TLS
+ * legs and call [McpSession]'s local HTTP server directly.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class ToolCallHappyPathTest {
+
+    private val harness = AppIntegrationTestHarness(
+        integrationsFactory = { listOf(TestEchoMcpIntegration()) }
+    )
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var observerJob: Job? = null
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(Dispatchers.Unconfined)
+        harness.start()
+    }
+
+    @After
+    fun tearDown() {
+        observerJob?.cancel()
+        scope.cancel()
+        harness.stop()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `echo round-trips, audits one entry, and posts session summary`() = runBlocking {
+        harness.provisionDevice()
+        harness.enableIntegrations(listOf(TestEchoMcpIntegration.ID))
+        // Robolectric persists DataStore across tests in the same JVM; pin the
+        // mode explicitly to avoid leakage from a prior scenario.
+        harness.koin.get<com.rousecontext.api.NotificationSettingsProvider>()
+            .setPostSessionMode(com.rousecontext.api.PostSessionMode.SUMMARY)
+
+        val mcpSession: McpSession = harness.koin.get()
+        mcpSession.resolvePort()
+
+        val tokenStore: TokenStore = harness.koin.get()
+        val tokenPair = tokenStore.createTokenPair(
+            integrationId = TestEchoMcpIntegration.ID,
+            clientId = "test-client",
+            clientName = "Test Client"
+        )
+
+        val summaryNotifier: SessionSummaryNotifier = harness.koin.get()
+        val tunnelState = TestTunnelState()
+        observerJob = scope.launch {
+            summaryNotifier.observe(tunnelState.tunnelStateFlow)
+        }
+        tunnelState.markActive()
+
+        McpTestDriver(
+            session = mcpSession,
+            hostHeader = "synth-${TestEchoMcpIntegration.ID}.example.test",
+            bearerToken = tokenPair.accessToken
+        ).use { driver ->
+            driver.initialize()
+            val body = driver.callTool(
+                name = "echo",
+                argumentsJson = """{"message":"hello-from-happy-path"}"""
+            )
+            assertTrue(
+                "echo should round-trip the input message: $body",
+                body.contains("hello-from-happy-path")
+            )
+        }
+
+        // Audit row committed synchronously (issue #244 made the listener
+        // `suspend`, so by the time `callTool` returned the row is durable).
+        val auditDao: AuditDao = harness.koin.get()
+        val latestId = auditDao.latestId()
+        assertNotNull("latestId must be non-null after a tool call", latestId)
+        val entry = auditDao.getById(latestId!!)
+        assertNotNull("audit entry for latest id must be retrievable", entry)
+        assertEquals("echo", entry!!.toolName)
+
+        // Drive stream-drain → summary notification post.
+        tunnelState.markDrained()
+        delay(OBSERVER_SETTLE_MS)
+
+        val nm = ApplicationProvider.getApplicationContext<android.app.Application>()
+            .getSystemService(NotificationManager::class.java)
+        val posted = shadowOf(nm).activeNotifications
+        assertTrue(
+            "session summary notification must be posted on ACTIVE→CONNECTED transition; " +
+                "posted ids=${posted.map { it.id }}",
+            posted.any { it.id == SessionSummaryNotifier.NOTIFICATION_ID }
+        )
+    }
+
+    private companion object {
+        private const val OBSERVER_SETTLE_MS = 300L
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/integration/harness/AppIntegrationTestHarness.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/harness/AppIntegrationTestHarness.kt
@@ -121,7 +121,15 @@ class AppIntegrationTestHarness(
      */
     private val initialSubdomain: String = "smoke-device",
     private val relayHostname: String = "relay.test.local",
-    private val baseDomain: String = "relay.test.local"
+    private val baseDomain: String = "relay.test.local",
+    /**
+     * Integrations to register in place of the production list. Issue #252
+     * scenarios need at least one integration wired into the Koin graph
+     * (the default `emptyList()` leaves `ProviderRegistry` empty, so the
+     * MCP session has no tools to call). Callers provide a lightweight
+     * in-test integration like `TestEchoMcpIntegration` here.
+     */
+    private val integrationsFactory: () -> List<McpIntegration> = { emptyList() }
 ) {
     // ---- Lifecycle state ----
     // All set by [start], cleared by [stop]. The backing storage is intentionally
@@ -237,7 +245,8 @@ class AppIntegrationTestHarness(
                     relayHostname = relayHostname,
                     baseDomain = baseDomain,
                     harnessScope = newHarnessScope,
-                    fakeHealth = newFakeHealth
+                    fakeHealth = newFakeHealth,
+                    integrations = integrationsFactory()
                 )
             )
         }.koin
@@ -287,14 +296,15 @@ class AppIntegrationTestHarness(
  * `@Suppress("LongMethod")` — split into sub-functions would obscure the
  * parallel structure with [appModule].
  */
-@Suppress("LongMethod")
+@Suppress("LongMethod", "LongParameterList")
 private fun buildTestOverrides(
     ca: TestCertificateAuthority,
     relayPort: Int,
     relayHostname: String,
     baseDomain: String,
     harnessScope: CoroutineScope,
-    fakeHealth: HarnessFakeHealthConnectRepository
+    fakeHealth: HarnessFakeHealthConnectRepository,
+    integrations: List<McpIntegration>
 ) = module {
     // --- appScope override ---
     // Production supplies a main-dispatcher scope from RouseApplication. We
@@ -316,12 +326,11 @@ private fun buildTestOverrides(
     // not shipped in Robolectric's SDK 33 runtime, so Koin start would
     // cascade-fail with `NoSuchAlgorithmException: AndroidKeyStore`.
     //
-    // Replace the list with an empty one here; scenario tests that need a
-    // specific integration wired in should extend this override further.
-    // `TestMcpIntegration` from the debug source set is intentionally not
-    // pulled in because it would cascade into `debugModules()` wiring that
-    // `startKoin` in this harness does not load.
-    single<List<McpIntegration>> { emptyList() }
+    // Tests that need providers wired into the MCP session pass them via
+    // `AppIntegrationTestHarness(integrationsFactory = { ... })`; the
+    // default is the empty list (onboarding / cert-provisioning scenarios
+    // don't talk to the MCP server and don't need providers).
+    single<List<McpIntegration>> { integrations }
 
     // --- DeviceKeyManager ---
     // AndroidKeystoreDeviceKeyManager requires the AndroidKeyStore JCA
@@ -421,6 +430,21 @@ private fun buildTestOverrides(
     // production graph reads this qualifier to pick the relay endpoint.
     single<String>(named("relayUrl")) {
         "wss://$relayHostname:$relayPort/ws"
+    }
+
+    // --- AuditListener override (no FieldEncryptor) ---
+    // Production's `RoomAuditListener` encrypts sensitive fields with a
+    // [com.rousecontext.notifications.FieldEncryptor] backed by the
+    // AndroidKeyStore JCA provider, which isn't shipped in Robolectric's
+    // SDK 33 runtime. `RoomAuditListener` already takes a nullable
+    // [FieldEncryptor], so we just re-bind the AuditListener with `null`.
+    single<com.rousecontext.mcp.core.AuditListener> {
+        com.rousecontext.notifications.audit.RoomAuditListener(
+            dao = get(),
+            fieldEncryptor = null,
+            perCallObserver = get(),
+            mcpRequestDao = get()
+        )
     }
 }
 

--- a/app/src/test/java/com/rousecontext/app/integration/harness/TestEchoMcpIntegration.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/harness/TestEchoMcpIntegration.kt
@@ -1,0 +1,69 @@
+package com.rousecontext.app.integration.harness
+
+import com.rousecontext.api.McpIntegration
+import com.rousecontext.mcp.core.McpServerProvider
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Minimal [McpIntegration] exposing a couple of deterministic tools
+ * (`echo` and `get_time`) for batch B integration scenarios (issue #252).
+ *
+ * Scenarios use this integration as the "test" one they connect through
+ * so their assertions don't depend on any production integration's
+ * behaviour. The production debug-only `TestMcpIntegration` lives in the
+ * `debug` source set which `:app:test` cannot see; this is a replica
+ * scoped to the test harness.
+ */
+class TestEchoMcpIntegration : McpIntegration {
+    override val id = ID
+    override val displayName = "Test"
+    override val description = "Harness-only echo/get_time tools for integration scenarios"
+    override val path = "/test"
+    override val onboardingRoute = "setup"
+    override val settingsRoute = "settings"
+    override val provider: McpServerProvider = TestEchoProvider()
+    override suspend fun isAvailable(): Boolean = true
+
+    companion object {
+        const val ID: String = "test"
+    }
+}
+
+private class TestEchoProvider : McpServerProvider {
+    override val id = TestEchoMcpIntegration.ID
+    override val displayName = "Test"
+
+    override fun register(server: Server) {
+        server.addTool(
+            name = "echo",
+            description = "Echoes the input message",
+            inputSchema = ToolSchema(
+                properties = buildJsonObject {
+                    put(
+                        "message",
+                        buildJsonObject {
+                            put("type", JsonPrimitive("string"))
+                        }
+                    )
+                },
+                required = listOf("message")
+            )
+        ) { request ->
+            val message = request.params.arguments
+                ?.get("message")?.jsonPrimitive?.content ?: ""
+            CallToolResult(content = listOf(TextContent(message)))
+        }
+        server.addTool(
+            name = "get_time",
+            description = "Returns a fixed string (tests don't care about the value)"
+        ) {
+            CallToolResult(content = listOf(TextContent("synth-time")))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Six app-wired integration scenarios for the device-side inbound tool-call path land here:

- **Happy-path** — echo tool round-trips, one audit row lands in Room, session-summary notification posts on ACTIVE → CONNECTED.
- **Audit-race regression** (#244 guard) — summary still fires when the mux stream drains on the same turn the tool call returned. Pre-#244 the fire-and-forget audit insert lost the race.
- **Per-call notifier path** (`PostSessionMode.EACH_USAGE`) — one per-call notification per tool call, no summary, audit still recorded.
- **Suppressed mode** (`PostSessionMode.SUPPRESS`) — zero notifications, audit still recorded.
- **Multi-tool session** — three `echo` calls in one session, summary shows the aggregated count.
- **Health Connect smoke** — `list_record_types` against the harness fake repository audits and returns data.

Each test drives the real `McpSession` Ktor server via loopback TCP, with the production `RoomAuditListener`, `SessionSummaryNotifier`, and `PerToolCallNotifier` wired through the real Koin graph (the #250 scaffold). Tunnel-state transitions that drive the summary observer come from a test-owned `MutableStateFlow<TunnelState>`.

## What isn't here

The original design had a synthetic AI client reaching through the relay's SNI passthrough. That path runs into a Robolectric + Conscrypt quirk — the ClientHello comes out with no SNI extension regardless of which SNI-setting API you call — so the relay rejects every AI-client connection under the Robolectric test runner. Filed as #262, blocking the reach-through shape for both batch B and batch C (#253).

Until #262 is resolved the relay → bridge → TLS legs remain regression-guarded in `:core:tunnel:jvmTest`'s `ClaudeFullFlowEndToEndTest`. All of batch B's user-visible assertions are downstream of that layer, so they land here unblocked.

## Harness changes

- `AppIntegrationTestHarness(integrationsFactory = …)` constructor parameter lets scenarios inject a list of `McpIntegration`s into the Koin graph. Default stays `emptyList()` so batch A keeps passing unchanged.
- Re-bind `RoomAuditListener` with `fieldEncryptor = null`. Production wires it through `FieldEncryptor`, whose AndroidKeyStore dependency isn't shipped in Robolectric's SDK 33 runtime.
- New `TestEchoMcpIntegration` in the harness package provides `echo` + `get_time`, mirroring the debug-source-set `TestMcpIntegration` that `:app:test` can't see.

## Test plan

- [x] `./gradlew :app:integrationTest` — 14 tests pass (6 new batch B + 8 existing batch A + smoke).
- [x] `./gradlew :app:testDebugUnitTest :notifications:testDebugUnitTest` — pass.
- [x] `./gradlew ktlintCheck` — pass.
- [x] `./gradlew detekt` — 77 weighted issues, matches baseline before this PR (no new violations from this change).
- [ ] CI green on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)