### PR TITLE
Fix #266: StreamFailureDoesNotKillTunnelTest via test-mode emit-stream-error hook

### DIFF
--- a/core/testfixtures/src/main/kotlin/com/rousecontext/tunnel/integration/TestRelayFixture.kt
+++ b/core/testfixtures/src/main/kotlin/com/rousecontext/tunnel/integration/TestRelayFixture.kt
@@ -421,6 +421,43 @@ class TestRelayManager(
         requireAdmin().killActiveWebsocket(subdomain)
 
     /**
+     * Push a synthetic mux OPEN frame to the device on the mux session for
+     * [subdomain]. Used by the batch-C "stream failure" scenarios that need an
+     * already-open inbound stream before injecting failure — see issue #266.
+     *
+     * `streamId` must not collide with an existing stream on the session. The
+     * relay's `MuxDemux` on the device side will surface the new stream on
+     * `TunnelClient.incomingSessions`.
+     *
+     * Requires [enableTestMode] = true. Returns true if the relay accepted the
+     * request; false means no mux session is currently registered for the
+     * subdomain.
+     */
+    fun openStream(subdomain: String, streamId: Int, sniHostname: String = ""): Boolean =
+        requireAdmin().openStream(subdomain, streamId, sniHostname)
+
+    /**
+     * Push a synthetic mux ERROR frame onto an already-open stream. Tests use
+     * this to exercise the "stream-level failure does not tear down the
+     * tunnel" regression (issue #266). The device-side `MuxDemux` will tear
+     * down the stream and propagate the error but MUST leave the tunnel
+     * itself in [com.rousecontext.tunnel.TunnelState.CONNECTED] (or ACTIVE
+     * if other streams are still open).
+     *
+     * [errorCode] is a `MuxErrorCode` value (1..=4); the default
+     * `STREAM_RESET` (2) mirrors the most common relay-originated failure.
+     *
+     * Requires [enableTestMode] = true. Returns true if the relay accepted
+     * the request.
+     */
+    fun emitStreamError(
+        subdomain: String,
+        streamId: Int,
+        errorCode: Int = STREAM_RESET_CODE,
+        message: String = ""
+    ): Boolean = requireAdmin().emitStreamError(subdomain, streamId, errorCode, message)
+
+    /**
      * Record a synthetic FCM wake for [subdomain] on the relay. This does NOT
      * actually wake a device — it populates the relay-side test metrics so
      * assertions in integration tests can confirm a wake was requested. The
@@ -563,6 +600,14 @@ class TestRelayManager(
 
     companion object {
         private const val RELAY_STARTUP_TIMEOUT_MS = 10_000L
+
+        /**
+         * `MuxErrorCode.STREAM_RESET`, mirrored from the relay / Kotlin tunnel
+         * side so tests don't have to import the tunnel module (the fixture
+         * lives in `:core:testfixtures`, which intentionally does not depend
+         * on `:core:tunnel`).
+         */
+        const val STREAM_RESET_CODE: Int = 2
     }
 }
 
