### PR TITLE
Fix #285 (part 1): /rotate-secret replace-semantics

### DIFF
--- a/app/src/test/java/com/rousecontext/app/integration/ReEnableDisabledIntegrationTest.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/ReEnableDisabledIntegrationTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -23,11 +24,12 @@ import org.robolectric.RobolectricTestRunner
  * Issue #276 — re-enabling a previously disabled integration must push the
  * integration back into the relay's valid-secrets cache.
  *
- * Unlike the initial-enable path, the integration already has a stored
- * secret: the relay's `/rotate-secret` handler is merge-missing, so when the
- * ID re-appears in the request it reuses the existing secret rather than
- * generating a fresh one. This test locks down that the device-side secret
- * is preserved verbatim across the disable/re-enable cycle.
+ * Since #285, the relay's `/rotate-secret` handler is replace-wholesale:
+ * when the device pushes `[test]` after disabling `test2`, the relay DROPS
+ * `test2`'s secret. When `test2` is re-enabled and the device pushes
+ * `[test, test2]`, the relay mints a FRESH secret for `test2` — the old
+ * one stays dead so any URL that leaked while it was live is permanently
+ * invalidated. This test locks down the new behavior.
  *
  * Scenario:
  *  1. Provision with two integrations configured.
@@ -35,8 +37,9 @@ import org.robolectric.RobolectricTestRunner
  *  3. Disable `test2`, push `[test]` only.
  *  4. Re-enable `test2`, push `[test, test2]`.
  *  5. Assert the final captured payload includes `test2`, the relay
