### PR TITLE
Fix #262: Swap in BouncyCastle JSSE for SNI emission under Robolectric

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -247,6 +247,13 @@ dependencies {
     // The fixture uses `kotlin.test.fail`; surface it here so the integration
     // smoke tests can pattern-match against the same failure messages.
     testImplementation(kotlin("test"))
+    // BouncyCastle JSSE — test-scope only. See the comment in
+    // `gradle/libs.versions.toml` / issue #262. `AppIntegrationTestHarness`
+    // registers the provider at position 1 so synthetic AI-client
+    // `SSLSocket`s correctly emit SNI (Conscrypt, Robolectric's default,
+    // silently omits it).
+    testImplementation(libs.bouncycastle.jsse)
+    testImplementation(libs.bouncycastle.prov)
 }
 
 // Integration-tier tests that boot the real relay binary and exercise the

--- a/app/src/test/java/com/rousecontext/app/integration/McpSessionTestHarness.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/McpSessionTestHarness.kt
@@ -22,21 +22,17 @@ import kotlinx.coroutines.flow.MutableStateFlow
  * rows, session-summary notifications, per-call notifications, tool
  * dispatch. That's all downstream of the TLS + mux + bridge layers.
  *
- * Robolectric ships Conscrypt as the default TLS provider, and its client
- * sockets silently drop the SNI extension from the ClientHello (see
- * #262). The relay's passthrough router rejects connections without SNI,
- * so a synthetic AI client can't reach the device's bridge at all under
- * Robolectric — independently of `setHostname` /
- * `SSLParameters.serverNames` / `Conscrypt.setHostname` / the
- * `setUseEngineSocket(false)` legacy path.
- *
- * Batch B's assertions only care about the device-side half of the pipe,
- * so we skip the relay + bridge layers entirely and call
- * [McpSession]'s local HTTP server directly. The bridge layer is already
- * end-to-end regression-guarded by the JVM-only
+ * Historically (pre-#262) Robolectric's Conscrypt provider silently
+ * stripped SNI from every outbound ClientHello, which blocked any
+ * attempt to route a synthetic AI client through the real relay's
+ * SNI-routed passthrough. Batch B landed against this loopback driver
+ * to make progress; [ToolCallViaSniPassthroughTest] now proves the
+ * SNI path works end-to-end (via BouncyCastle JSSE swap in
+ * [AppIntegrationTestHarness]). The loopback scenarios here stay as-is
+ * because their assertions only care about the device-side half of the
+ * pipe — the relay + bridge legs are regression-guarded by the JVM-only
  * [com.rousecontext.tunnel.integration.ClaudeFullFlowEndToEndTest] and
- * [com.rousecontext.bridge.SessionHandlerTest]; batch C (#253) picks up
- * the resilience scenarios once #262 is resolved.
+ * [com.rousecontext.bridge.SessionHandlerTest].
  *
  * ## How it works
  *

--- a/app/src/test/java/com/rousecontext/app/integration/ToolCallViaSniPassthroughTest.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/ToolCallViaSniPassthroughTest.kt
@@ -1,0 +1,224 @@
+package com.rousecontext.app.integration
+
+import com.rousecontext.app.integration.TunnelTestSupport.awaitState
+import com.rousecontext.app.integration.harness.AppIntegrationTestHarness
+import com.rousecontext.app.integration.harness.TestEchoMcpIntegration
+import com.rousecontext.bridge.SessionHandler
+import com.rousecontext.bridge.TunnelSessionManager
+import com.rousecontext.tunnel.CertificateStore
+import com.rousecontext.tunnel.TunnelClientImpl
+import com.rousecontext.tunnel.TunnelState
+import java.security.cert.X509Certificate
+import javax.net.ssl.SNIHostName
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Proof that BouncyCastle JSSE (issue #262) restores SNI emission from the
+ * synthetic AI client, so the relay's SNI-routed passthrough actually
+ * reaches the device. Before this fix, Robolectric's default Conscrypt
+ * provider silently dropped the SNI extension from every ClientHello and
+ * the relay rejected every AI-client connection with `no valid SNI`.
+ *
+ * ## What this test proves
+ *
+ * 1. The synthetic AI client's outbound `ClientHello` contains the SNI
+ *    extension set via [javax.net.ssl.SSLParameters.serverNames].
+ * 2. The relay (Rust / Rustls) parses the SNI, classifies it as
+ *    `DevicePassthrough`, and attempts to forward the connection onto
+ *    the device's mux session. The test-mode hook in
+ *    `relay/src/main.rs::handle_connection` records the routed SNI into
+ *    [com.rousecontext.tunnel.integration.TestRelayManager.routedPassthroughSnis].
+ * 3. The real device-side [TunnelClientImpl] + [TunnelSessionManager] +
+ *    [SessionHandler] from the production Koin graph are wired up and
+ *    receive the inbound mux stream (the stream handshakes the inner
+ *    TLS session before hitting MCP routing).
+ *
+ * ## What this test does NOT exercise
+ *
+ * - The inner TLS handshake between the AI client and the device's
+ *   `CertStoreTlsCertProvider`. The test-mode relay's stub ACME returns
+ *   the literal string `"stub-cert"` as the device's server cert (see
+ *   [StubAcme] in `relay/src/main.rs`), which is not a parseable X.509
+ *   cert — the device cannot complete a server-side TLS handshake in
+ *   harness mode. The AI client's handshake therefore fails after the
+ *   relay has already routed (and recorded) the SNI. That failure is
+ *   swallowed; the routed-SNI assertion is what matters for #262.
+ * - MCP JSON-RPC round-trips. Those are exercised by
+ *   [ToolCallHappyPathTest] and siblings via the loopback
+ *   [McpTestDriver], which bypasses the relay/TLS path entirely. Those
+ *   scenarios stay as-is per #262's "leave the loopback version alone
+ *   if you add a new SNI test" guidance.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ToolCallViaSniPassthroughTest {
+
+    private val harness = AppIntegrationTestHarness(
+        integrationsFactory = { listOf(TestEchoMcpIntegration()) }
+    )
+    private lateinit var tunnelScope: CoroutineScope
+    private var tunnel: TunnelClientImpl? = null
+    private var sessionManager: TunnelSessionManager? = null
+
+    @Before
+    fun setUp() {
+        harness.start()
+        tunnelScope = TunnelTestSupport.newTunnelScope()
+    }
+
+    @After
+    fun tearDown() {
+        sessionManager?.stop()
+        sessionManager = null
+        runBlocking { tunnel?.disconnect() }
+        tunnel = null
+        tunnelScope.cancel()
+        harness.stop()
+    }
+
+    @Test
+    fun `synthetic AI client ClientHello carries SNI and reaches relay passthrough`() =
+        runBlocking {
+            val subdomain = harness.provisionDevice()
+            harness.enableIntegrations(listOf(TestEchoMcpIntegration.ID))
+
+            // Bring the device-to-relay tunnel up and wire inbound mux streams
+            // through the production SessionHandler. Without a live mux
+            // session the relay routes passthrough attempts straight to
+            // fcm-wake + timeout instead of recording a routed-SNI.
+            val connectedTunnel = TunnelTestSupport.buildTunnel(harness, tunnelScope)
+                .also { tunnel = it }
+            connectedTunnel.connect(TunnelTestSupport.tunnelUrl(harness))
+            connectedTunnel.awaitState(
+                TunnelState.CONNECTED,
+                timeout = TunnelTestSupport.DEFAULT_CONNECT_TIMEOUT
+            )
+
+            val sessionHandler: SessionHandler = harness.koin.get()
+            sessionManager = TunnelSessionManager(
+                tunnelClient = connectedTunnel,
+                sessionHandler = sessionHandler,
+                scope = tunnelScope
+            ).also { it.start() }
+
+            // Per-integration secret is the prefix the relay uses to match the
+            // SNI label to a specific integration on this device.
+            val certStore: CertificateStore = harness.koin.get()
+            val integrationSecret = certStore
+                .getSecretForIntegration(TestEchoMcpIntegration.ID)
+                ?: error(
+                    "provisionDevice did not persist an integration secret for " +
+                        "`${TestEchoMcpIntegration.ID}` — harness is mis-wired"
+                )
+            // SNI shape the relay expects for device-passthrough routes:
+            //   {integrationSecret}.{subdomain}.{baseDomain}
+            // where `baseDomain` is the relay_hostname with its leading
+            // "relay." prefix stripped (see `RouteDecision::from_sni` in
+            // `relay/src/sni.rs`). The harness runs with
+            // `relay_hostname = "relay.test.local"`, so the base domain
+            // is `test.local` — the SNI does NOT include "relay.".
+            val sniHost = "$integrationSecret.$subdomain.test.local"
+
+            // Open a TLS socket with the SNI extension set and force the
+            // ClientHello onto the wire. The handshake will NOT complete
+            // end-to-end (stub-cert; see kdoc). What matters for #262 is
+            // that the bytes the relay sees contain the SNI extension —
+            // the relay's routing handler records the SNI *before* any
+            // inner handshake completes, so a failed downstream handshake
+            // is fine.
+            withContext(Dispatchers.IO) {
+                openSniSocket(harness.relayPort, sniHost).use { socket ->
+                    // `startHandshake()` flushes the ClientHello; wrap in
+                    // runCatching because the inner TLS handshake the
+                    // device attempts on the other side of the passthrough
+                    // will fail against our trust-all context when the
+                    // relay closes the connection with no valid device
+                    // cert downstream.
+                    runCatching { socket.startHandshake() }
+                    // Give the relay a beat to finish parsing SNI and
+                    // record it before we assert.
+                    runCatching { socket.outputStream.flush() }
+                }
+                kotlinx.coroutines.delay(POST_HANDSHAKE_SETTLE_MS)
+            }
+
+            // The relay records the reconstructed hostname
+            // `{secret}.{subdomain}.{base_domain_config}` rather than the
+            // exact SNI string off the wire (the parsed router pipes the
+            // prefix-stripped form through). In harness mode the config's
+            // base_domain is `relay.test.local`, so the recorded form is
+            // `{secret}.{subdomain}.relay.test.local`. The key invariant
+            // for #262 is that a device-passthrough SNI was *routed at
+            // all* — empty means Conscrypt silently stripped SNI and the
+            // router classified every attempt as Reject/RelayApi.
+            val routed = harness.fixture.routedPassthroughSnis()
+            assertTrue(
+                "relay must have recorded a routed-passthrough SNI — before the BC JSSE " +
+                    "swap Conscrypt stripped SNI and the relay rejected every " +
+                    "AI-client connection; saw: $routed",
+                routed.isNotEmpty()
+            )
+            val expectedRecordedSni = "$integrationSecret.$subdomain.relay.test.local"
+            assertEquals(
+                "the routed SNI must name the integration and subdomain we targeted",
+                expectedRecordedSni,
+                routed.last()
+            )
+        }
+
+    // --- helpers ---
+
+    private fun openSniSocket(relayPort: Int, sniHost: String): SSLSocket {
+        // Trust-all: we are not asserting anything about the inner TLS, only
+        // about the relay's view of the outer ClientHello. Using a
+        // trust-all TM keeps the test focused on SNI emission.
+        val trustAll = arrayOf<TrustManager>(
+            object : X509TrustManager {
+                override fun checkClientTrusted(
+                    chain: Array<out X509Certificate>?,
+                    authType: String?
+                ) = Unit
+
+                override fun checkServerTrusted(
+                    chain: Array<out X509Certificate>?,
+                    authType: String?
+                ) = Unit
+
+                override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+            }
+        )
+        // `SSLContext.getInstance("TLS")` resolves to BouncyCastle JSSE
+        // because [AppIntegrationTestHarness.start] inserted BC at priority 1.
+        // That is the whole point of this test.
+        val ctx = SSLContext.getInstance("TLS")
+        ctx.init(null, trustAll, null)
+        val factory: SSLSocketFactory = ctx.socketFactory
+
+        val socket = factory.createSocket("127.0.0.1", relayPort) as SSLSocket
+        socket.soTimeout = HANDSHAKE_TIMEOUT_MS
+        val params = socket.sslParameters
+        params.serverNames = listOf(SNIHostName(sniHost))
+        socket.sslParameters = params
+        return socket
+    }
+
+    private companion object {
+        private const val HANDSHAKE_TIMEOUT_MS = 10_000
+        private const val POST_HANDSHAKE_SETTLE_MS = 500L
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/integration/harness/AppIntegrationTestHarness.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/harness/AppIntegrationTestHarness.kt
@@ -28,6 +28,7 @@ import java.net.InetAddress
 import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.KeyStore
+import java.security.Security
 import java.security.cert.X509Certificate
 import java.security.spec.ECGenParameterSpec
 import java.util.concurrent.TimeUnit
@@ -187,6 +188,32 @@ class AppIntegrationTestHarness(
      * matching the rest of the integration suite.
      */
     fun start() {
+        // Capture the pre-swap provider list snapshot (see [stop]).
+        snapshotSecurityProviders()
+
+        // Insert BouncyCastle JSSE + Prov at JCA priority 1 for the
+        // duration of this harness. Robolectric registers Conscrypt as the
+        // default JSSE, and Conscrypt's outbound `SSLSocket` silently drops
+        // the SNI extension from client ClientHellos regardless of how it
+        // is configured — issue #262. BC JSSE honours
+        // `SSLParameters.serverNames`, so raw `SSLSocket` code paths
+        // (synthetic AI client in `ToolCallViaSniPassthroughTest`) actually
+        // reach the relay's SNI router.
+        //
+        // Must happen before any `SSLContext.getInstance("TLS")` call
+        // inside `start()` — in particular before OkHttp builds the
+        // relay mTLS client, and before the TunnelClient opens its
+        // WebSocket.
+        //
+        // [FreshSslContextSocketFactory] explicitly falls back to the
+        // highest-priority non-BC TLS provider so the OkHttp mTLS
+        // `DelegatingX509KeyManager` path keeps the same JSSE it was
+        // validated against (Conscrypt under Robolectric). BC's TLS 1.3
+        // client-auth handshake does not interoperate with that
+        // delegating key manager; scoping BC to raw SSLSockets avoids
+        // dragging every OkHttp handshake into BC-land.
+        installBouncyCastleJsseProvider()
+
         val relayBinary = findRelayBinary()
         assumeTrue(
             "Relay binary not found. Build with: cd relay && cargo build --features test-mode",
@@ -280,6 +307,91 @@ class AppIntegrationTestHarness(
 
         tempDir?.takeIf { it.exists() }?.deleteRecursively()
         tempDir = null
+
+        // Restore the JCA provider list to whatever it was before
+        // [start] so the next test class in the same JVM is not affected
+        // by BC's position.
+        restoreSecurityProviders()
+    }
+
+    private var snapshotProviderNames: List<String>? = null
+
+    private fun snapshotSecurityProviders() {
+        snapshotProviderNames = Security.getProviders().map { it.name }
+    }
+
+    private fun restoreSecurityProviders() {
+        // Remove any provider that is not in the pre-start snapshot.
+        val keep = snapshotProviderNames ?: return
+        Security.getProviders().toList().forEach { p ->
+            if (p.name !in keep) {
+                Security.removeProvider(p.name)
+            }
+        }
+        snapshotProviderNames = null
+    }
+}
+
+/**
+ * Return the highest-priority JCA provider that advertises a service of
+ * [serviceType] (e.g. `"SSLContext"`, `"TrustManagerFactory"`) whose
+ * algorithm [algorithmFilter] accepts, excluding BouncyCastle.
+ *
+ * Callers use this to route specific JCA lookups around the global BC
+ * provider that the harness installs at priority 1. The mTLS OkHttp
+ * client (`DelegatingX509KeyManager` / PKCS12 / `SunX509` stack) was
+ * validated against Conscrypt's JSSE, and BC's TLS 1.3 client-auth path
+ * does not interoperate cleanly with that setup.
+ */
+private fun pickNonBouncyCastleProviderOffering(
+    serviceType: String,
+    algorithmFilter: (String) -> Boolean
+): java.security.Provider {
+    for (p in Security.getProviders()) {
+        if (p.name == "BCJSSE" || p.name == "BC") continue
+        val supports = p.services.any { svc ->
+            svc.type == serviceType && algorithmFilter(svc.algorithm)
+        }
+        if (supports) return p
+    }
+    error(
+        "No non-BouncyCastle JCA provider offers $serviceType matching the " +
+            "requested algorithm filter — harness cannot build its mTLS stack"
+    )
+}
+
+/**
+ * Alias for [pickNonBouncyCastleProviderOffering] restricted to the default
+ * [TrustManagerFactory] algorithm. Used by [buildFixtureMtlsHttpClient] to
+ * ensure the trust manager comes from the same JSSE implementation as the
+ * mTLS SSLContext.
+ */
+private fun pickNonBouncyCastleTrustProvider(): java.security.Provider {
+    val defaultAlgo = TrustManagerFactory.getDefaultAlgorithm()
+    return pickNonBouncyCastleProviderOffering("TrustManagerFactory") {
+        it == defaultAlgo
+    }
+}
+
+/**
+ * Insert BouncyCastle's JSSE + crypto providers at JCA priority 1 so
+ * `SSLContext.getInstance("TLS")` resolves to BC by default. Loaded
+ * reflectively to keep BC out of the app module's production classpath —
+ * the libraries are declared `testImplementation` only. Idempotent:
+ * skipped if already registered.
+ */
+private fun installBouncyCastleJsseProvider() {
+    if (Security.getProvider("BC") == null) {
+        val bcProv = Class.forName("org.bouncycastle.jce.provider.BouncyCastleProvider")
+            .getDeclaredConstructor()
+            .newInstance() as java.security.Provider
+        Security.insertProviderAt(bcProv, 1)
+    }
+    if (Security.getProvider("BCJSSE") == null) {
+        val bcJsse = Class.forName("org.bouncycastle.jsse.provider.BouncyCastleJsseProvider")
+            .getDeclaredConstructor()
+            .newInstance() as java.security.Provider
+        Security.insertProviderAt(bcJsse, 1)
     }
 }
 
@@ -516,7 +628,16 @@ private fun buildFixtureMtlsHttpClient(
     val trustStore = KeyStore.getInstance(KeyStore.getDefaultType())
     trustStore.load(null, null)
     trustStore.setCertificateEntry("ca", caCert)
-    val tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+    // Pin the trust-manager factory to a non-BC provider so its trust
+    // manager pairs cleanly with the non-BC `SSLContext` built in
+    // [FreshSslContextSocketFactory]. Mixing a BC trust manager with a
+    // Conscrypt SSLContext throws "Unsupported server authType: GENERIC"
+    // on TLS 1.3 handshakes — the two providers use different authType
+    // coding.
+    val tmf = TrustManagerFactory.getInstance(
+        TrustManagerFactory.getDefaultAlgorithm(),
+        pickNonBouncyCastleTrustProvider()
+    )
     tmf.init(trustStore)
     val trustManager = tmf.trustManagers.firstOrNull { it is X509TrustManager } as? X509TrustManager
         ?: error("No X509TrustManager")
@@ -669,7 +790,16 @@ private class FreshSslContextSocketFactory(
 ) : javax.net.ssl.SSLSocketFactory() {
 
     private fun freshFactory(): javax.net.ssl.SSLSocketFactory {
-        val sslContext = SSLContext.getInstance("TLS")
+        // Pin this factory to the first non-BouncyCastle TLS provider
+        // (Conscrypt under Robolectric, SunJSSE under plain JVM). The
+        // harness installs BC JSSE at priority 1 to fix raw-SSLSocket SNI
+        // emission for #262, but BC's TLS 1.3 client-auth path does not
+        // interoperate with the `DelegatingX509KeyManager` / PKCS12 /
+        // `SunX509` stack this OkHttp mTLS client uses — the handshake
+        // completes without a client cert and the relay 401s. Scoping BC
+        // to raw SSLSockets (in `ToolCallViaSniPassthroughTest`) keeps
+        // every OkHttp path on whichever JSSE it was validated against.
+        val sslContext = SSLContext.getInstance("TLS", pickNonBouncyCastleTlsProvider())
         sslContext.init(
             arrayOf(DelegatingX509KeyManager(keyManagerSource)),
             trustManagers,
@@ -679,6 +809,9 @@ private class FreshSslContextSocketFactory(
         sslContext.clientSessionContext?.sessionTimeout = 1
         return sslContext.socketFactory
     }
+
+    private fun pickNonBouncyCastleTlsProvider(): java.security.Provider =
+        pickNonBouncyCastleProviderOffering("SSLContext") { it == "TLS" || it == "Default" }
 
     override fun getDefaultCipherSuites(): Array<String> = freshFactory().defaultCipherSuites
     override fun getSupportedCipherSuites(): Array<String> = freshFactory().supportedCipherSuites

--- a/core/testfixtures/src/main/kotlin/com/rousecontext/tunnel/integration/TestRelayFixture.kt
+++ b/core/testfixtures/src/main/kotlin/com/rousecontext/tunnel/integration/TestRelayFixture.kt
@@ -487,6 +487,18 @@ class TestRelayManager(
     fun lastRequestHadClientCert(endpoint: String): Boolean? =
         requireAdmin().lastRequestHadClientCert(endpoint)
 
+    /**
+     * SNI hostnames the relay dispatched to device-passthrough routes,
+     * in arrival order. Recorded from `main.rs::handle_connection` under
+     * `#[cfg(feature = "test-mode")]`. Used by `:app` integration tests
+     * (issue #262) to prove the synthetic AI client actually emitted an
+     * SNI extension in its outbound ClientHello — Conscrypt
+     * (Robolectric's default JSSE) silently strips SNI, so these tests
+     * swap in BouncyCastle JSSE and rely on this counter to lock in the
+     * fix.
+     */
+    fun routedPassthroughSnis(): List<String> = requireAdmin().routedPassthroughSnis()
+
     private fun requireAdmin(): TestRelayAdmin = admin ?: fail(
         "TestRelayManager: test-mode admin not available — " +
             "construct with enableTestMode = true"
@@ -773,9 +785,22 @@ class TestRelayAdmin(private val port: Int) {
     }
 
     /** Subdomains captured by synthetic `/test/fcm-wake` calls, in arrival order. */
-    fun capturedWakes(): List<String> {
-        val body = statsRaw()
-        val marker = "\"captured_wakes\":"
+    fun capturedWakes(): List<String> = parseStringArrayField(statsRaw(), "captured_wakes")
+
+    /**
+     * SNI hostnames the relay's router dispatched to the device-passthrough
+     * path, in arrival order. Populated by `handle_connection` in
+     * `relay/src/main.rs` under `#[cfg(feature = "test-mode")]`. Used by
+     * `:app` integration tests (#262) to assert the synthetic AI client
+     * actually emitted an SNI extension in its ClientHello — Conscrypt
+     * (Robolectric's default JSSE) strips SNI, and BouncyCastle JSSE was
+     * swapped in to restore it.
+     */
+    fun routedPassthroughSnis(): List<String> =
+        parseStringArrayField(statsRaw(), "routed_passthrough_snis")
+
+    private fun parseStringArrayField(body: String, field: String): List<String> {
+        val marker = "\"$field\":"
         val idx = body.indexOf(marker)
         if (idx < 0) return emptyList()
         val open = body.indexOf('[', idx)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ okhttp = "5.3.2"
 desugar = "2.1.5"
 kover = "0.9.8"
 firebase-crashlytics-gradle = "3.0.6"
+bouncycastle = "1.78.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -115,6 +116,16 @@ datastore-preferences = { group = "androidx.datastore", name = "datastore-prefer
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
+
+# BouncyCastle JSSE — test-scope only. Robolectric registers Conscrypt as the
+# default JCA TLS provider; ConscryptEngineSocket silently strips the SNI
+# extension from outbound ClientHellos regardless of how it's configured (see
+# issue #262). BC JSSE honours `SSLParameters.serverNames`, so the synthetic
+# AI-client integration tests insert it at Security priority 1 for the
+# duration of the harness lifecycle to force `SSLContext.getInstance("TLS")`
+# to resolve to BC. Production code is untouched — no `implementation` dep.
+bouncycastle-jsse = { group = "org.bouncycastle", name = "bctls-jdk18on", version.ref = "bouncycastle" }
+bouncycastle-prov = { group = "org.bouncycastle", name = "bcprov-jdk18on", version.ref = "bouncycastle" }
 splashscreen = { group = "androidx.core", name = "core-splashscreen", version = "1.2.0" }
 desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugar" }
 

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -377,6 +377,14 @@ async fn handle_connection(
             // Build the SNI hostname for the OPEN frame
             let sni_hostname = format!("{integration_secret}.{subdomain}.{}", ctx.base_domain);
 
+            // Record the routed SNI for test-mode observers. `--test-mode` off
+            // (release builds) leaves `test_metrics` as None so this is a
+            // single nullable check on the hot path.
+            #[cfg(feature = "test-mode")]
+            if let Some(metrics) = &ctx.app_state.test_metrics {
+                metrics.record_routed_passthrough(&sni_hostname);
+            }
+
             let pt_ctx = PassthroughContext {
                 relay_state: ctx.relay_state,
                 session_registry: ctx.session_registry,

--- a/relay/src/test_mode.rs
+++ b/relay/src/test_mode.rs
@@ -66,6 +66,14 @@ pub struct TestMetrics {
     pub last_client_cert_seen: Mutex<std::collections::HashMap<String, bool>>,
     /// Synthetic FCM wake events captured via `POST /test/fcm-wake`.
     pub captured_wakes: Mutex<Vec<String>>,
+    /// SNI hostnames seen on successfully-routed device-passthrough
+    /// connections, in arrival order. Populated by `record_routed_passthrough`
+    /// from `main.rs::handle_connection` when a ClientHello is dispatched to
+    /// a device's mux session. Used by `:app` integration tests (#262) to
+    /// prove the synthetic AI client's outbound TLS actually carried an SNI
+    /// extension — previously Conscrypt (Robolectric's default JSSE) silently
+    /// dropped it.
+    pub routed_passthrough_snis: Mutex<Vec<String>>,
 }
 
 impl TestMetrics {
@@ -94,6 +102,15 @@ impl TestMetrics {
         }
         if let Ok(mut map) = self.last_client_cert_seen.lock() {
             map.insert(path.to_string(), had_client_cert);
+        }
+    }
+
+    /// Record an SNI hostname that was resolved to a device-passthrough route.
+    /// Called from the SNI router in `main.rs::handle_connection` right
+    /// before the splice task starts.
+    pub fn record_routed_passthrough(&self, sni: &str) {
+        if let Ok(mut v) = self.routed_passthrough_snis.lock() {
+            v.push(sni.to_string());
         }
     }
 }
@@ -180,6 +197,7 @@ pub struct StatsResponse {
     pub ws_calls: u64,
     pub last_client_cert_seen: std::collections::HashMap<String, bool>,
     pub captured_wakes: Vec<String>,
+    pub routed_passthrough_snis: Vec<String>,
 }
 
 pub async fn handle_stats(State(state): State<AdminState>) -> Response {
@@ -197,6 +215,11 @@ pub async fn handle_stats(State(state): State<AdminState>) -> Response {
             .unwrap_or_default(),
         captured_wakes: m
             .captured_wakes
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_default(),
+        routed_passthrough_snis: m
+            .routed_passthrough_snis
             .lock()
             .map(|g| g.clone())
             .unwrap_or_default(),


### PR DESCRIPTION
## Summary

- Install BouncyCastle JSSE + Prov at JCA priority 1 for the lifetime of `AppIntegrationTestHarness` so raw `SSLSocket` code paths (synthetic AI client) emit SNI via `SSLParameters.serverNames`. Conscrypt, Robolectric's default, silently stripped it.
- Route the OkHttp mTLS relay client (`FreshSslContextSocketFactory`) explicitly around BC to the highest-priority non-BC `SSLContext` + `TrustManagerFactory` provider. BC's TLS 1.3 client-auth path does not interoperate with the harness's `DelegatingX509KeyManager` / PKCS12 / `SunX509` stack.
- Relay test-mode gains a `routed_passthrough_snis` counter so tests can assert "the AI client's ClientHello actually reached the relay with SNI populated".
- New `ToolCallViaSniPassthroughTest` is the primary regression guard — stands up the real tunnel + `SessionHandler` and opens a raw `SSLSocket` with SNI, asserts the relay routed it to `DevicePassthrough`.

Does not replace the loopback batch-B scenarios; those still cover the device-side audit + notifier + MCP seams and the loopback driver is the right shape for them.

## Test plan

- [x] `./gradlew :app:integrationTest` — 20/20 pass, including the new `ToolCallViaSniPassthroughTest`
- [x] `./gradlew :app:testDebugUnitTest` — green
- [x] `./gradlew testDebugUnitTest` across all modules — green
- [x] `./gradlew :core:tunnel:integrationTest` — green (test fixture addition is backwards-compatible)
- [x] `./gradlew ktlintCheck` — green
- [x] Detekt on changed files — no new violations (pre-existing suite-wide detekt failures remain unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)