@@ -630,6 +675,68 @@ class TestRelayAdmin(private val port: Int) {
      */
     fun sendFcmWake(subdomain: String) {
         post("/test/fcm-wake?subdomain=${subdomain.urlEncoded()}", "")
+    }
+
+    /**
+     * Push a synthetic OPEN frame to the device on the mux session for
+     * [subdomain]. Wraps `POST /test/open-stream`. See the [TestRelayManager]
+     * counterpart for scenario notes.
+     *
+     * Returns true if the relay enqueued the frame, false if no session is
+     * registered for the subdomain.
+     */
+    fun openStream(subdomain: String, streamId: Int, sniHostname: String): Boolean {
+        val path = buildString {
+            append("/test/open-stream?subdomain=")
+            append(subdomain.urlEncoded())
+            append("&stream_id=")
+            append(streamId)
+            if (sniHostname.isNotEmpty()) {
+                append("&sni=")
+                append(sniHostname.urlEncoded())
+            }
+        }
+        val (code, body) = postExpectingAny(path)
+        return when (code) {
+            HTTP_OK -> parseBoolField(body, "opened")
+            HTTP_NOT_FOUND -> false
+            else -> fail("test-mode admin returned HTTP $code on open-stream: $body")
+        }
+    }
+
+    /**
+     * Push a synthetic ERROR frame onto an already-open mux stream. Wraps
+     * `POST /test/emit-stream-error`.
+     *
+     * Returns true if the relay enqueued the frame, false if no session is
+     * registered for the subdomain.
+     */
+    fun emitStreamError(
+        subdomain: String,
+        streamId: Int,
+        errorCode: Int,
+        message: String
+    ): Boolean {
+        val path = buildString {
+            append("/test/emit-stream-error?subdomain=")
+            append(subdomain.urlEncoded())
+            append("&stream_id=")
+            append(streamId)
+            append("&code=")
+            append(errorCode)
+            if (message.isNotEmpty()) {
+                append("&message=")
+                append(message.urlEncoded())
+            }
+        }
+        val (code, body) = postExpectingAny(path)
+        return when (code) {
+            HTTP_OK -> parseBoolField(body, "emitted")
+            HTTP_NOT_FOUND -> false
+            else -> fail(
+                "test-mode admin returned HTTP $code on emit-stream-error: $body"
+            )
+        }
     }
 
     /** Number of `/register` calls observed since the relay started. */
@@ -718,6 +825,24 @@ class TestRelayAdmin(private val port: Int) {
         return readBody(conn)
     }
 
+    /**
+     * Like [post] but returns both the HTTP status code and the response body
+     * without failing on non-2xx responses. Used by admin handlers that
+     * deliberately return 404 for "subdomain not registered" so callers can
+     * distinguish that from a protocol error.
+     */
+    private fun postExpectingAny(path: String): Pair<Int, String> {
+        val conn = openConnection(path).apply {
+            requestMethod = "POST"
+            doOutput = true
+        }
+        conn.outputStream.use { it.write(ByteArray(0)) }
+        val code = conn.responseCode
+        val stream = if (code in 200..299) conn.inputStream else conn.errorStream
+        val body = stream?.bufferedReader()?.use { it.readText() }.orEmpty()
+        return code to body
+    }
+
     private fun openConnection(path: String): HttpURLConnection {
         val url: URL = URI.create(baseUrl + path).toURL()
         return (url.openConnection() as HttpURLConnection).apply {
@@ -759,6 +884,8 @@ class TestRelayAdmin(private val port: Int) {
     companion object {
         private const val HTTP_TIMEOUT_MS = 3_000
         private const val READY_POLL_MS = 50L
+        private const val HTTP_OK = 200
+        private const val HTTP_NOT_FOUND = 404
     }
 }
 

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/StreamFailureDoesNotKillTunnelTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/StreamFailureDoesNotKillTunnelTest.kt
@@ -1,0 +1,366 @@
+package com.rousecontext.tunnel.integration
+
+import com.rousecontext.tunnel.MuxStream
+import com.rousecontext.tunnel.TunnelClientImpl
+import com.rousecontext.tunnel.TunnelState
+import java.io.File
+import java.security.KeyStore
+import java.security.cert.X509Certificate
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+
+/**
+ * Regression guard for "stream-level failure does not kill the tunnel"
+ * (issue #266, part of the batch-C scenarios tracked by #253).
+ *
+ * Scenario:
+ *   1. Device connects to the relay, establishes a mux session.
+ *   2. Relay pushes a synthetic inbound stream (via `POST /test/open-stream`)
+ *      and the device observes it on `TunnelClient.incomingSessions`.
+ *   3. Relay emits a synthetic `MuxFrame.Error` for that stream (via
+ *      `POST /test/emit-stream-error`).
+ *   4. The device MUST tear the stream down but MUST leave the tunnel state
+ *      at [TunnelState.CONNECTED]; a second stream opened the same way
+ *      afterwards MUST still be accepted.
+ *
+ * The `/test/open-stream` hook exists because driving the relay's real
+ * passthrough path — an AI-client TLS handshake with SNI routing — is
+ * blocked under Robolectric by Conscrypt's SNI suppression (issue #262).
+ * Emitting a synthetic OPEN + ERROR pair is a narrow workaround that
+ * exercises the device-side `MuxDemux` error-handling code path without
+ * needing a real AI client.
+ *
+ * Related coverage:
+ *   - `EndToEndSessionTest` (same module) covers OPEN/CLOSE/ERROR end-to-end
+ *     through real SNI routing at the protocol layer.
+ *   - This test pins the tunnel-state invariant specifically: a single
+ *     stream's ERROR MUST NOT propagate up into a tunnel disconnect.
+ */
+@Tag("integration")
+@Timeout(value = 120, unit = TimeUnit.SECONDS)
+class StreamFailureDoesNotKillTunnelTest {
+
+    companion object {
+        private const val RELAY_HOSTNAME = "localhost"
+        private const val DEVICE_SUBDOMAIN = "stream-failure"
+
+        /** Accelerated keepalive so a mis-wired keepalive loop shows up fast. */
+        private const val KEEPALIVE_INTERVAL_MS = 2_000L
+        private const val KEEPALIVE_TIMEOUT_MS = 1_000L
+        private const val KEEPALIVE_MAX_MISSES = 3
+
+        /**
+         * Wall-clock budget for the relay to register the mux session with
+         * its `SessionRegistry` after the WebSocket upgrade. Bounded; if it
+         * ever exceeds this the test fails loudly instead of flaking.
+         */
+        private const val SESSION_REGISTRATION_TIMEOUT_MS = 5_000L
+        private const val POLL_MS = 100L
+
+        private const val FIRST_STREAM_ID = 1001
+        private const val SECOND_STREAM_ID = 1002
+
+        /**
+         * A stream id that is never OPENed on the device side; used by
+         * [waitForRelaySession] as a harmless probe (the device silently
+         * drops ERROR frames for unknown streams — see `MuxDemux.handleFrame`).
+         */
+        private const val PROBE_STREAM_ID: Int = 0x7FFF_FFFE
+
+        /** How long to observe [TunnelState.CONNECTED] after the ERROR frame. */
+        private const val POST_ERROR_OBSERVATION_MS = 2_000L
+    }
+
+    private lateinit var tempDir: File
+    private lateinit var ca: TestCertificateAuthority
+    private lateinit var relayManager: TestRelayManager
+    private var relayPort: Int = 0
+
+    private val caCert: X509Certificate get() = ca.caCert
+    private val deviceKeyStore: KeyStore get() = ca.deviceKeyStore
+
+    @BeforeEach
+    fun setUp() {
+        val relayBinary = findRelayBinary()
+        assumeTrue(
+            relayBinary.exists() && relayBinary.canExecute(),
+            "Relay binary not found. Build with: cd relay && cargo build --features test-mode"
+        )
+
+        tempDir = File.createTempFile("stream-failure-", "")
+        tempDir.delete()
+        tempDir.mkdirs()
+
+        ca = TestCertificateAuthority(tempDir, RELAY_HOSTNAME, DEVICE_SUBDOMAIN)
+        ca.generate()
+
+        relayManager = TestRelayManager(
+            tempDir = tempDir,
+            relayHostname = RELAY_HOSTNAME,
+            enableTestMode = true
+        )
+        relayPort = findFreePort()
+        relayManager.start(relayPort)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        if (::relayManager.isInitialized) {
+            relayManager.stop()
+        }
+        if (::tempDir.isInitialized && tempDir.exists()) {
+            tempDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun `stream ERROR frame does not disconnect tunnel and subsequent stream is accepted`() =
+        runBlocking {
+            val tunnelScope = CoroutineScope(Dispatchers.IO)
+            val tunnelClient = connectTunnelClient(tunnelScope)
+            try {
+                assertEquals(
+                    TunnelState.CONNECTED,
+                    tunnelClient.state.value,
+                    "Tunnel should be CONNECTED before injecting stream-level failure"
+                )
+
+                val firstStream = openSyntheticStream(
+                    tunnelScope,
+                    tunnelClient,
+                    FIRST_STREAM_ID,
+                    FIRST_STREAM_UID
+                )
+                val firstDrainJob = drainInBackground(tunnelScope, firstStream)
+                // The OPEN frame above flipped the tunnel to ACTIVE. Wait for
+                // that transition to land so the upcoming "no DISCONNECTED"
+                // observation isn't confused by the brief CONNECTED->ACTIVE
+                // blip that MuxDemux emits via stateFlow.drop(1).
+                withTimeoutOrNull(ACTIVE_WAIT) {
+                    tunnelClient.state.first { it == TunnelState.ACTIVE }
+                }
+
+                emitErrorOnFirstStream()
+
+                // Core invariant under test: a stream-level ERROR frame MUST
+                // NOT knock the tunnel into DISCONNECTING / DISCONNECTED. The
+                // tunnel may briefly stay ACTIVE (if MuxDemux has not yet
+                // decremented the stream count) and then flip back to
+                // CONNECTED — both are acceptable. Anything else is the
+                // regression.
+                val neverDisconnected = stateNeverReachedDisconnectedFor(
+                    tunnelClient,
+                    POST_ERROR_OBSERVATION_MS
+                )
+                assertTrue(
+                    neverDisconnected,
+                    "Tunnel must not transition to DISCONNECTED after a stream-level " +
+                        "ERROR frame; observed state=${tunnelClient.state.value}"
+                )
+                // Once MuxDemux has processed the ERROR the stream count
+                // returns to zero and we should be back in CONNECTED.
+                val backToConnected = withTimeoutOrNull(ACTIVE_WAIT) {
+                    tunnelClient.state.first { it == TunnelState.CONNECTED }
+                }
+                assertEquals(
+                    TunnelState.CONNECTED,
+                    backToConnected,
+                    "Tunnel should return to CONNECTED once the errored stream is torn down"
+                )
+                firstDrainJob.cancel()
+
+                val secondStream = openSyntheticStream(
+                    tunnelScope,
+                    tunnelClient,
+                    SECOND_STREAM_ID,
+                    SECOND_STREAM_UID
+                )
+                assertEquals(SECOND_STREAM_UID, secondStream.id)
+                assertTunnelReachesActiveThenCleansUp(tunnelClient, secondStream)
+            } finally {
+                runCatching { tunnelClient.disconnect() }
+                tunnelScope.coroutineContext.cancelChildren()
+            }
+        }
+
+    /**
+     * Ask the relay to push a synthetic OPEN frame for [streamId] and wait
+     * until [TunnelClient.incomingSessions] surfaces the matching stream.
+     * The async/await dance pre-arms the collector before the OPEN is sent
+     * so MuxDemux's emission cannot race ahead of us.
+     */
+    private suspend fun openSyntheticStream(
+        scope: CoroutineScope,
+        client: TunnelClientImpl,
+        streamId: Int,
+        expectedUid: UInt
+    ): MuxStream {
+        val deferred = scope.async(Dispatchers.IO) {
+            withTimeout(STREAM_WAIT) {
+                client.incomingSessions.first { it.id == expectedUid }
+            }
+        }
+        val opened = relayManager.openStream(
+            subdomain = DEVICE_SUBDOMAIN,
+            streamId = streamId,
+            sniHostname = "ai.test"
+        )
+        assertTrue(opened, "relay should have enqueued the OPEN frame for $streamId")
+        return deferred.await()
+    }
+
+    private fun emitErrorOnFirstStream() {
+        val sent = relayManager.emitStreamError(
+            subdomain = DEVICE_SUBDOMAIN,
+            streamId = FIRST_STREAM_ID,
+            errorCode = TestRelayManager.STREAM_RESET_CODE,
+            message = "synthetic stream reset"
+        )
+        assertTrue(sent, "relay should have enqueued the ERROR frame")
+    }
+
+    /**
+     * Confirms the tunnel reaches ACTIVE while the second stream is live,
+     * then closes it and waits for the back-transition to CONNECTED so the
+     * finally-block disconnect doesn't race with stream-count bookkeeping.
+     */
+    private suspend fun assertTunnelReachesActiveThenCleansUp(
+        client: TunnelClientImpl,
+        openStream: MuxStream
+    ) {
+        val becameActive = withTimeoutOrNull(ACTIVE_WAIT) {
+            client.state.first { it == TunnelState.ACTIVE }
+        }
+        assertEquals(
+            TunnelState.ACTIVE,
+            becameActive,
+            "Tunnel should transition to ACTIVE while the second stream is open"
+        )
+        openStream.close()
+        withTimeoutOrNull(ACTIVE_WAIT) {
+            client.state.first { it == TunnelState.CONNECTED }
+        }
+    }
+
+    /**
+     * Returns true iff [TunnelClient.state] stays out of
+     * [TunnelState.DISCONNECTING] / [TunnelState.DISCONNECTED] for the entire
+     * [windowMs] window, polling at [POLL_MS] intervals. [TunnelState.CONNECTED]
+     * and [TunnelState.ACTIVE] are both acceptable — the invariant under test
+     * is specifically "the tunnel does not die", not "the tunnel does not
+     * briefly hold a stream".
+     */
+    private suspend fun stateNeverReachedDisconnectedFor(
+        client: TunnelClientImpl,
+        windowMs: Long
+    ): Boolean {
+        val deadline = System.currentTimeMillis() + windowMs
+        while (System.currentTimeMillis() < deadline) {
+            val s = client.state.value
+            if (s == TunnelState.DISCONNECTED || s == TunnelState.DISCONNECTING) {
+                return false
+            }
+            delay(POLL_MS)
+        }
+        val finalState = client.state.value
+        return finalState != TunnelState.DISCONNECTED &&
+            finalState != TunnelState.DISCONNECTING
+    }
+
+    /**
+     * Collect [MuxStream.incoming] in the background so its bounded channel
+     * never blocks MuxDemux. Any IO / cancellation exception is swallowed —
+     * the stream may be torn down by the ERROR frame, which is exactly the
+     * behaviour under test.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun drainInBackground(scope: CoroutineScope, stream: MuxStream): Job =
+        scope.launch(Dispatchers.IO) {
+            try {
+                stream.incoming.collect { /* drop */ }
+            } catch (_: Exception) {
+                // stream closed/errored — expected
+            }
+        }
+
+    private suspend fun connectTunnelClient(scope: CoroutineScope): TunnelClientImpl {
+        val sslContext = TestSslContexts.buildMtls(deviceKeyStore, caCert)
+        val wsFactory = MtlsWebSocketFactory(sslContext)
+        val client = TunnelClientImpl(
+            scope = scope,
+            webSocketFactory = wsFactory,
+            keepaliveIntervalMillis = KEEPALIVE_INTERVAL_MS,
+            keepaliveTimeoutMillis = KEEPALIVE_TIMEOUT_MS,
+            keepaliveMaxMisses = KEEPALIVE_MAX_MISSES
+        )
+        val url = "wss://$RELAY_HOSTNAME:$relayPort/ws"
+        client.connect(url)
+        // Wait for the relay to finish registering the session with its
+        // SessionRegistry — otherwise the first `/test/open-stream` would hit
+        // the "subdomain not registered" path and surface as 404.
+        waitForRelaySession()
+        return client
+    }
+
+    /**
+     * Poll a harmless `/test/emit-stream-error` admin call on an unused
+     * stream id until the relay reports the session is registered (response
+     * = `{"emitted": true}`). The ERROR frame is silently discarded by the
+     * device because no stream matches the id, so this probe has no
+     * observable side effect.
+     */
+    private suspend fun waitForRelaySession() {
+        val deadline = System.currentTimeMillis() + SESSION_REGISTRATION_TIMEOUT_MS
+        while (System.currentTimeMillis() < deadline) {
+            val seen = relayManager.emitStreamError(
+                subdomain = DEVICE_SUBDOMAIN,
+                streamId = PROBE_STREAM_ID,
+                errorCode = TestRelayManager.STREAM_RESET_CODE,
+                message = ""
+            )
+            if (seen) return
+            delay(POLL_MS)
+        }
+        error(
+            "Relay did not register the mux session for '$DEVICE_SUBDOMAIN' within " +
+                "${SESSION_REGISTRATION_TIMEOUT_MS}ms"
+        )
+    }
+}
+
+private val STREAM_WAIT: Duration = 10.seconds
+private val ACTIVE_WAIT: Duration = 5.seconds
+
+// UInt literals: the `u` suffix is the only form the current Kotlin/IR
+// `const` evaluator accepts inside `.first { it.id == ... }` predicates
+// without tripping an internal `toUInt(kotlin.Int)` lookup bug. Kept at
+// file scope rather than `companion object` because the IR bug also
+// fires when these are `const val UInt` in a companion object — the
+// `@Suppress("MayBeConst")` here is the intentional trade-off (see
+// issue #266 for the full context).
+@Suppress("MayBeConst")
+private val FIRST_STREAM_UID: UInt = 1001u
+
+@Suppress("MayBeConst")
+private val SECOND_STREAM_UID: UInt = 1002u

--- a/relay/src/api/ws.rs
+++ b/relay/src/api/ws.rs
@@ -168,7 +168,14 @@ async fn handle_mux_session(socket: WebSocket, params: SessionParams) {
     // Order matters: insert into registry FIRST so try_open_stream() works,
     // THEN signal waiters via register_mux_connection(). Otherwise, FCM
     // waiters wake up but find no session entry and get StreamRefused.
-    session_registry.insert(&subdomain, open_stream_tx, kill_tx);
+    //
+    // `frame_tx` is a clone of the session's outbound channel (same one the
+    // write loop consumes from). Exposed on the registry so the test-mode
+    // admin endpoints in `test_mode.rs` (`/test/emit-stream-error`,
+    // `/test/open-stream`) can inject synthetic frames without a real AI
+    // client — see issue #266.
+    let registry_frame_tx = session.handle().frame_tx.clone();
+    session_registry.insert(&subdomain, open_stream_tx, kill_tx, registry_frame_tx);
     relay_state.register_mux_connection(&subdomain);
 
     info!(subdomain = %subdomain, "Mux session registered");

--- a/relay/src/passthrough.rs
+++ b/relay/src/passthrough.rs
@@ -77,6 +77,15 @@ pub struct SessionEntry {
     /// simulate a relay-side network drop (see issue #249). In production the
     /// sender is never fired; the channel sits idle.
     pub kill_tx: mpsc::Sender<()>,
+    /// Clone of the mux session's outbound frame channel. The write loop
+    /// forwards each frame to the device's WebSocket. Used by test-mode admin
+    /// endpoints (`POST /test/emit-stream-error`, `POST /test/open-stream`) to
+    /// inject synthetic frames onto an already-registered session without
+    /// going through the passthrough/SNI path. See issue #266 for the batch-C
+    /// scenario that forced this hook (Conscrypt's SNI suppression under
+    /// Robolectric blocked driving a real AI-client handshake). In production
+    /// this sender is used exclusively by the session's own write loop.
+    pub frame_tx: mpsc::Sender<Frame>,
 }
 
 /// Registry of active mux sessions, keyed by subdomain.
@@ -105,14 +114,33 @@ impl SessionRegistry {
         subdomain: &str,
         open_stream_tx: mpsc::Sender<OpenStreamRequest>,
         kill_tx: mpsc::Sender<()>,
+        frame_tx: mpsc::Sender<Frame>,
     ) {
         self.sessions.insert(
             subdomain.to_string(),
             SessionEntry {
                 open_stream_tx,
                 kill_tx,
+                frame_tx,
             },
         );
+    }
+
+    /// Send a frame directly to the device's mux WebSocket. Test-only hook
+    /// used by `POST /test/emit-stream-error` and `POST /test/open-stream` to
+    /// inject synthetic frames (ERROR for an existing stream, OPEN for a new
+    /// one) onto a registered session. Returns `Ok(true)` if the frame was
+    /// enqueued, `Ok(false)` if no session is registered for the subdomain,
+    /// and `Err(())` if the session exists but its outbound channel was
+    /// already closed (a racing teardown). See issue #266.
+    pub async fn emit_frame(&self, subdomain: &str, frame: Frame) -> Result<bool, ()> {
+        let frame_tx = match self.sessions.get(subdomain) {
+            Some(entry) => entry.frame_tx.clone(),
+            None => return Ok(false),
+        };
+        // Drop the DashMap ref before the await to avoid holding it across
+        // suspension, matching the pattern in `try_open_stream`.
+        frame_tx.send(frame).await.map(|_| true).map_err(|_| ())
     }
 
     /// Signal the mux session for `subdomain` to abort without sending a close

--- a/relay/src/test_mode.rs
+++ b/relay/src/test_mode.rs
@@ -11,6 +11,17 @@
 //!   or network drop so the device-side half-open detector fires.
 //! - `POST /test/fcm-wake?subdomain=<sub>` — record a synthetic FCM wake in
 //!   the in-memory fake. The test harness reads this via `/test/stats`.
+//! - `POST /test/open-stream?subdomain=<sub>&stream_id=<id>&sni=<host>` —
+//!   push a mux OPEN frame to the device as if the relay's passthrough code
+//!   had routed an inbound AI-client connection for `stream_id`. Used by
+//!   `:app` integration tests to drive inbound mux streams without having to
+//!   perform a real SNI-routed TLS handshake (Conscrypt suppresses SNI under
+//!   Robolectric — see issue #262). The device-side `MuxDemux` will surface
+//!   the new stream on `TunnelClient.incomingSessions`.
+//! - `POST /test/emit-stream-error?subdomain=<sub>&stream_id=<id>&code=<n>&message=<s>` —
+//!   push a mux ERROR frame onto an already-open stream so tests can assert
+//!   that stream-level failures do not tear down the tunnel. `code` is a
+//!   `MuxErrorCode` value (1..=4); `message` is an optional UTF-8 diagnostic.
 //! - `GET  /test/stats` — per-endpoint request counters + synthetic-wake log.
 //!
 //! See issue #249 for the motivating scenarios (#247 integration tier).
@@ -32,6 +43,7 @@ use std::sync::{Arc, Mutex};
 use tokio::net::TcpListener;
 use tracing::{info, warn};
 
+use crate::mux::frame::{ErrorCode, Frame, FrameType};
 use crate::passthrough::SessionRegistry;
 
 /// Per-endpoint request counters and captured synthetic wake events.
@@ -192,10 +204,175 @@ pub async fn handle_stats(State(state): State<AdminState>) -> Response {
     (StatusCode::OK, Json(snapshot)).into_response()
 }
 
+/// Query parameters for `/test/open-stream`: subdomain + stream id + SNI hostname.
+///
+/// `sni` is surfaced as the OPEN frame payload so the device side sees the
+/// same bytes a real passthrough would carry (the device currently ignores
+/// the payload, but keeping the shape identical avoids divergence if it ever
+/// starts validating).
+#[derive(Deserialize)]
+pub struct OpenStreamQuery {
+    subdomain: String,
+    stream_id: u32,
+    #[serde(default)]
+    sni: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct OpenStreamResponse {
+    opened: bool,
+    subdomain: String,
+    stream_id: u32,
+}
+
+/// Push a synthetic OPEN frame to the device. See module docs.
+pub async fn handle_open_stream(
+    State(state): State<AdminState>,
+    Query(q): Query<OpenStreamQuery>,
+) -> Response {
+    let payload = q.sni.as_deref().unwrap_or_default().as_bytes().to_vec();
+    let frame = Frame {
+        frame_type: FrameType::Open,
+        stream_id: q.stream_id,
+        payload,
+    };
+    match state.session_registry.emit_frame(&q.subdomain, frame).await {
+        Ok(true) => {
+            info!(
+                subdomain = %q.subdomain,
+                stream_id = q.stream_id,
+                "test-mode: synthetic OPEN frame emitted"
+            );
+            (
+                StatusCode::OK,
+                Json(OpenStreamResponse {
+                    opened: true,
+                    subdomain: q.subdomain,
+                    stream_id: q.stream_id,
+                }),
+            )
+                .into_response()
+        }
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Json(OpenStreamResponse {
+                opened: false,
+                subdomain: q.subdomain,
+                stream_id: q.stream_id,
+            }),
+        )
+            .into_response(),
+        Err(()) => (
+            StatusCode::CONFLICT,
+            Json(OpenStreamResponse {
+                opened: false,
+                subdomain: q.subdomain,
+                stream_id: q.stream_id,
+            }),
+        )
+            .into_response(),
+    }
+}
+
+/// Query parameters for `/test/emit-stream-error`.
+#[derive(Deserialize)]
+pub struct EmitStreamErrorQuery {
+    subdomain: String,
+    stream_id: u32,
+    /// Mux error code (1..=4). Defaults to `STREAM_RESET` (2) if omitted.
+    #[serde(default)]
+    code: Option<u32>,
+    /// Optional diagnostic message appended to the ERROR payload.
+    #[serde(default)]
+    message: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct EmitStreamErrorResponse {
+    emitted: bool,
+    subdomain: String,
+    stream_id: u32,
+}
+
+/// Push a synthetic ERROR frame onto an already-open stream. See module docs.
+pub async fn handle_emit_stream_error(
+    State(state): State<AdminState>,
+    Query(q): Query<EmitStreamErrorQuery>,
+) -> Response {
+    let code_raw = q.code.unwrap_or(ErrorCode::StreamReset as u32);
+    let code = match ErrorCode::from_u32(code_raw) {
+        Ok(c) => c,
+        Err(_) => {
+            warn!(
+                subdomain = %q.subdomain,
+                code = code_raw,
+                "test-mode: invalid error code on emit-stream-error"
+            );
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(EmitStreamErrorResponse {
+                    emitted: false,
+                    subdomain: q.subdomain,
+                    stream_id: q.stream_id,
+                }),
+            )
+                .into_response();
+        }
+    };
+    let payload = code.encode_payload(q.message.as_deref());
+    let frame = Frame {
+        frame_type: FrameType::Error,
+        stream_id: q.stream_id,
+        payload,
+    };
+    match state.session_registry.emit_frame(&q.subdomain, frame).await {
+        Ok(true) => {
+            info!(
+                subdomain = %q.subdomain,
+                stream_id = q.stream_id,
+                code = code_raw,
+                "test-mode: synthetic ERROR frame emitted"
+            );
+            (
+                StatusCode::OK,
+                Json(EmitStreamErrorResponse {
+                    emitted: true,
+                    subdomain: q.subdomain,
+                    stream_id: q.stream_id,
+                }),
+            )
+                .into_response()
+        }
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Json(EmitStreamErrorResponse {
+                emitted: false,
+                subdomain: q.subdomain,
+                stream_id: q.stream_id,
+            }),
+        )
+            .into_response(),
+        Err(()) => (
+            StatusCode::CONFLICT,
+            Json(EmitStreamErrorResponse {
+                emitted: false,
+                subdomain: q.subdomain,
+                stream_id: q.stream_id,
+            }),
+        )
+            .into_response(),
+    }
+}
+
 pub fn build_admin_router(admin_state: AdminState) -> axum::Router {
     axum::Router::new()
         .route("/test/kill-ws", axum::routing::post(handle_kill_ws))
         .route("/test/fcm-wake", axum::routing::post(handle_fcm_wake))
+        .route("/test/open-stream", axum::routing::post(handle_open_stream))
+        .route(
+            "/test/emit-stream-error",
+            axum::routing::post(handle_emit_stream_error),
+        )
         .route("/test/stats", axum::routing::get(handle_stats))
         .with_state(admin_state)
 }
@@ -225,4 +402,139 @@ pub async fn spawn_admin_server(
     });
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mux::frame::{ErrorCode, FrameType};
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tokio::sync::mpsc;
+    use tower::ServiceExt;
+
+    /// Register a fake session entry on the registry and hand back the
+    /// receiver end of its `frame_tx`, so tests can observe what the admin
+    /// handler actually enqueued.
+    fn register_fake_session(registry: &SessionRegistry, subdomain: &str) -> mpsc::Receiver<Frame> {
+        let (open_tx, _open_rx) = mpsc::channel(4);
+        let (kill_tx, _kill_rx) = mpsc::channel(1);
+        let (frame_tx, frame_rx) = mpsc::channel(16);
+        registry.insert(subdomain, open_tx, kill_tx, frame_tx);
+        frame_rx
+    }
+
+    fn admin_state() -> (AdminState, Arc<SessionRegistry>) {
+        let registry = Arc::new(SessionRegistry::new());
+        let state = AdminState {
+            metrics: Arc::new(TestMetrics::new()),
+            session_registry: registry.clone(),
+        };
+        (state, registry)
+    }
+
+    async fn post(router: axum::Router, uri: &str) -> axum::response::Response {
+        router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn emit_stream_error_writes_error_frame_to_registered_session() {
+        let (state, registry) = admin_state();
+        let mut frame_rx = register_fake_session(&registry, "dev-1");
+
+        let router = build_admin_router(state);
+        let resp = post(
+            router,
+            "/test/emit-stream-error?subdomain=dev-1&stream_id=7&code=2&message=boom",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let frame = frame_rx.try_recv().expect("ERROR frame should be enqueued");
+        assert_eq!(frame.frame_type, FrameType::Error);
+        assert_eq!(frame.stream_id, 7);
+        let (code, msg) = ErrorCode::decode_payload(&frame.payload).unwrap();
+        assert_eq!(code, ErrorCode::StreamReset);
+        assert_eq!(msg.as_deref(), Some("boom"));
+    }
+
+    #[tokio::test]
+    async fn emit_stream_error_default_code_is_stream_reset() {
+        let (state, registry) = admin_state();
+        let mut frame_rx = register_fake_session(&registry, "dev-2");
+
+        let router = build_admin_router(state);
+        let resp = post(
+            router,
+            "/test/emit-stream-error?subdomain=dev-2&stream_id=3",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let frame = frame_rx.try_recv().expect("frame expected");
+        let (code, msg) = ErrorCode::decode_payload(&frame.payload).unwrap();
+        assert_eq!(code, ErrorCode::StreamReset);
+        assert!(msg.is_none());
+    }
+
+    #[tokio::test]
+    async fn emit_stream_error_rejects_unknown_subdomain() {
+        let (state, _registry) = admin_state();
+        let router = build_admin_router(state);
+        let resp = post(
+            router,
+            "/test/emit-stream-error?subdomain=nope&stream_id=1&code=2",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn emit_stream_error_rejects_invalid_code() {
+        let (state, registry) = admin_state();
+        let _frame_rx = register_fake_session(&registry, "dev-3");
+        let router = build_admin_router(state);
+        let resp = post(
+            router,
+            "/test/emit-stream-error?subdomain=dev-3&stream_id=1&code=999",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn open_stream_writes_open_frame_with_sni_payload() {
+        let (state, registry) = admin_state();
+        let mut frame_rx = register_fake_session(&registry, "dev-4");
+
+        let router = build_admin_router(state);
+        let resp = post(
+            router,
+            "/test/open-stream?subdomain=dev-4&stream_id=5&sni=ai.example.com",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let frame = frame_rx.try_recv().expect("OPEN frame should be enqueued");
+        assert_eq!(frame.frame_type, FrameType::Open);
+        assert_eq!(frame.stream_id, 5);
+        assert_eq!(frame.payload, b"ai.example.com");
+    }
+
+    #[tokio::test]
+    async fn open_stream_rejects_unknown_subdomain() {
+        let (state, _registry) = admin_state();
+        let router = build_admin_router(state);
+        let resp = post(router, "/test/open-stream?subdomain=missing&stream_id=1").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
 }

--- a/relay/tests/passthrough_test.rs
+++ b/relay/tests/passthrough_test.rs
@@ -36,12 +36,13 @@ fn setup_device(
 ) -> mpsc::Receiver<Frame> {
     let mut session = MuxSession::new(subdomain.to_string(), max_streams);
     let frame_rx = session.take_frame_rx().unwrap();
+    let frame_tx = session.handle().frame_tx.clone();
 
     let (open_tx, mut open_rx) = mpsc::channel::<OpenStreamRequest>(16);
     let (kill_tx, _kill_rx) = mpsc::channel::<()>(1);
 
     relay_state.register_mux_connection(subdomain);
-    registry.insert(subdomain, open_tx, kill_tx);
+    registry.insert(subdomain, open_tx, kill_tx, frame_tx);
 
     // Spawn a task to handle open-stream requests
     tokio::spawn(async move {
@@ -363,9 +364,10 @@ async fn cold_client_fcm_then_device_connects() {
         tokio::time::sleep(Duration::from_millis(50)).await;
         // Device wakes up and establishes mux
         let mut session = MuxSession::new("cold-dev".to_string(), 8);
+        let frame_tx = session.handle().frame_tx.clone();
         let (open_tx, mut open_rx) = mpsc::channel::<OpenStreamRequest>(16);
         let (kill_tx, _kill_rx) = mpsc::channel::<()>(1);
-        reg.insert("cold-dev", open_tx, kill_tx);
+        reg.insert("cold-dev", open_tx, kill_tx, frame_tx);
         rs.register_mux_connection("cold-dev");
         // Handle open-stream requests
         while let Some(req) = open_rx.recv().await {
@@ -692,6 +694,7 @@ fn spawn_delayed_device(
     let sub = subdomain.to_string();
     let mut session = MuxSession::new(sub.clone(), max_streams);
     let frame_rx = session.take_frame_rx().unwrap();
+    let frame_tx = session.handle().frame_tx.clone();
 
     let rs = relay_state;
     let reg = registry;
@@ -701,7 +704,7 @@ fn spawn_delayed_device(
         let (kill_tx, _kill_rx) = mpsc::channel::<()>(1);
         // Insert into registry BEFORE register_mux_connection so that
         // when subscribe_connect fires, the session is already available.
-        reg.insert(&sub, open_tx, kill_tx);
+        reg.insert(&sub, open_tx, kill_tx, frame_tx);
         rs.register_mux_connection(&sub);
         while let Some(req) = open_rx.recv().await {
             let result = session

--- a/relay/tests/valid_secrets_cache_test.rs
+++ b/relay/tests/valid_secrets_cache_test.rs
@@ -48,10 +48,11 @@ fn setup_device(
 ) -> mpsc::Receiver<Frame> {
     let mut session = MuxSession::new(subdomain.to_string(), 8);
     let frame_rx = session.take_frame_rx().unwrap();
+    let frame_tx = session.handle().frame_tx.clone();
     let (open_tx, mut open_rx) = mpsc::channel::<OpenStreamRequest>(16);
     let (kill_tx, _kill_rx) = mpsc::channel::<()>(1);
     relay_state.register_mux_connection(subdomain);
-    registry.insert(subdomain, open_tx, kill_tx);
+    registry.insert(subdomain, open_tx, kill_tx, frame_tx);
     tokio::spawn(async move {
         while let Some(req) = open_rx.recv().await {
             let result = session


### PR DESCRIPTION
## Summary

- Adds two narrow test-mode admin endpoints on the relay (`POST /test/open-stream`, `POST /test/emit-stream-error`) that inject synthetic mux OPEN/ERROR frames onto an already-registered session, plus fixture wrappers on `TestRelayManager`.
- Implements the last batch-C scenario from #253 as `:core:tunnel:jvmTest/integration/StreamFailureDoesNotKillTunnelTest` — asserts a stream-level ERROR frame does not knock the tunnel into DISCONNECTED and that a subsequent inbound stream is still accepted.
- Adds Rust unit tests for the two new admin handlers (happy path, unknown subdomain, invalid error code).

## Why not run this at the `:app` Koin-wired layer?

The batch-C umbrella initially asked for the scenario at the `:app` integration tier. Driving a `TunnelClient.connect(wss://...)` from there requires a mTLS WebSocket through Robolectric, which currently routes via Conscrypt — the same `#262` blocker that tanked the "open an inbound stream via SNI" approach. Running the scenario in `:core:tunnel:jvmTest` uses the already-proven `MtlsWebSocketFactory` (Java HttpClient + SunJSSE) and gives us the regression guard the issue is asking for. The `EndToEndSessionTest` protocol-layer coverage already noted on #266 still stands; this test pins the specific "stream ERROR does not equal tunnel disconnect" invariant.

## Relay plumbing

- `SessionEntry` now exposes a clone of the session's outbound `frame_tx` so admin handlers can push frames directly to the device's WebSocket write loop, bypassing passthrough. Two pre-existing `SessionRegistry` test harnesses in `relay/tests/` were updated to match the new `insert(...)` arity.

## Test plan

- [x] `cd relay && cargo fmt --check && cargo test && cargo test --features test-mode && cargo clippy --all-targets --features test-mode -- -D warnings`
- [x] `./gradlew :core:tunnel:integrationTest` — all green including the new test (5m total)
- [x] `./gradlew :app:integrationTest :app:testDebugUnitTest ktlintCheck` — green
- [x] `./gradlew detekt` — no new issues attributable to this PR (net count unchanged vs. `main`)

Closes #266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)