- *     returned the SAME `test2` secret as the initial enable (merge-missing
- *     preserves it), and the device's local secret map matches.
+ *     issued a NEW `test2` secret different from the initial enable
+ *     (replace-wholesale, #285), and the device's local secret map
+ *     matches the fresh value.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
@@ -104,10 +107,10 @@ class ReEnableDisabledIntegrationTest {
                 captured[2]
             )
 
-            // Merge-missing: relay preserves the existing `test2` secret
-            // rather than generating a fresh one on re-enable. Verifying
-            // this pins down current design (issue #276 scope: "If existing
-            // design reuses the prior stored secret, assert that").
+            // Replace-wholesale (#285): the relay drops `test2`'s secret
+            // when the disable-push carries only `[test]`, then mints a
+            // FRESH secret for `test2` on re-enable. The original secret
+            // must stay dead so any leaked URL is permanently invalidated.
             val finalSecrets = certStore.getIntegrationSecrets()
             assertNotNull("final secrets map must be populated", finalSecrets)
             requireNotNull(finalSecrets)
@@ -115,9 +118,9 @@ class ReEnableDisabledIntegrationTest {
                 "final secrets map must contain the re-enabled integration",
                 finalSecrets.containsKey(TestSecondMcpIntegration.ID)
             )
-            assertEquals(
-                "relay's merge-missing behaviour must preserve the existing secret " +
-                    "across a disable/re-enable cycle (regression guard for #276)",
+            assertNotEquals(
+                "replace-wholesale (#285): re-enable after disable must mint " +
+                    "a fresh secret; the pre-disable value must stay invalid",
                 initialSecondSecret,
                 finalSecrets[TestSecondMcpIntegration.ID]
             )

--- a/relay/src/api/rotate_secret.rs
+++ b/relay/src/api/rotate_secret.rs
@@ -1,14 +1,24 @@
-//! POST /rotate-secret -- Merge-missing rotation of per-integration secrets.
+//! POST /rotate-secret -- Replace-wholesale rotation of per-integration
+//! secrets.
 //!
 //! Authenticated via mTLS (the subdomain is extracted from the client cert).
 //!
-//! Behavior:
+//! Behavior (see #285):
+//! * The `integrations` list in the request body is the AUTHORITATIVE set
+//!   of integrations the device wants live on the relay.
 //! * For each integration id in the request that already has a secret in
-//!   `DeviceRecord::integration_secrets`, the existing secret is preserved.
-//! * For each integration id not yet in the map, a fresh
-//!   `{adjective}-{integrationId}` secret is generated.
+//!   `DeviceRecord::integration_secrets`, the existing secret is preserved
+//!   (so repeated rotates-with-same-set are idempotent and don't invalidate
+//!   live client URLs).
+//! * For each integration id in the request not yet in the stored map, a
+//!   fresh `{adjective}-{integrationId}` secret is generated.
+//! * For each integration id in the stored map but NOT in the request, the
+//!   entry is REMOVED. This is the fix for #285: disabling an integration
+//!   on-device must be able to invalidate its secret on the relay.
 //! * `valid_secrets` is rebuilt from the resulting map so the SNI fast path
-//!   stays in sync.
+//!   stays in sync. An empty request list legitimately produces an empty
+//!   valid-secrets map and evicts the cache entry (device stays onboarded —
+//!   subdomain, account, cert, etc. are untouched).
 //! * The response returns the FULL integration→secret mapping; the client
 //!   treats its local store as a server-delivered mirror and replaces it
 //!   wholesale.
@@ -17,12 +27,11 @@
 //! `integration_secrets` field existed will hit this handler with an empty
 //! map. Every integration in the request will look "missing" and get a new
 //! secret — equivalent to the pre-#148 wholesale rotation, one time. After
-//! this call the map is populated and subsequent rotations preserve
-//! unchanged entries.
+//! this call the map matches the request exactly.
 //!
-//! Note: this handler does NOT drop integrations that disappear from the
-//! request. Removing a secret is not a supported operation here — the client
-//! calls this endpoint to add-or-refresh, not to trim.
+//! Security note: replace-wholesale means this endpoint can invalidate
+//! every active client URL for a device in one call. The mTLS identity
+//! requirement (#202) ensures only the device itself can trigger this.
 
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -40,18 +49,21 @@ use crate::api::{ApiError, AppState};
 
 #[derive(Debug, Deserialize)]
 pub struct RotateSecretRequest {
-    /// Integration IDs the client wants to have secrets for. The relay
-    /// generates fresh `{adjective}-{integrationId}` secrets only for IDs
-    /// not already present in the stored mapping.
+    /// Integration IDs the client wants to have secrets for. This is the
+    /// AUTHORITATIVE set (#285): the relay preserves existing secrets for
+    /// IDs that remain in this list, mints fresh secrets for new IDs, and
+    /// DROPS any previously stored secret whose id is not in this list.
+    /// An empty list is valid and invalidates every active per-integration
+    /// URL for this device.
     pub integrations: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct RotateSecretResponse {
     pub success: bool,
-    /// Full integration id → secret mapping after merge-missing. Includes
-    /// both preserved existing secrets and newly generated ones so the
-    /// client can mirror server-owned state without a local merge step.
+    /// Full integration id → secret mapping after replace-wholesale.
+    /// Exactly matches the request's integration set. The client mirrors
+    /// this wholesale into its local store.
     pub secrets: HashMap<String, String>,
 }
 
@@ -87,29 +99,40 @@ pub async fn handle_rotate_secret(
         }
     };
 
-    // Merge-missing: keep existing secrets, generate fresh ones only for
-    // integration ids not yet present in the stored mapping.
+    // Replace-wholesale (#285): the request's integration list is the
+    // authoritative set. Preserve secrets for integrations carried over
+    // from the previous map (idempotent for unchanged IDs), mint fresh
+    // secrets for new IDs, and DROP any previously stored secret whose
+    // integration id is not in the request.
     //
     // Scope the ThreadRng to this block so it is dropped before the next
     // `.await`; ThreadRng is `!Send`, so the future would otherwise not be
     // `Send` and couldn't be used with axum's Handler trait.
-    let mut merged = record.integration_secrets.clone();
+    let previous = record.integration_secrets.clone();
+    let mut replaced: HashMap<String, String> = HashMap::with_capacity(req.integrations.len());
     let mut newly_generated: Vec<String> = Vec::new();
     {
         let mut rng = rand::thread_rng();
         for integration_id in &req.integrations {
-            if !merged.contains_key(integration_id) {
+            if let Some(existing) = previous.get(integration_id) {
+                replaced.insert(integration_id.clone(), existing.clone());
+            } else {
                 let secret = generate_one_secret(integration_id, &mut rng);
-                merged.insert(integration_id.clone(), secret);
+                replaced.insert(integration_id.clone(), secret);
                 newly_generated.push(integration_id.clone());
             }
         }
     }
+    let removed: Vec<String> = previous
+        .keys()
+        .filter(|id| !replaced.contains_key(id.as_str()))
+        .cloned()
+        .collect();
 
     // Persist both shapes: the mapping is authoritative; valid_secrets is
     // derived so the SNI fast path keeps a flat membership list.
-    let valid_secrets: Vec<String> = merged.values().cloned().collect();
-    record.integration_secrets = merged.clone();
+    let valid_secrets: Vec<String> = replaced.values().cloned().collect();
+    record.integration_secrets = replaced.clone();
     record.valid_secrets = valid_secrets.clone();
 
     // Update Firestore
@@ -119,6 +142,9 @@ pub async fn handle_rotate_secret(
 
     // Update the in-memory valid_secrets cache so the next SNI connection for
     // this device does not have to wait for Firestore eventual consistency.
+    // `set_valid_secrets_cache` evicts the entry entirely when the vec is
+    // empty, which is the correct behavior for a wholesale-to-empty rotate
+    // (every previously live URL becomes invalid immediately).
     state
         .relay_state
         .set_valid_secrets_cache(&subdomain, valid_secrets);
@@ -127,14 +153,15 @@ pub async fn handle_rotate_secret(
         subdomain = %subdomain,
         requested = ?req.integrations,
         newly_generated = ?newly_generated,
-        "Secrets merged (merge-missing)"
+        removed = ?removed,
+        "Secrets replaced (replace-wholesale, #285)"
     );
 
     (
         StatusCode::OK,
         Json(RotateSecretResponse {
             success: true,
-            secrets: merged,
+            secrets: replaced,
         }),
     )
         .into_response()

--- a/relay/tests/api_rotate_secret_test.rs
+++ b/relay/tests/api_rotate_secret_test.rs
@@ -1,9 +1,18 @@
-//! Tests for POST /rotate-secret -- Merge-missing rotation.
+//! Tests for POST /rotate-secret -- Replace-wholesale rotation (#285).
+//!
+//! Prior to #285 this handler was merge-missing: integrations in the
+//! request were added or kept, and entries already in the stored map were
+//! never dropped. That left the "disable integration" path as a no-op
+//! against the relay: the per-integration URL stayed live after the user
+//! flipped it off. Fixed by making the request's `integrations` list the
+//! authoritative set — entries no longer present are removed from both
+//! Firestore and the in-memory cache.
 
 mod test_helpers;
 
 use rouse_relay::api::build_router;
 use rouse_relay::api::ws::DeviceIdentity;
+use rouse_relay::api::AppState;
 use rouse_relay::firestore::DeviceRecord;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -16,7 +25,7 @@ fn make_app_with_ca_as(
     firestore: MockFirestore,
     firebase_auth: MockFirebaseAuth,
     identity_subdomain: &str,
-) -> (axum::Router, Arc<MockFirestore>) {
+) -> (axum::Router, Arc<MockFirestore>, Arc<AppState>) {
     let firestore = Arc::new(firestore);
     let state = build_test_state_with_ca(
         firestore.clone(),
@@ -24,10 +33,10 @@ fn make_app_with_ca_as(
         Arc::new(MockAcme::new("test-cert")),
         Arc::new(firebase_auth),
     );
-    let router = build_router(state).layer(axum::Extension(DeviceIdentity {
+    let router = build_router(state.clone()).layer(axum::Extension(DeviceIdentity {
         subdomain: identity_subdomain.to_string(),
     }));
-    (router, firestore)
+    (router, firestore, state)
 }
 
 /// Build a router WITHOUT any `DeviceIdentity` extension, simulating an
@@ -64,7 +73,7 @@ fn make_device(secret: &str) -> DeviceRecord {
 #[tokio::test]
 async fn rotate_secret_generates_and_returns_new_secrets() {
     let firestore = MockFirestore::new().with_device("cool-penguin", make_device("old-secret"));
-    let (app, fs) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "cool-penguin");
+    let (app, fs, _state) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "cool-penguin");
 
     let resp = axum::http::Request::builder()
         .method("POST")
@@ -106,7 +115,8 @@ async fn rotate_secret_generates_and_returns_new_secrets() {
     }
 
     // Verify Firestore was updated with both the flat list (SNI path) and
-    // the integration map (authoritative source for future merge-missing).
+    // the integration map (authoritative source for future replace-
+    // wholesale rotations).
     let devices = fs.devices.lock().unwrap();
     let updated = devices.get("cool-penguin").unwrap();
     assert_eq!(updated.valid_secrets.len(), 2);
@@ -131,7 +141,8 @@ async fn rotate_secret_generates_and_returns_new_secrets() {
 async fn rotate_secret_preserves_existing_secrets_when_all_present() {
     // Device already has two integrations with known secrets — rotate-secret
     // called with the same two IDs should return exactly those values
-    // unchanged (merge-missing-of-zero).
+    // unchanged (replace-wholesale is idempotent for the unchanged-set
+    // case; #285).
     let mut device = make_device("unused");
     device.integration_secrets = HashMap::from([
         ("outreach".to_string(), "brave-outreach".to_string()),
@@ -139,7 +150,7 @@ async fn rotate_secret_preserves_existing_secrets_when_all_present() {
     ]);
     device.valid_secrets = device.integration_secrets.values().cloned().collect();
     let firestore = MockFirestore::new().with_device("cool-penguin", device);
-    let (app, fs) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "cool-penguin");
+    let (app, fs, _state) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "cool-penguin");
 
     let resp = axum::http::Request::builder()
         .method("POST")
@@ -188,7 +199,7 @@ async fn rotate_secret_mix_of_new_and_existing_returns_full_map() {
         HashMap::from([("outreach".to_string(), "brave-outreach".to_string())]);
     device.valid_secrets = device.integration_secrets.values().cloned().collect();
     let firestore = MockFirestore::new().with_device("cool-penguin", device);
-    let (app, fs) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "cool-penguin");
+    let (app, fs, _state) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "cool-penguin");
 
     let resp = axum::http::Request::builder()
         .method("POST")
@@ -246,10 +257,10 @@ async fn rotate_secret_legacy_device_populates_map() {
     // Transitional: device registered before #148 has an empty
     // integration_secrets map. Every requested integration looks "missing"
     // and gets a fresh secret — equivalent to pre-#148 wholesale rotation
-    // for this one call. After, the map is populated for future merges.
+    // for this one call. After, the map is populated for future rotations.
     let device = make_device("unused"); // integration_secrets = HashMap::new()
     let firestore = MockFirestore::new().with_device("cool-penguin", device);
-    let (app, fs) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "cool-penguin");
+    let (app, fs, _state) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "cool-penguin");
 
     let resp = axum::http::Request::builder()
         .method("POST")
@@ -296,7 +307,7 @@ async fn rotate_secret_device_not_found_returns_404() {
     let firestore = MockFirestore::new(); // no devices
                                           // mTLS layer presents an identity for a subdomain that no device record
                                           // exists for (e.g. cert was revoked or Firestore lost the row).
-    let (app, _) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "nonexistent");
+    let (app, _, _) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "nonexistent");
 
     let resp = axum::http::Request::builder()
         .method("POST")
@@ -365,7 +376,7 @@ async fn rotate_secret_ignores_body_subdomain_when_identity_present() {
     let firestore = MockFirestore::new()
         .with_device("cool-penguin", make_device("owned-by-victim"))
         .with_device("attacker-sub", make_device("owned-by-attacker"));
-    let (app, fs) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "attacker-sub");
+    let (app, fs, _state) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "attacker-sub");
 
     let resp = axum::http::Request::builder()
         .method("POST")
@@ -400,4 +411,243 @@ async fn rotate_secret_ignores_body_subdomain_when_identity_present() {
         1,
         "attacker's own subdomain (from mTLS identity) is the one that gets rotated"
     );
+}
+
+/// #285 regression: starting with [A, B, C], POST /rotate-secret with
+/// [A, C] must DROP B from both the Firestore valid-secrets map and the
+/// in-memory cache. Before the fix, the handler was merge-missing and B
+/// would have stayed valid forever.
+#[tokio::test]
+async fn rotate_secret_drops_integrations_not_in_request() {
+    let mut device = make_device("unused");
+    device.integration_secrets = HashMap::from([
+        ("a".to_string(), "brave-a".to_string()),
+        ("b".to_string(), "clever-b".to_string()),
+        ("c".to_string(), "swift-c".to_string()),
+    ]);
+    device.valid_secrets = device.integration_secrets.values().cloned().collect();
+    let firestore = MockFirestore::new().with_device("cool-penguin", device);
+    let (app, fs, state) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "cool-penguin");
+
+    // Prime the in-memory cache to mirror the Firestore state, simulating
+    // the state after a prior SNI lookup. The test then asserts the cache
+    // is rewritten to exclude B.
+    state.relay_state.set_valid_secrets_cache(
+        "cool-penguin",
+        vec![
+            "brave-a".to_string(),
+            "clever-b".to_string(),
+            "swift-c".to_string(),
+        ],
+    );
+
+    let req = axum::http::Request::builder()
+        .method("POST")
+        .uri("/rotate-secret")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            serde_json::json!({ "integrations": ["a", "c"] }).to_string(),
+        ))
+        .unwrap();
+    let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let secrets = json["secrets"].as_object().expect("secrets map missing");
+    assert_eq!(secrets.len(), 2, "response must contain exactly [a, c]");
+    assert_eq!(secrets["a"].as_str().unwrap(), "brave-a");
+    assert_eq!(secrets["c"].as_str().unwrap(), "swift-c");
+    assert!(secrets.get("b").is_none(), "b must be absent from response");
+
+    // Firestore: B is gone from both the map and the flat list.
+    let devices = fs.devices.lock().unwrap();
+    let stored = devices.get("cool-penguin").unwrap();
+    assert_eq!(stored.integration_secrets.len(), 2);
+    assert!(!stored.integration_secrets.contains_key("b"));
+    assert!(stored.valid_secrets.contains(&"brave-a".to_string()));
+    assert!(stored.valid_secrets.contains(&"swift-c".to_string()));
+    assert!(
+        !stored.valid_secrets.contains(&"clever-b".to_string()),
+        "B's secret must be dropped from Firestore valid_secrets"
+    );
+    drop(devices);
+
+    // In-memory cache: B's secret must no longer be a valid member.
+    let cached = state
+        .relay_state
+        .get_valid_secrets_cache("cool-penguin")
+        .expect("cache entry should exist for non-empty set");
+    assert_eq!(cached.len(), 2);
+    assert!(cached.contains(&"brave-a".to_string()));
+    assert!(cached.contains(&"swift-c".to_string()));
+    assert!(
+        !cached.contains(&"clever-b".to_string()),
+        "B's secret must be evicted from the valid-secrets cache"
+    );
+}
+
+/// #285 regression: starting with [A], POST /rotate-secret with [B] must
+/// invalidate A and mint a fresh secret for B. Both sides of the
+/// replace-wholesale semantics exercised in a single call.
+#[tokio::test]
+async fn rotate_secret_swaps_integration_set() {
+    let mut device = make_device("unused");
+    device.integration_secrets = HashMap::from([("a".to_string(), "brave-a".to_string())]);
+    device.valid_secrets = device.integration_secrets.values().cloned().collect();
+    let firestore = MockFirestore::new().with_device("cool-penguin", device);
+    let (app, fs, state) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "cool-penguin");
+    state
+        .relay_state
+        .set_valid_secrets_cache("cool-penguin", vec!["brave-a".to_string()]);
+
+    let req = axum::http::Request::builder()
+        .method("POST")
+        .uri("/rotate-secret")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            serde_json::json!({ "integrations": ["b"] }).to_string(),
+        ))
+        .unwrap();
+    let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let secrets = json["secrets"].as_object().expect("secrets map missing");
+    assert_eq!(secrets.len(), 1);
+    let b_secret = secrets["b"].as_str().unwrap().to_string();
+    assert!(b_secret.ends_with("-b"));
+
+    // Firestore: A is gone, B is present and freshly minted.
+    let devices = fs.devices.lock().unwrap();
+    let stored = devices.get("cool-penguin").unwrap();
+    assert_eq!(stored.integration_secrets.len(), 1);
+    assert!(!stored.integration_secrets.contains_key("a"));
+    assert_eq!(stored.integration_secrets.get("b").unwrap(), &b_secret);
+    assert_eq!(stored.valid_secrets, vec![b_secret.clone()]);
+    drop(devices);
+
+    // In-memory cache: only B's secret is valid now.
+    let cached = state
+        .relay_state
+        .get_valid_secrets_cache("cool-penguin")
+        .expect("cache entry should exist for non-empty set");
+    assert_eq!(cached, vec![b_secret]);
+}
+
+/// #285 regression: empty integrations list legitimately invalidates
+/// every per-integration URL for the device — but the device itself stays
+/// onboarded (subdomain, account, public key, cert all untouched). The
+/// in-memory cache entry is fully evicted so the passthrough path returns
+/// a miss.
+#[tokio::test]
+async fn rotate_secret_empty_list_clears_all_secrets() {
+    let mut device = make_device("keep-me");
+    device.integration_secrets = HashMap::from([
+        ("a".to_string(), "brave-a".to_string()),
+        ("b".to_string(), "clever-b".to_string()),
+    ]);
+    device.valid_secrets = device.integration_secrets.values().cloned().collect();
+    let original_fcm = device.fcm_token.clone();
+    let original_uid = device.firebase_uid.clone();
+    let original_pubkey = device.public_key.clone();
+    let original_cert_expires = device.cert_expires;
+    let original_registered_at = device.registered_at;
+    let original_prefix = device.secret_prefix.clone();
+
+    let firestore = MockFirestore::new().with_device("cool-penguin", device);
+    let (app, fs, state) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "cool-penguin");
+    state.relay_state.set_valid_secrets_cache(
+        "cool-penguin",
+        vec!["brave-a".to_string(), "clever-b".to_string()],
+    );
+
+    let req = axum::http::Request::builder()
+        .method("POST")
+        .uri("/rotate-secret")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            serde_json::json!({ "integrations": [] }).to_string(),
+        ))
+        .unwrap();
+    let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let secrets = json["secrets"].as_object().expect("secrets map missing");
+    assert!(
+        secrets.is_empty(),
+        "response map must be empty after wholesale-to-empty rotate"
+    );
+
+    // Firestore: secrets are gone but everything else about the device
+    // record is preserved. Device stays onboarded; the user can still
+    // re-enable integrations later without re-registering.
+    let devices = fs.devices.lock().unwrap();
+    let stored = devices.get("cool-penguin").unwrap();
+    assert!(stored.integration_secrets.is_empty());
+    assert!(stored.valid_secrets.is_empty());
+    assert_eq!(stored.fcm_token, original_fcm);
+    assert_eq!(stored.firebase_uid, original_uid);
+    assert_eq!(stored.public_key, original_pubkey);
+    assert_eq!(stored.cert_expires, original_cert_expires);
+    assert_eq!(stored.registered_at, original_registered_at);
+    assert_eq!(stored.secret_prefix, original_prefix);
+    drop(devices);
+
+    // Cache is evicted (not just emptied) so the passthrough path falls
+    // back to Firestore and sees no valid secrets.
+    assert_eq!(
+        state.relay_state.get_valid_secrets_cache("cool-penguin"),
+        None,
+        "cache must be evicted when valid_secrets becomes empty"
+    );
+}
+
+/// #285 regression guard: the additions-still-work case. Starting with
+/// [A], POST /rotate-secret with [A, B] leaves A untouched and mints B.
+/// This is the behavior that pre-#285 tests covered; we keep it green to
+/// ensure replace-wholesale didn't accidentally break additive rotates.
+#[tokio::test]
+async fn rotate_secret_additions_still_work() {
+    let mut device = make_device("unused");
+    device.integration_secrets = HashMap::from([("a".to_string(), "brave-a".to_string())]);
+    device.valid_secrets = device.integration_secrets.values().cloned().collect();
+    let firestore = MockFirestore::new().with_device("cool-penguin", device);
+    let (app, fs, _state) = make_app_with_ca_as(firestore, MockFirebaseAuth::new(), "cool-penguin");
+
+    let req = axum::http::Request::builder()
+        .method("POST")
+        .uri("/rotate-secret")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(
+            serde_json::json!({ "integrations": ["a", "b"] }).to_string(),
+        ))
+        .unwrap();
+    let resp = tower::ServiceExt::oneshot(app, req).await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let secrets = json["secrets"].as_object().expect("secrets map missing");
+    assert_eq!(secrets.len(), 2);
+    assert_eq!(secrets["a"].as_str().unwrap(), "brave-a");
+    let b_secret = secrets["b"].as_str().unwrap();
+    assert!(b_secret.ends_with("-b"));
+
+    let devices = fs.devices.lock().unwrap();
+    let stored = devices.get("cool-penguin").unwrap();
+    assert_eq!(stored.integration_secrets.len(), 2);
+    assert_eq!(stored.integration_secrets.get("a").unwrap(), "brave-a");
+    assert_eq!(stored.integration_secrets.get("b").unwrap(), b_secret);
 }


