### PR TITLE
Fix #253: Integration scenarios batch C (resilience)

### DIFF
--- a/app/src/test/java/com/rousecontext/app/integration/CertRotationMidSessionTest.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/CertRotationMidSessionTest.kt
@@ -1,0 +1,129 @@
+package com.rousecontext.app.integration
+
+import com.rousecontext.app.integration.TunnelTestSupport.awaitState
+import com.rousecontext.app.integration.harness.AppIntegrationTestHarness
+import com.rousecontext.tunnel.CertRenewalFlow
+import com.rousecontext.tunnel.CertificateStore
+import com.rousecontext.tunnel.CsrSigner
+import com.rousecontext.tunnel.DeviceKeyManager
+import com.rousecontext.tunnel.RenewalResult
+import com.rousecontext.tunnel.TunnelState
+import java.security.Signature
+import java.util.Base64
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression guard for #237-class bugs: running [CertRenewalFlow] against a
+ * *live* tunnel must not knock the existing WebSocket off the relay, and the
+ * renewal must still present a valid client cert on `/renew`.
+ *
+ * The assertions line up with the #253 spec:
+ *  - Existing tunnel stays [TunnelState.CONNECTED] across the renewal.
+ *  - Relay sees exactly one `/renew` call with a valid mTLS client cert.
+ *  - Client cert on disk has actually rolled (server cert is stub-cert
+ *    byte-identical, documented in [CertRotationIntegrationTest]).
+ *
+ * #262 note: no synthetic AI client, all assertions are device-side.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CertRotationMidSessionTest {
+
+    private val harness = AppIntegrationTestHarness()
+    private lateinit var tunnelScope: CoroutineScope
+
+    @Before
+    fun setUp() {
+        harness.start()
+        tunnelScope = TunnelTestSupport.newTunnelScope()
+    }
+
+    @After
+    fun tearDown() {
+        tunnelScope.cancel()
+        harness.stop()
+    }
+
+    @Test
+    fun `renewWithMtls while tunnel is CONNECTED does not tear it down`() = runBlocking {
+        harness.provisionDevice()
+
+        val certStore: CertificateStore = harness.koin.get()
+        val initialClientCert = certStore.getClientCertificate()
+        assertEquals(
+            "renew call count starts at zero",
+            0,
+            harness.fixture.renewCalls()
+        )
+
+        val tunnel = TunnelTestSupport.buildTunnel(harness, tunnelScope)
+        tunnel.connect(TunnelTestSupport.tunnelUrl(harness))
+        tunnel.awaitState(
+            TunnelState.CONNECTED,
+            timeout = TunnelTestSupport.DEFAULT_CONNECT_TIMEOUT
+        )
+
+        // --- Trigger renewal while the tunnel is live. ---
+        val renewalFlow: CertRenewalFlow = harness.koin.get()
+        val keyManager: DeviceKeyManager = harness.koin.get()
+        val csrSigner = CsrSigner { csrDer ->
+            val signature = Signature.getInstance("SHA256withECDSA")
+            signature.initSign(keyManager.getOrCreateKeyPair().private)
+            signature.update(csrDer)
+            Base64.getEncoder().encodeToString(signature.sign())
+        }
+
+        val renewalResult = renewalFlow.renewWithMtls(csrSigner = csrSigner)
+        assertTrue(
+            "renewal must succeed, got: $renewalResult",
+            renewalResult is RenewalResult.Success
+        )
+
+        // --- Tunnel must still be CONNECTED. ---
+        //
+        // Renewal goes over a fresh /renew HTTPS request and does NOT touch
+        // the device's WebSocket to the relay. If the tunnel flipped out of
+        // CONNECTED here, something in the cert rotation path would have
+        // side-effected the TunnelClient's socket — exactly the class of
+        // regression this test guards against.
+        assertEquals(
+            "tunnel must stay CONNECTED across cert renewal (mid-session)",
+            TunnelState.CONNECTED,
+            tunnel.state.value
+        )
+
+        // --- Renewal counter + mTLS proof-of-possession. ---
+        assertEquals(
+            "relay should see exactly one /renew call",
+            1,
+            harness.fixture.renewCalls()
+        )
+        assertEquals(
+            "/renew must carry the device's mTLS client certificate",
+            true,
+            harness.fixture.lastRequestHadClientCert("/renew")
+        )
+
+        // --- Client cert must have rolled. ---
+        // The test relay runs with a stub ACME client (returns "stub-cert"
+        // verbatim), so the server cert is byte-identical across renewals.
+        // The client cert, signed by the device-CA, does roll. Verifying
+        // that gives us real coverage of the new-cert-surfaces path.
+        val renewedClientCert = certStore.getClientCertificate()
+        assertNotEquals(
+            "renewed client cert must differ from the initial one — otherwise " +
+                "cert rotation silently kept the stale cert",
+            initialClientCert,
+            renewedClientCert
+        )
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/integration/HalfOpenReconnectTest.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/HalfOpenReconnectTest.kt
@@ -1,0 +1,104 @@
+package com.rousecontext.app.integration
+
+import com.rousecontext.app.integration.TunnelTestSupport.awaitState
+import com.rousecontext.app.integration.harness.AppIntegrationTestHarness
+import com.rousecontext.tunnel.TunnelState
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression guard for issue #243 — "always reconnect on FCM wake, never
+ * trust stale tunnel state".
+ *
+ * Setup: provision the device and bring the tunnel to [TunnelState.CONNECTED].
+ * The relay-side WebSocket is then killed *without a close frame* via
+ * [com.rousecontext.tunnel.integration.TestRelayManager.killActiveWebsocket],
+ * which leaves the device-side TCP socket in a half-open state — reads hang
+ * forever, writes silently succeed into the kernel's send buffer, and
+ * nothing at the application layer knows the peer is gone.
+ *
+ * The mux keepalive job then fires periodic Pings (accelerated timings in
+ * [TunnelTestSupport]: 2s interval, 1s timeout, 3 misses) and drives the
+ * tunnel to [TunnelState.DISCONNECTED] once the miss budget is exhausted.
+ * That is the #243 behaviour we want to lock in — before the fix, a stale
+ * ACTIVE state would have caused the next FCM wake to skip the reconnect
+ * entirely.
+ *
+ * Scope note (#262): this scenario exercises the device-side TunnelClient
+ * recovery path only. It does not route a synthetic AI client through the
+ * relay, so the Conscrypt SNI suppression that blocks batch B is not in
+ * play here.
+ */
+@RunWith(RobolectricTestRunner::class)
+class HalfOpenReconnectTest {
+
+    private val harness = AppIntegrationTestHarness()
+    private lateinit var tunnelScope: CoroutineScope
+
+    @Before
+    fun setUp() {
+        harness.start()
+        tunnelScope = TunnelTestSupport.newTunnelScope()
+    }
+
+    @After
+    fun tearDown() {
+        tunnelScope.cancel()
+        harness.stop()
+    }
+
+    @Test
+    fun `half-open socket drives tunnel to DISCONNECTED via keepalive`() = runBlocking {
+        val subdomain = harness.provisionDevice()
+
+        val tunnel = TunnelTestSupport.buildTunnel(harness, tunnelScope)
+        tunnel.connect(TunnelTestSupport.tunnelUrl(harness))
+
+        // Sanity: tunnel reached CONNECTED through the real TLS + WS handshake.
+        assertEquals(
+            "tunnel should be CONNECTED before we kill the relay-side socket",
+            TunnelState.CONNECTED,
+            tunnel.state.value
+        )
+
+        // Drop the relay-side WebSocket without a close frame. The device-side
+        // TCP socket is now half-open — see [TcpDropProxy] in the
+        // `:core:tunnel:jvmTest` HalfOpenDetectionTest for the kernel-level
+        // semantics that match this behaviour.
+        val killed = harness.fixture.killActiveWebsocket(subdomain)
+        assertTrue(
+            "fixture must have had a live session registered to kill",
+            killed
+        )
+
+        // Keepalive should detect the dead connection within
+        // ~interval * max_misses = ~6s; allow generous margin for the
+        // Robolectric JVM + subprocess scheduling jitter.
+        tunnel.awaitState(TunnelState.DISCONNECTED, timeout = 30.seconds)
+
+        assertEquals(
+            "tunnel must transition to DISCONNECTED after keepalive exhaustion",
+            TunnelState.DISCONNECTED,
+            tunnel.state.value
+        )
+
+        // The FCM wake hook (sendFcmWake) is orthogonal to this regression:
+        // #243 is about NOT skipping reconnect on FCM wake when state looks
+        // ACTIVE. We've verified the pre-condition (state correctly moves to
+        // DISCONNECTED after a silent drop), which is what the decider in
+        // :work/WakeReconnectDecider.kt already handles with a Reconnect
+        // action. Calling sendFcmWake here would require re-driving the
+        // device-side TunnelForegroundService, which is covered in
+        // IdleTimeoutWakeTest below.
+        harness.fixture.sendFcmWake(subdomain)
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/integration/IdleTimeoutWakeTest.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/IdleTimeoutWakeTest.kt
@@ -1,0 +1,95 @@
+package com.rousecontext.app.integration
+
+import com.rousecontext.app.integration.TunnelTestSupport.awaitState
+import com.rousecontext.app.integration.harness.AppIntegrationTestHarness
+import com.rousecontext.tunnel.TunnelState
+import com.rousecontext.work.WakeAction
+import com.rousecontext.work.WakeReconnectDecider
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Verifies the "idle timeout + wake" recovery: after a relay-side idle
+ * disconnect, a fresh FCM wake must drive the tunnel back to [TunnelState.CONNECTED].
+ *
+ * We don't have a clean way to advance the relay's 5-minute idle wall clock
+ * from the test process, so [com.rousecontext.tunnel.integration.TestRelayManager.killActiveWebsocket]
+ * is used as the closest proxy — it produces the same device-side observation
+ * an idle-timeout close would (the relay drops the socket without warning).
+ * The important assertion is that the *decider* (#243) picks a
+ * [WakeAction.Reconnect] and a subsequent `connect` brings the tunnel back up.
+ *
+ * #262 note: this scenario is entirely device-side, no synthetic AI client
+ * is routed through the relay's SNI passthrough.
+ */
+@RunWith(RobolectricTestRunner::class)
+class IdleTimeoutWakeTest {
+
+    private val harness = AppIntegrationTestHarness()
+    private lateinit var tunnelScope: CoroutineScope
+
+    @Before
+    fun setUp() {
+        harness.start()
+        tunnelScope = TunnelTestSupport.newTunnelScope()
+    }
+
+    @After
+    fun tearDown() {
+        tunnelScope.cancel()
+        harness.stop()
+    }
+
+    @Test
+    fun `fcm wake after idle-equivalent drop reconnects the tunnel`() = runBlocking {
+        val subdomain = harness.provisionDevice()
+
+        val tunnel = TunnelTestSupport.buildTunnel(harness, tunnelScope)
+        val url = TunnelTestSupport.tunnelUrl(harness)
+        tunnel.connect(url)
+        tunnel.awaitState(
+            TunnelState.CONNECTED,
+            timeout = TunnelTestSupport.DEFAULT_CONNECT_TIMEOUT
+        )
+
+        // --- Simulate relay-side idle close. ---
+        // The production relay would have closed the WebSocket after ~5 min
+        // idle; here we drop it synchronously so the test finishes in seconds.
+        assertTrue(harness.fixture.killActiveWebsocket(subdomain))
+
+        // Mux keepalive drives the local state machine to DISCONNECTED.
+        tunnel.awaitState(TunnelState.DISCONNECTED, timeout = 30.seconds)
+
+        // Relay delivers an FCM wake to the device: bump the fixture-side
+        // counter and drive the decider, mimicking what FcmReceiver would
+        // do inside TunnelForegroundService.
+        harness.fixture.sendFcmWake(subdomain)
+        val action = WakeReconnectDecider.decide(tunnel, healthCheckTimeout = 2.seconds)
+        assertTrue(
+            "decider must pick Reconnect on a dead tunnel, got $action",
+            action is WakeAction.Reconnect
+        )
+
+        // Service would call connect on the Reconnect action — do so directly.
+        tunnel.connect(url)
+        tunnel.awaitState(
+            TunnelState.CONNECTED,
+            timeout = TunnelTestSupport.DEFAULT_CONNECT_TIMEOUT
+        )
+
+        assertEquals(
+            "tunnel must be CONNECTED again after the FCM wake + reconnect cycle",
+            TunnelState.CONNECTED,
+            tunnel.state.value
+        )
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/integration/RapidFcmWakesTest.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/RapidFcmWakesTest.kt
@@ -1,0 +1,107 @@
+package com.rousecontext.app.integration
+
+import com.rousecontext.app.integration.TunnelTestSupport.awaitState
+import com.rousecontext.app.integration.harness.AppIntegrationTestHarness
+import com.rousecontext.tunnel.TunnelState
+import com.rousecontext.work.WakeAction
+import com.rousecontext.work.WakeReconnectDecider
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Five FCM wakes fired within 2s must not drive the client into a connect
+ * loop / socket-spawning frenzy.
+ *
+ * Production's dedup lives in two layers:
+ *  1. [WakeReconnectDecider]: returns [WakeAction.AlreadyConnecting] when the
+ *     tunnel is already mid-handshake.
+ *  2. [com.rousecontext.work.TunnelForegroundService.launchReconnect]:
+ *     skips if `reconnectJob?.isActive == true`.
+ *
+ * Under Robolectric we can't drive the foreground service directly (its
+ * `startForeground` requires an Activity context), so this test exercises
+ * layer (1) only. The CONNECTED path in the decider always returns
+ * [WakeAction.Reconnect], mirroring the #243 fix that removed the
+ * health-check-based "skip" altogether (a CONNECTED-state ACTIVE tunnel is
+ * no guarantee the relay still has a WS mapping for it).
+ *
+ * Assertions:
+ *  - All 5 fixture wake calls complete without error; the relay counts them.
+ *  - The decider behaves consistently under rapid-fire invocation — never
+ *    throws, always returns a valid [WakeAction].
+ *  - The tunnel finishes in CONNECTED regardless of wake volume.
+ *
+ * Layer (2) dedup is regression-guarded at `work` via
+ * `WakeReconnectDeciderTest` / `TunnelForegroundServiceTest` — it's a pure
+ * JVM unit-test because it needs direct control over `reconnectJob`.
+ *
+ * #262 note: device-side only.
+ */
+@RunWith(RobolectricTestRunner::class)
+class RapidFcmWakesTest {
+
+    private val harness = AppIntegrationTestHarness()
+    private lateinit var tunnelScope: CoroutineScope
+
+    @Before
+    fun setUp() {
+        harness.start()
+        tunnelScope = TunnelTestSupport.newTunnelScope()
+    }
+
+    @After
+    fun tearDown() {
+        tunnelScope.cancel()
+        harness.stop()
+    }
+
+    @Test
+    fun `five rapid fcm wakes plus decider calls keep tunnel stable`() = runBlocking {
+        val subdomain = harness.provisionDevice()
+        val tunnel = TunnelTestSupport.buildTunnel(harness, tunnelScope)
+        val url = TunnelTestSupport.tunnelUrl(harness)
+        tunnel.connect(url)
+        tunnel.awaitState(
+            TunnelState.CONNECTED,
+            timeout = TunnelTestSupport.DEFAULT_CONNECT_TIMEOUT
+        )
+
+        // Fire 5 fixture wakes + decider calls in a tight loop (<2s).
+        val actions = mutableListOf<WakeAction>()
+        repeat(FIVE_WAKES) {
+            harness.fixture.sendFcmWake(subdomain)
+            actions += WakeReconnectDecider.decide(tunnel, 1.seconds)
+        }
+
+        // The decider must not throw, and each action must be a valid
+        // [WakeAction] subtype — the production service treats Reconnect /
+        // AlreadyConnecting as the only two valid outcomes.
+        assertEquals(FIVE_WAKES, actions.size)
+        assertTrue(
+            "every action must be Reconnect or AlreadyConnecting, got $actions",
+            actions.all { it is WakeAction.Reconnect || it is WakeAction.AlreadyConnecting }
+        )
+
+        // Tunnel stays CONNECTED — calling the decider does not itself
+        // disturb tunnel state; the reconnect action is the *service*'s
+        // responsibility to execute.
+        assertEquals(
+            "tunnel stays CONNECTED after rapid decider calls",
+            TunnelState.CONNECTED,
+            tunnel.state.value
+        )
+    }
+
+    private companion object {
+        const val FIVE_WAKES = 5
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/integration/RelayRestartTest.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/RelayRestartTest.kt
@@ -1,0 +1,90 @@
+package com.rousecontext.app.integration
+
+import com.rousecontext.app.integration.TunnelTestSupport.awaitState
+import com.rousecontext.app.integration.harness.AppIntegrationTestHarness
+import com.rousecontext.tunnel.TunnelState
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Verifies the client recovers after the relay process is killed and
+ * restarted. The device-side keepalive should detect the dead connection via
+ * ping timeout and flip the tunnel to [TunnelState.DISCONNECTED]; once the
+ * relay is back up and an FCM wake arrives, the device reconnects cleanly.
+ *
+ * Procedure:
+ *  1. Provision + bring tunnel up.
+ *  2. `relayManager.stop()` — terminate the relay subprocess without warning.
+ *  3. Assert tunnel reaches DISCONNECTED via mux keepalive.
+ *  4. `relayManager.start(port)` — restart the relay on the same port so the
+ *     device's cached `wss://relay.test.local:<port>/ws` still works.
+ *  5. Simulate FCM wake and call connect; assert CONNECTED.
+ *
+ * #262 note: client-side only; no AI-client SNI handling.
+ */
+@RunWith(RobolectricTestRunner::class)
+class RelayRestartTest {
+
+    private val harness = AppIntegrationTestHarness()
+    private lateinit var tunnelScope: CoroutineScope
+
+    @Before
+    fun setUp() {
+        harness.start()
+        tunnelScope = TunnelTestSupport.newTunnelScope()
+    }
+
+    @After
+    fun tearDown() {
+        tunnelScope.cancel()
+        harness.stop()
+    }
+
+    @Test
+    fun `client reconnects after relay subprocess restart`() = runBlocking {
+        val subdomain = harness.provisionDevice()
+
+        val tunnel = TunnelTestSupport.buildTunnel(harness, tunnelScope)
+        val url = TunnelTestSupport.tunnelUrl(harness)
+        tunnel.connect(url)
+        tunnel.awaitState(
+            TunnelState.CONNECTED,
+            timeout = TunnelTestSupport.DEFAULT_CONNECT_TIMEOUT
+        )
+
+        // --- Kill the relay subprocess. ---
+        // The device-side WebSocket is now pointed at a dead TCP peer. The
+        // kernel will RST on the next write, and keepalive Pings will fail
+        // fast — so we expect DISCONNECTED well within the 30s bound.
+        harness.fixture.stop()
+
+        tunnel.awaitState(TunnelState.DISCONNECTED, timeout = 30.seconds)
+
+        // --- Restart the relay on the same port. ---
+        // The fixture's cert files / base config remain on disk from the
+        // original [start], so this is effectively a process recycle.
+        harness.fixture.start(harness.relayPort)
+
+        // --- FCM wake + reconnect. ---
+        harness.fixture.sendFcmWake(subdomain)
+        tunnel.connect(url)
+        tunnel.awaitState(
+            TunnelState.CONNECTED,
+            timeout = TunnelTestSupport.DEFAULT_CONNECT_TIMEOUT
+        )
+
+        assertEquals(
+            "tunnel must be CONNECTED again after relay restart + wake",
+            TunnelState.CONNECTED,
+            tunnel.state.value
+        )
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/integration/TunnelTestSupport.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/TunnelTestSupport.kt
@@ -1,0 +1,275 @@
+package com.rousecontext.app.integration
+
+import android.app.Application
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.rousecontext.app.integration.harness.AppIntegrationTestHarness
+import com.rousecontext.tunnel.DeviceKeyManager
+import com.rousecontext.tunnel.TunnelClient
+import com.rousecontext.tunnel.TunnelClientImpl
+import com.rousecontext.tunnel.TunnelState
+import com.rousecontext.tunnel.WebSocketFactory
+import com.rousecontext.tunnel.WebSocketHandle
+import com.rousecontext.tunnel.WebSocketListener
+import java.io.File
+import java.net.InetAddress
+import java.security.KeyStore
+import java.security.PrivateKey
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509KeyManager
+import javax.net.ssl.X509TrustManager
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeout
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okio.ByteString
+import okio.ByteString.Companion.toByteString
+
+/**
+ * Resilience / reconnect scenario plumbing for batch C (#253).
+ *
+ * The harness used across batch A / B wires the production `TunnelClient` into
+ * the Koin graph via `LazyWebSocketFactory`, which in turn uses the production
+ * `MtlsWebSocketFactory`. That factory reads the client cert from filesDir
+ * (fine — [provisionDevice] writes it there) but does NOT install a DNS
+ * override for the fixture hostname (`relay.test.local`), trust the fixture
+ * CA, or accept the loose loopback SAN. Wiring that override directly into
+ * `appModule` would leak test behaviour into production.
+ *
+ * Instead, batch C's tests drive a dedicated [TunnelClientImpl] constructed
+ * here with a test-friendly [WebSocketFactory]. The factory re-uses the exact
+ * device-cert layout production persists (cert PEM + relay CA PEM in filesDir,
+ * private key from [DeviceKeyManager]) so the regressions the test guards
+ * against — half-open reconnect, cert-rotation survival, stream-failure
+ * containment — still exercise the same TLS / mux code paths the production
+ * tunnel does.
+ *
+ * Keepalive is accelerated (2s interval, 1s per-ping timeout, 3 misses) so
+ * half-open detection takes ~9s instead of the production ~120s. Matches
+ * `:core:tunnel:jvmTest/HalfOpenDetectionTest`.
+ */
+internal object TunnelTestSupport {
+
+    private const val KEEPALIVE_INTERVAL_MS = 2_000L
+    private const val KEEPALIVE_TIMEOUT_MS = 1_000L
+    private const val KEEPALIVE_MAX_MISSES = 3
+
+    /** Default CONNECTED-state assertion bound — generous for relay startup. */
+    val DEFAULT_CONNECT_TIMEOUT: Duration = 15.seconds
+
+    /**
+     * Build a [TunnelClientImpl] wired against the fixture relay.
+     *
+     * Uses the harness's [AppIntegrationTestHarness.certificateAuthority] for
+     * trust and reads the freshly-provisioned client cert from filesDir. Caller
+     * must have run [provisionDevice] before constructing so the disk layout
+     * is populated.
+     *
+     * [ownerScope] is the lifecycle scope for the tunnel's internal jobs — use
+     * a scope owned by the test (cancelled in `@After`) so nothing leaks.
+     */
+    fun buildTunnel(
+        harness: AppIntegrationTestHarness,
+        ownerScope: CoroutineScope
+    ): TunnelClientImpl {
+        val context: Context = androidContext(harness)
+        val deviceKeyManager: DeviceKeyManager = harness.koin.get()
+        val fixtureCa: X509Certificate = harness.certificateAuthority.caCert
+
+        val wsFactory = FixtureMtlsWebSocketFactory(
+            context = context,
+            deviceKeyManager = deviceKeyManager,
+            fixtureCa = fixtureCa
+        )
+        return TunnelClientImpl(
+            scope = ownerScope,
+            webSocketFactory = wsFactory,
+            keepaliveIntervalMillis = KEEPALIVE_INTERVAL_MS,
+            keepaliveTimeoutMillis = KEEPALIVE_TIMEOUT_MS,
+            keepaliveMaxMisses = KEEPALIVE_MAX_MISSES
+        )
+    }
+
+    /** Build the wss:// URL the tunnel should connect to (fixture loopback). */
+    fun tunnelUrl(harness: AppIntegrationTestHarness): String =
+        "wss://relay.test.local:${harness.relayPort}/ws"
+
+    /**
+     * Spawn a fresh scope for the tunnel's jobs. Call [CoroutineScope.cancel]
+     * on the returned scope in test teardown to clean up.
+     */
+    fun newTunnelScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /** Suspend until [target] is seen on [TunnelClient.state], with a timeout. */
+    suspend fun TunnelClient.awaitState(target: TunnelState, timeout: Duration) {
+        withTimeout(timeout) { state.first { it == target } }
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    private fun androidContext(harness: AppIntegrationTestHarness): Context =
+        ApplicationProvider.getApplicationContext<Application>()
+}
+
+/**
+ * OkHttp-backed [WebSocketFactory] configured to reach the harness's fixture
+ * relay.
+ *
+ * - Reads the provisioned client cert chain + relay CA from filesDir, exactly
+ *   like production's [com.rousecontext.app.cert.MtlsWebSocketFactory]. The
+ *   device private key comes from the harness's [DeviceKeyManager] override.
+ * - Trusts the fixture CA (production trusts the JVM default store, which
+ *   rejects the fixture's CN=Test CA root).
+ * - DNS override maps the fixture hostname to 127.0.0.1, and a loose hostname
+ *   verifier accepts the non-FQDN SAN the fixture cert uses. Collocated
+ *   rationale in [AppIntegrationTestHarness]'s DNS / hostnameVerifier comments.
+ */
+private class FixtureMtlsWebSocketFactory(
+    private val context: Context,
+    private val deviceKeyManager: DeviceKeyManager,
+    private val fixtureCa: X509Certificate
+) : WebSocketFactory {
+
+    override fun connect(url: String, listener: WebSocketListener): WebSocketHandle {
+        val client = buildClient()
+        val request = Request.Builder().url(url).build()
+        val ws = client.newWebSocket(
+            request,
+            object : okhttp3.WebSocketListener() {
+                override fun onOpen(webSocket: WebSocket, response: Response) {
+                    listener.onOpen()
+                }
+
+                override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
+                    listener.onBinaryMessage(bytes.toByteArray())
+                }
+
+                override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                    listener.onClosing(code, reason)
+                    webSocket.close(code, reason)
+                }
+
+                override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                    listener.onFailure(t)
+                }
+            }
+        )
+        return OkHttpHandle(ws)
+    }
+
+    private fun buildClient(): OkHttpClient {
+        val certChain = loadCertChain() ?: error(
+            "FixtureMtlsWebSocketFactory: no client cert on disk — did you call provisionDevice()?"
+        )
+        val privateKey = deviceKeyManager.getOrCreateKeyPair().private
+        val keyManager = DirectKeyManager(privateKey, certChain.toTypedArray())
+
+        val trustStore = KeyStore.getInstance(KeyStore.getDefaultType())
+        trustStore.load(null, null)
+        trustStore.setCertificateEntry("fixture-ca", fixtureCa)
+        val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        tmf.init(trustStore)
+        val trustManager = tmf.trustManagers
+            .first { it is X509TrustManager } as X509TrustManager
+
+        val sslContext = SSLContext.getInstance("TLS").apply {
+            init(arrayOf(keyManager), tmf.trustManagers, null)
+        }
+
+        return OkHttpClient.Builder()
+            .sslSocketFactory(sslContext.socketFactory, trustManager)
+            .hostnameVerifier { _, _ -> true }
+            .dns { _ -> listOf(InetAddress.getByName("127.0.0.1")) }
+            // Short ping interval keeps OkHttp-level keepalive snappy; the
+            // mux-level keepalive is what actually drives state transitions.
+            .pingInterval(1, TimeUnit.SECONDS)
+            .build()
+    }
+
+    private fun loadCertChain(): List<X509Certificate>? {
+        val certFile = File(context.filesDir, CLIENT_CERT_PEM_FILE)
+        if (!certFile.exists()) return null
+        return parsePemCertificates(certFile.readText()).takeIf { it.isNotEmpty() }
+    }
+
+    private fun parsePemCertificates(pem: String): List<X509Certificate> {
+        val factory = CertificateFactory.getInstance("X.509")
+        val certs = mutableListOf<X509Certificate>()
+        val regex = Regex(
+            "-----BEGIN CERTIFICATE-----(.+?)-----END CERTIFICATE-----",
+            RegexOption.DOT_MATCHES_ALL
+        )
+        for (match in regex.findAll(pem)) {
+            val base64 = match.groupValues[1].replace("\\s".toRegex(), "")
+            val der = Base64.getDecoder().decode(base64)
+            val cert = factory.generateCertificate(der.inputStream()) as X509Certificate
+            certs.add(cert)
+        }
+        return certs
+    }
+
+    private companion object {
+        const val CLIENT_CERT_PEM_FILE = "rouse_client_cert.pem"
+    }
+}
+
+/**
+ * Direct [X509KeyManager] that hands the SSL engine the [privateKey] + chain
+ * without any intermediate keystore. Same rationale as production's
+ * `DirectX509KeyManager`: hardware-backed keys can't be round-tripped through
+ * a PKCS12 / BKS store.
+ *
+ * Tests use a software-backed EC key ([com.rousecontext.app.integration.harness
+ * .SoftwareDeviceKeyManager]) but the same key manager shape works there too.
+ */
+private class DirectKeyManager(
+    private val privateKey: PrivateKey,
+    private val chain: Array<X509Certificate>
+) : X509KeyManager {
+    private val alias = "device"
+
+    override fun chooseClientAlias(
+        keyType: Array<out String>?,
+        issuers: Array<out java.security.Principal>?,
+        socket: java.net.Socket?
+    ): String = alias
+
+    override fun chooseServerAlias(
+        keyType: String?,
+        issuers: Array<out java.security.Principal>?,
+        socket: java.net.Socket?
+    ): String? = null
+
+    override fun getCertificateChain(alias: String?): Array<X509Certificate> = chain
+
+    override fun getClientAliases(
+        keyType: String?,
+        issuers: Array<out java.security.Principal>?
+    ): Array<String> = arrayOf(alias)
+
+    override fun getServerAliases(
+        keyType: String?,
+        issuers: Array<out java.security.Principal>?
+    ): Array<String> = emptyArray()
+
+    override fun getPrivateKey(alias: String?): PrivateKey = privateKey
+}
+
+private class OkHttpHandle(private val ws: WebSocket) : WebSocketHandle {
+    override suspend fun sendBinary(data: ByteArray): Boolean = ws.send(data.toByteString())
+    override suspend fun sendText(text: String): Boolean = ws.send(text)
+    override suspend fun close(code: Int, reason: String) {
+        ws.close(code, reason)
+    }
+}


### PR DESCRIPTION
## Summary

Integration-tier resilience scenarios from #253 (umbrella #247). Five of six scenarios implemented against `AppIntegrationTestHarness`; the stream-failure-containment one is deferred to #266 because it needs a new fixture hook (relay-side mux ERROR injection).

- **HalfOpenReconnectTest** — #243 regression guard: relay-side WS drop without a close frame drives the tunnel to DISCONNECTED via mux keepalive.
- **IdleTimeoutWakeTest** — idle-equivalent drop plus synthetic FCM wake recovers to CONNECTED through `WakeReconnectDecider`.
- **CertRotationMidSessionTest** — #237-class guard: `renewWithMtls` while the tunnel is live doesn't knock it off; client cert rolls; `/renew` carries the mTLS client cert.
- **RelayRestartTest** — killing + restarting the relay subprocess lets the client detect via keepalive and reconnect on wake.
- **RapidFcmWakesTest** — 5 FCM wakes + decider calls in <2s keep the tunnel stable. (Service-level `reconnectJob` dedup is covered at `:work`'s unit-test tier.)

`TunnelTestSupport` wires a test-friendly `WebSocketFactory` (OkHttp + DNS loopback override, fixture-CA trust, on-disk cert) so scenarios drive a real `TunnelClientImpl` with accelerated keepalive instead of mutating the production factory in Koin. #262's Conscrypt SNI issue is not in play because these scenarios only exercise the device-side TLS egress, not the relay's SNI passthrough for synthetic AI clients.

## Test plan

- [x] `:app:integrationTest` green for all five new tests
- [x] `:app:testDebugUnitTest` — unchanged, green
- [x] `:core:tunnel:jvmTest` + `:core:tunnel:integrationTest` — unchanged, green
- [x] `ktlintCheck` — green
- [x] `detekt` — pre-existing 77 issues on main, no new issues in added files

Closes #253. Defers one scenario to #266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)