### PR DESCRIPTION
## Summary

Part 1 of #285 (ship-block). Changes the relay's `/rotate-secret` handler from merge-missing to replace-wholesale so that disabling an integration on-device can actually invalidate its per-integration URL.

Before: the request's integrations list was merged into the stored map; entries only in the stored map were never dropped. A client calling `/rotate-secret` with a shortened list after a disable couldn't remove the disabled integration's secret.

After: the request's `integrations` list is the authoritative set. Entries preserved across requests keep their existing secret (repeat rotates stay idempotent). Entries no longer present are removed from both Firestore's valid-secrets map and the in-memory passthrough cache. Empty list is valid and invalidates every per-integration URL while leaving the device onboarded (subdomain, account, cert, FCM token untouched).

Out of scope for this PR: the device-side auto-push listener (observe `IntegrationStateStore` flips and batch `/rotate-secret` on each). That's part 2, lands separately.

## Landing order rationale

This change is safe to land before part 2. No current device client calls `/rotate-secret` with a disabled integration removed from the list — so replace-wholesale only changes behavior when a part-2-aware client shows up. The existing regression tests (additions, preserving unchanged secrets, unauthenticated 401, device-not-found 404) all stay green with the new semantics.

## Tests

New Rust tests in `relay/tests/api_rotate_secret_test.rs`:

- `rotate_secret_drops_integrations_not_in_request` — start with [A, B, C], POST [A, C], assert B is gone from Firestore and from the in-memory cache.
- `rotate_secret_swaps_integration_set` — start with [A], POST [B], assert A invalidated and B freshly minted on both sides.
- `rotate_secret_empty_list_clears_all_secrets` — POST with `[]`, assert secrets gone but device record (fcm_token, firebase_uid, public_key, cert_expires, registered_at, secret_prefix) untouched and cache entry evicted.
- `rotate_secret_additions_still_work` — regression guard: start with [A], POST [A, B], both present, A unchanged.

Also updated `ReEnableDisabledIntegrationTest.kt` (#276 coverage) which was pinning down the merge-missing design: under replace-wholesale, re-enabling a previously disabled integration must mint a fresh secret (the old one stays dead to kill any leaked URL). Swapped `assertEquals` for `assertNotEquals` and updated the kdoc.

All 11 relay tests pass, full `cargo test` green, `cargo clippy --all-targets -- -D warnings` clean (also with `--features test-mode`). The affected app-level integration test passes via `:app:integrationTest`.

## Follow-up

- #285 stays open pending part 2 (device-side auto-push listener).
- Part 2 owner: extend `:work` (or equivalent) to observe `IntegrationStateStore.userEnabled` flips and call `RelayApiClient.updateSecrets` with the current enabled set. Then close #285.

## Test plan

- [x] `cargo fmt`
- [x] `cargo test` (full relay suite green)
- [x] `cargo test --features test-mode` (green)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo clippy --all-targets --features test-mode -- -D warnings` (clean)
- [x] `:app:integrationTest --tests ReEnableDisabledIntegrationTest` (green)

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)