### PR TITLE
Fix #289: Force-immediate cert renewal check on app start

### DIFF
--- a/app/src/main/java/com/rousecontext/app/RouseApplication.kt
+++ b/app/src/main/java/com/rousecontext/app/RouseApplication.kt
@@ -10,6 +10,7 @@ import com.rousecontext.app.debug.debugModules
 import com.rousecontext.app.di.appModule
 import com.rousecontext.app.state.AppStatePreferences
 import com.rousecontext.notifications.NotificationChannels
+import com.rousecontext.tunnel.CertificateStore
 import com.rousecontext.work.CertRenewalScheduler
 import com.rousecontext.work.KoinWorkerFactory
 import com.rousecontext.work.SecurityCheckWorker
@@ -68,6 +69,28 @@ class RouseApplication :
         configureCrashReporting()
         scheduleSecurityChecks()
         CertRenewalScheduler.enqueuePeriodic(this)
+        enqueueImmediateCertRenewalIfNeeded()
+    }
+
+    /**
+     * Fire-and-forget app-start hook that forces an immediate cert renewal
+     * when the stored cert is near-expiry or already expired (issue #289).
+     *
+     * Without this, the periodic worker's 24h interval means a user opening
+     * the app with an expired cert would sit stuck until the next periodic
+     * tick — the TLS tunnel handshake would fail well before that, with no
+     * in-band recovery path.
+     *
+     * Runs on [appScope] so [onCreate] stays non-blocking; Koin resolution
+     * for [CertificateStore] also happens here rather than in the static
+     * scheduler to keep the scheduler reusable from tests that don't run
+     * the full DI graph.
+     */
+    private fun enqueueImmediateCertRenewalIfNeeded() {
+        appScope.launch {
+            val certStore: CertificateStore = GlobalContext.get().get()
+            CertRenewalScheduler.enqueueImmediateIfExpiring(this@RouseApplication, certStore)
+        }
     }
 
     /**

--- a/app/src/test/java/com/rousecontext/app/integration/ExpiredCertRenewalOnStartTest.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/ExpiredCertRenewalOnStartTest.kt
@@ -9,6 +9,7 @@ import androidx.work.WorkManager
 import androidx.work.testing.SynchronousExecutor
 import androidx.work.testing.WorkManagerTestInitHelper
 import com.rousecontext.app.integration.harness.AppIntegrationTestHarness
+import com.rousecontext.tunnel.CertificateStore
 import com.rousecontext.tunnel.RenewalResult
 import com.rousecontext.work.CertRenewalPreferences
 import com.rousecontext.work.CertRenewalScheduler
@@ -22,7 +23,9 @@ import java.util.UUID
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -30,53 +33,39 @@ import org.koin.dsl.module
 import org.robolectric.RobolectricTestRunner
 
 /**
- * Integration-tier coverage for issue #278 — the "device sat idle past 90-day
- * cert expiry, then the user opens the app" flow.
+ * Integration-tier coverage for issues #278 + #289.
  *
- * # What this test file covers (distinct from #277)
+ * # What this test file covers
  *
  * Issue #277 ([CertRenewalWorkerSchedulingTest]) verifies WorkManager
  * *scheduling* wiring (constraints, reschedule-after-success, periodic-work
  * enqueue semantics) and the **near-expiry mTLS** branch of
- * [CertRenewalWorker.doWork]. The worker's **already-expired Firebase**
- * branch — entered only when `millisUntilExpiry <= 0` — was not exercised
- * at integration tier prior to this file.
+ * [CertRenewalWorker.doWork]. Issue #278 asked for coverage of the
+ * **already-expired Firebase** branch that sibling test didn't exercise.
+ * Issue #289 asked for coverage of the app-start *immediate-renewal* path
+ * that was missing prior to this fix.
  *
- * The distinction matters because:
+ * This file owns both:
  *
- * - The near-expiry branch reaches [CertRenewer.renewWithMtls]; the expired
- *   branch reaches [CertRenewer.renewWithFirebase]. These are *different*
- *   relay endpoints (`/renew` with mTLS proof-of-possession vs. `/renew`
- *   with a Firebase token + CSR signature), and the [RenewalAuthProvider]
- *   contract splits between [RenewalAuthProvider.signCsr] and
- *   [RenewalAuthProvider.acquireFirebaseCredentials] along the same line.
- *   A regression that only fires on the expired path (Firebase token
- *   acquisition bug, keystore signing bug specific to that call site) would
- *   sail past the near-expiry tests unnoticed.
- *
- * - The #277 test file overrides the on-disk cert file with a keytool-minted
- *   stub whose `notAfter` is ~10 days out. That path never drives the code
- *   the expired branch executes. Here we mint a stub whose `notAfter` is in
- *   the past, observe the worker take the Firebase path, and confirm the
- *   success/failure outcomes are persisted via [CertRenewalPreferences].
+ * - Worker-path scenarios (the #278 coverage): an already-expired cert takes
+ *   [CertRenewer.renewWithFirebase], not the mTLS path, and the
+ *   `EXPIRED_NO_AUTH` outcome is persisted when Firebase auth is unavailable.
+ * - App-start scheduling scenarios (the #289 coverage):
+ *   [CertRenewalScheduler.enqueueImmediateIfExpiring] — the new call wired
+ *   from [com.rousecontext.app.RouseApplication.onCreate] — actually enqueues
+ *   an immediate one-time renewal when the cert is expired or near-expiry,
+ *   is a no-op for a healthy cert, and does NOT clobber the periodic slot.
  *
  * # What this test file does NOT cover
  *
- * The issue's original scenario — "user opens the app with an expired cert
- * and renewal kicks in *immediately*" — cannot pass against current code.
- * [com.rousecontext.app.RouseApplication.onCreate] only calls
- * [CertRenewalScheduler.enqueuePeriodic], which schedules a periodic
- * worker on a 24-hour interval. There is no app-start or tunnel-connect
- * path that checks cert expiry and forces an immediate renewal run.
- *
- * This gap is tracked as a follow-up in issue #289 (filed during the
- * discovery phase of #278). The [appStartDoesNotForceImmediateRenewal]
- * scenario below is a **regression guard** documenting current behaviour
- * so #289's fix can be verified: once the app-start path learns to force
- * an immediate run on near-expiry cert, that test flips to assert the
- * *new* correct behaviour (renewal fired once at startup) and the
- * worker's Firebase-path coverage stays useful as the underlying exercise
- * of the expired-cert code branch.
+ * The `enqueueImmediateIfExpiring` threshold-decision unit tests (no cert,
+ * far-from-expiry vs near-expiry, `ExistingWorkPolicy.KEEP` semantics) live
+ * in `:work`'s [com.rousecontext.work.CertRenewalSchedulerTest]. That suite
+ * drives the scheduler directly without the relay fixture, so it's the
+ * cheaper place to cover pure-decision logic; this file is the integration
+ * counterpart that proves the immediate-renewal path reaches the real
+ * [com.rousecontext.app.cert.FileCertificateStore] off disk and actually
+ * runs the worker end-to-end.
  *
  * # Why integration tier
  *
@@ -89,6 +78,14 @@ import org.robolectric.RobolectricTestRunner
  * writes outcome telemetry, and WorkManager drives the whole thing — the
  * same shape every production-code regression would have to traverse to
  * be caught.
+ *
+ * We invoke [CertRenewalScheduler] directly (rather than booting a fresh
+ * [com.rousecontext.app.RouseApplication] per scenario) because the harness
+ * already stands up the full Koin graph with the fixture relay —
+ * re-constructing the `Application` under Robolectric would re-boot Koin
+ * underneath the running relay and hit teardown ordering bugs. The scheduler
+ * call is the exact one that `onCreate` makes, so this covers the
+ * production path without the `Application`-lifecycle tangle.
  */
 @RunWith(RobolectricTestRunner::class)
 class ExpiredCertRenewalOnStartTest {
@@ -214,50 +211,155 @@ class ExpiredCertRenewalOnStartTest {
     }
 
     // ------------------------------------------------------------------
-    // Scenario 3: regression guard for gap #289 — app start does NOT force
-    // an immediate renewal run today
+    // Scenario 3: app start with an already-expired cert forces an
+    // immediate renewal (the #289 fix). Inverts the earlier regression
+    // guard — once #289 landed, we no longer expect the expired-cert user
+    // to sit stuck for up to 24h.
     // ------------------------------------------------------------------
 
     @Test
-    fun `app start only schedules periodic work and does not run renewal immediately`() =
-        runBlocking {
-            harness.provisionDevice()
-            overwriteCertOnDisk(daysUntilExpiry = -5L)
+    fun `app start with expired cert forces an immediate renewal run`() = runBlocking {
+        harness.provisionDevice()
+        overwriteCertOnDisk(daysUntilExpiry = -5L)
 
-            // This is the exact call made from `RouseApplication.onCreate` —
-            // no other renewal-kickoff exists in the production startup path.
-            CertRenewalScheduler.enqueuePeriodic(context)
+        val certStore: CertificateStore = harness.koin.get()
 
-            val wm = WorkManager.getInstance(context)
-            val infos = wm.getWorkInfosForUniqueWork(CertRenewalWorker.WORK_NAME).get()
-            assertEquals(
-                "enqueuePeriodic must create exactly one unique work entry",
-                1,
-                infos.size
-            )
-            val info = infos.single()
-            assertNotNull("periodic work must be tracked by WorkManager", info)
-            assertEquals(
-                "Periodic work is ENQUEUED waiting for the next period — NOT running. " +
-                    "Until gap #289 is fixed, a user who opens the app with an expired " +
-                    "cert waits up to `PERIODIC_INTERVAL_HOURS` (24h) for renewal to fire. " +
-                    "Once #289 lands, flip this assertion to verify the immediate kick.",
-                WorkInfo.State.ENQUEUED,
-                info.state
-            )
-            assertEquals(
-                "No renewer method must have fired from startup alone — the periodic " +
-                    "delay is what is stranding the expired-cert user. This is the " +
-                    "regression that gap #289 tracks. The [fakeRenewer] is per-test so " +
-                    "its counters reset across [setUp]; the call-count assertion is the " +
-                    "reliable signal that the worker did not run. (A sibling " +
-                    "`CertRenewalPreferences.lastOutcome` check would be flaky — the " +
-                    "`cert_renewal` DataStore file is reused across tests in the same " +
-                    "JVM and already holds whatever prior scenarios wrote.)",
-                0,
-                fakeRenewer.mtlsCalls + fakeRenewer.firebaseCalls
-            )
-        }
+        // Reproduce the exact `RouseApplication.onCreate` sequence.
+        CertRenewalScheduler.enqueuePeriodic(context)
+        val enqueued = CertRenewalScheduler.enqueueImmediateIfExpiring(context, certStore)
+
+        assertTrue(
+            "Expired cert at app start MUST force an immediate renewal — " +
+                "this is the #289 fix. Before the fix landed, only the periodic " +
+                "worker was scheduled and the expired-cert user sat stuck for " +
+                "up to 24h.",
+            enqueued
+        )
+
+        val wm = WorkManager.getInstance(context)
+        val periodicInfos = wm.getWorkInfosForUniqueWork(CertRenewalWorker.WORK_NAME).get()
+        assertEquals(
+            "Periodic slot must still hold exactly one periodic worker entry",
+            1,
+            periodicInfos.size
+        )
+        assertNotNull(
+            "Periodic work must be tracked",
+            periodicInfos.single()
+        )
+
+        val immediateInfos = wm
+            .getWorkInfosForUniqueWork(CertRenewalScheduler.WORK_NAME_IMMEDIATE)
+            .get()
+        assertEquals(
+            "Immediate slot must hold the one-time renewal request",
+            1,
+            immediateInfos.size
+        )
+        val immediateInfo = immediateInfos.single()
+
+        // Drive the constraints-gated one-time worker to completion.
+        val testDriver = WorkManagerTestInitHelper.getTestDriver(context)
+            ?: error("WorkManagerTestInitHelper.getTestDriver returned null")
+        testDriver.setAllConstraintsMet(immediateInfo.id)
+
+        val finalInfo = pollWorkInfo(wm, immediateInfo.id)
+        assertEquals(
+            "Immediate renewal must run to completion, not just sit enqueued",
+            WorkInfo.State.SUCCEEDED,
+            finalInfo.state
+        )
+        assertEquals(
+            "Expired cert must take the Firebase renewal path",
+            1,
+            fakeRenewer.firebaseCalls
+        )
+        assertEquals(
+            "mTLS path must not fire for an expired cert",
+            0,
+            fakeRenewer.mtlsCalls
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Scenario 4: near-expiry cert at app start also forces an immediate
+    // renewal — the window is wider than "already expired" so the user
+    // is pre-empted before the tunnel has a chance to break.
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `app start with near-expiry cert forces an immediate renewal run`() = runBlocking {
+        harness.provisionDevice()
+        overwriteCertOnDisk(daysUntilExpiry = 5L) // < 21-day window
+
+        val certStore: CertificateStore = harness.koin.get()
+        val enqueued = CertRenewalScheduler.enqueueImmediateIfExpiring(context, certStore)
+
+        assertTrue(
+            "Cert inside the 21-day renewal window must also trigger the " +
+                "immediate run — otherwise the first tunnel reconnect after app " +
+                "open races against the periodic schedule.",
+            enqueued
+        )
+
+        val wm = WorkManager.getInstance(context)
+        val immediateInfo = wm
+            .getWorkInfosForUniqueWork(CertRenewalScheduler.WORK_NAME_IMMEDIATE)
+            .get()
+            .single()
+
+        val testDriver = WorkManagerTestInitHelper.getTestDriver(context)
+            ?: error("WorkManagerTestInitHelper.getTestDriver returned null")
+        testDriver.setAllConstraintsMet(immediateInfo.id)
+
+        val finalInfo = pollWorkInfo(wm, immediateInfo.id)
+        assertEquals(WorkInfo.State.SUCCEEDED, finalInfo.state)
+        assertEquals(
+            "Near-expiry (not yet expired) cert must take the mTLS renewal path",
+            1,
+            fakeRenewer.mtlsCalls
+        )
+        assertEquals(
+            "Firebase path must not fire for a still-valid near-expiry cert",
+            0,
+            fakeRenewer.firebaseCalls
+        )
+    }
+
+    // ------------------------------------------------------------------
+    // Scenario 5: healthy cert at app start is a no-op. Prevents a
+    // regression where the new immediate-renewal path over-fires and
+    // turns into a second periodic worker.
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `app start with healthy cert does not enqueue immediate work`() = runBlocking {
+        harness.provisionDevice()
+        overwriteCertOnDisk(daysUntilExpiry = 70L) // well beyond the 21-day window
+
+        val certStore: CertificateStore = harness.koin.get()
+        val enqueued = CertRenewalScheduler.enqueueImmediateIfExpiring(context, certStore)
+
+        assertFalse(
+            "Healthy cert (70d > 21d window) must NOT enqueue an immediate run — " +
+                "the periodic worker is the correct owner of long-window renewals",
+            enqueued
+        )
+
+        val wm = WorkManager.getInstance(context)
+        val infos = wm
+            .getWorkInfosForUniqueWork(CertRenewalScheduler.WORK_NAME_IMMEDIATE)
+            .get()
+        assertTrue(
+            "No immediate work should exist for a healthy cert",
+            infos.isEmpty()
+        )
+        assertEquals(
+            "Renewer must not be invoked",
+            0,
+            fakeRenewer.mtlsCalls + fakeRenewer.firebaseCalls
+        )
+    }
 
     // ------------------------------------------------------------------
     // helpers
@@ -269,6 +371,11 @@ class ExpiredCertRenewalOnStartTest {
      * [CertRenewalWorkerSchedulingTest.enqueueAndDrain] — one-time work lets us
      * assert the terminal state directly rather than untangle WorkManager's
      * periodic-work "state bounces back to ENQUEUED on success" semantics.
+     *
+     * Used by the worker-path scenarios that exercise [CertRenewalWorker]
+     * directly; the app-start scenarios go through
+     * [CertRenewalScheduler.enqueueImmediateIfExpiring] instead so they cover
+     * the production enqueue path.
      */
     private fun enqueueAndDrain(): UUID {
         val request = OneTimeWorkRequestBuilder<CertRenewalWorker>().build()

--- a/work/src/main/kotlin/com/rousecontext/work/CertRenewalScheduler.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/CertRenewalScheduler.kt
@@ -9,6 +9,7 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
+import com.rousecontext.tunnel.CertificateStore
 import java.util.concurrent.TimeUnit
 
 /**
@@ -68,7 +69,70 @@ object CertRenewalScheduler {
         )
     }
 
+    /**
+     * Enqueue a one-time renewal immediately if the stored cert is near-expiry or
+     * already expired (issue #289). Intended to be called from
+     * `RouseApplication.onCreate` alongside [enqueuePeriodic] so a user who opens
+     * the app with an expired cert doesn't sit stuck waiting for the first
+     * periodic tick (up to 24h).
+     *
+     * Design notes:
+     * - Uses [WORK_NAME_IMMEDIATE], a *distinct* unique-work name, so it does
+     *   not clobber the periodic schedule installed by [enqueuePeriodic].
+     * - Uses [ExistingWorkPolicy.KEEP]: if a previous immediate run is still
+     *   pending, don't replace it. The periodic worker is the long-running
+     *   safety net — the immediate run is a best-effort kick.
+     * - Returns `false` when no immediate enqueue was necessary (cert missing
+     *   or valid for longer than [thresholdMillis]); the caller doesn't need
+     *   the return, but tests do.
+     *
+     * @param thresholdMillis how close to expiry triggers an immediate run.
+     *   Defaults to [CertRenewalWorker.DEFAULT_RENEWAL_WINDOW_DAYS] days,
+     *   matching the worker's internal `renewalWindowDays` so we don't enqueue
+     *   a run the worker will then early-out on.
+     */
+    suspend fun enqueueImmediateIfExpiring(
+        context: Context,
+        certStore: CertificateStore,
+        thresholdMillis: Long = DEFAULT_IMMEDIATE_THRESHOLD_MS,
+        now: Long = System.currentTimeMillis()
+    ): Boolean {
+        val expiry = certStore.getCertExpiry() ?: return false
+        val millisUntilExpiry = expiry - now
+        if (millisUntilExpiry > thresholdMillis) {
+            return false
+        }
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .setRequiresBatteryNotLow(true)
+            .build()
+        val request = OneTimeWorkRequestBuilder<CertRenewalWorker>()
+            .setConstraints(constraints)
+            .setBackoffCriteria(BackoffPolicy.LINEAR, BACKOFF_MINUTES, TimeUnit.MINUTES)
+            .build()
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            WORK_NAME_IMMEDIATE,
+            ExistingWorkPolicy.KEEP,
+            request
+        )
+        return true
+    }
+
     private const val PERIODIC_INTERVAL_HOURS = 24L
     private const val PERIODIC_FLEX_HOURS = 4L
     private const val BACKOFF_MINUTES = 15L
+
+    /**
+     * Unique-work slot for the app-start immediate-renewal request (issue #289).
+     *
+     * Deliberately NOT the same as [CertRenewalWorker.WORK_NAME] (periodic) or
+     * [CertRenewalWorker.WORK_NAME_DELAYED] (rate-limit reschedule): those
+     * slots have their own lifecycles and replacing them from app start would
+     * regress the scheduling contracts covered by #277.
+     */
+    const val WORK_NAME_IMMEDIATE = "cert_renewal_immediate"
+
+    /** Mirrors [CertRenewalWorker.DEFAULT_RENEWAL_WINDOW_DAYS] in millis. */
+    const val DEFAULT_IMMEDIATE_THRESHOLD_MS =
+        CertRenewalWorker.DEFAULT_RENEWAL_WINDOW_DAYS * 24L * 60L * 60L * 1000L
 }

--- a/work/src/test/kotlin/com/rousecontext/work/CertRenewalSchedulerTest.kt
+++ b/work/src/test/kotlin/com/rousecontext/work/CertRenewalSchedulerTest.kt
@@ -1,0 +1,208 @@
+package com.rousecontext.work
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.Configuration
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.testing.SynchronousExecutor
+import androidx.work.testing.WorkManagerTestInitHelper
+import com.rousecontext.tunnel.CertificateStore
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Unit tests for [CertRenewalScheduler.enqueueImmediateIfExpiring] (issue #289).
+ *
+ * The periodic + delayed paths are already covered by the scheduling
+ * integration test in `:app`. This suite focuses on the new app-start
+ * immediate-renewal decision: expired / near-expiry enqueues, far-from-expiry
+ * does not, and the unique-work slot is distinct from the periodic worker's.
+ */
+@RunWith(RobolectricTestRunner::class)
+class CertRenewalSchedulerTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var workManager: WorkManager
+
+    @Before
+    fun setUp() {
+        val config = Configuration.Builder()
+            .setExecutor(SynchronousExecutor())
+            .setTaskExecutor(SynchronousExecutor())
+            .setMinimumLoggingLevel(android.util.Log.DEBUG)
+            .build()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
+        workManager = WorkManager.getInstance(context)
+    }
+
+    @After
+    fun tearDown() {
+        workManager.cancelAllWork().result.get()
+    }
+
+    @Test
+    fun `no stored cert - does not enqueue immediate work`() = runBlocking {
+        val store = SchedulerFakeCertificateStore(expiry = null)
+
+        val enqueued = CertRenewalScheduler.enqueueImmediateIfExpiring(context, store)
+
+        assertFalse("No cert = nothing to renew", enqueued)
+        val infos = workManager
+            .getWorkInfosForUniqueWork(CertRenewalScheduler.WORK_NAME_IMMEDIATE)
+            .get()
+        assertTrue("No immediate work should exist", infos.isEmpty())
+    }
+
+    @Test
+    fun `cert far from expiry - does not enqueue immediate work`() = runBlocking {
+        val now = 1_000_000L
+        val store = SchedulerFakeCertificateStore(expiry = now + 60L * MS_PER_DAY)
+
+        val enqueued = CertRenewalScheduler.enqueueImmediateIfExpiring(
+            context,
+            store,
+            now = now
+        )
+
+        assertFalse(enqueued)
+        val infos = workManager
+            .getWorkInfosForUniqueWork(CertRenewalScheduler.WORK_NAME_IMMEDIATE)
+            .get()
+        assertTrue(
+            "Far-from-expiry cert must not trigger immediate renewal",
+            infos.isEmpty()
+        )
+    }
+
+    @Test
+    fun `cert inside renewal window - enqueues immediate one-time work`() = runBlocking {
+        val now = 1_000_000L
+        val store = SchedulerFakeCertificateStore(expiry = now + 3L * MS_PER_DAY)
+
+        val enqueued = CertRenewalScheduler.enqueueImmediateIfExpiring(
+            context,
+            store,
+            now = now
+        )
+
+        assertTrue("Near-expiry cert must enqueue immediate renewal", enqueued)
+        val infos = workManager
+            .getWorkInfosForUniqueWork(CertRenewalScheduler.WORK_NAME_IMMEDIATE)
+            .get()
+        assertEquals(1, infos.size)
+        assertEquals(WorkInfo.State.ENQUEUED, infos.single().state)
+    }
+
+    @Test
+    fun `expired cert - enqueues immediate one-time work`() = runBlocking {
+        val now = 1_000_000_000L
+        val store = SchedulerFakeCertificateStore(expiry = now - MS_PER_DAY)
+
+        val enqueued = CertRenewalScheduler.enqueueImmediateIfExpiring(
+            context,
+            store,
+            now = now
+        )
+
+        assertTrue("Expired cert must enqueue immediate renewal", enqueued)
+        val infos = workManager
+            .getWorkInfosForUniqueWork(CertRenewalScheduler.WORK_NAME_IMMEDIATE)
+            .get()
+        assertEquals(1, infos.size)
+    }
+
+    @Test
+    fun `immediate slot is distinct from periodic slot`() = runBlocking {
+        val now = 1_000_000L
+        val store = SchedulerFakeCertificateStore(expiry = now - MS_PER_DAY)
+
+        CertRenewalScheduler.enqueuePeriodic(context)
+        CertRenewalScheduler.enqueueImmediateIfExpiring(context, store, now = now)
+
+        val periodic = workManager
+            .getWorkInfosForUniqueWork(CertRenewalWorker.WORK_NAME)
+            .get()
+        val immediate = workManager
+            .getWorkInfosForUniqueWork(CertRenewalScheduler.WORK_NAME_IMMEDIATE)
+            .get()
+
+        assertEquals(
+            "Periodic slot must still have exactly the periodic worker — " +
+                "immediate enqueue must NOT clobber it",
+            1,
+            periodic.size
+        )
+        assertEquals(
+            "Immediate slot must have the one-time worker",
+            1,
+            immediate.size
+        )
+    }
+
+    @Test
+    fun `re-enqueue while previous immediate run is pending - keeps the existing request`() =
+        runBlocking {
+            val now = 1_000_000L
+            val store = SchedulerFakeCertificateStore(expiry = now - MS_PER_DAY)
+
+            CertRenewalScheduler.enqueueImmediateIfExpiring(context, store, now = now)
+            val firstId = workManager
+                .getWorkInfosForUniqueWork(CertRenewalScheduler.WORK_NAME_IMMEDIATE)
+                .get()
+                .single()
+                .id
+
+            // Simulate a second app start while the first immediate request is
+            // still pending (e.g. the user restarts before WorkManager gets a
+            // chance to run the first). ExistingWorkPolicy.KEEP should preserve
+            // the existing request rather than replacing it — otherwise run
+            // attempts would reset on every restart.
+            CertRenewalScheduler.enqueueImmediateIfExpiring(context, store, now = now)
+            val secondId = workManager
+                .getWorkInfosForUniqueWork(CertRenewalScheduler.WORK_NAME_IMMEDIATE)
+                .get()
+                .single()
+                .id
+
+            assertEquals(
+                "KEEP policy must preserve the original work id across re-enqueue",
+                firstId,
+                secondId
+            )
+        }
+
+    private companion object {
+        const val MS_PER_DAY = 24L * 60L * 60L * 1000L
+    }
+}
+
+private class SchedulerFakeCertificateStore(private val expiry: Long?) : CertificateStore {
+    override suspend fun getCertExpiry(): Long? = expiry
+    override suspend fun getCertChain(): List<ByteArray>? = null
+    override suspend fun getPrivateKeyBytes(): ByteArray? = null
+    override suspend fun storeCertChain(chain: List<ByteArray>) = Unit
+    override suspend fun getKnownFingerprints(): Set<String> = emptySet()
+    override suspend fun storeFingerprint(fingerprint: String) = Unit
+    override suspend fun hasFingerprintBootstrapMarker(): Boolean = false
+    override suspend fun writeFingerprintBootstrapMarker() = Unit
+    override suspend fun storeCertificate(pemChain: String) = Unit
+    override suspend fun getCertificate(): String? = null
+    override suspend fun storeClientCertificate(pemChain: String) = Unit
+    override suspend fun getClientCertificate(): String? = null
+    override suspend fun storeRelayCaCert(pem: String) = Unit
+    override suspend fun getRelayCaCert(): String? = null
+    override suspend fun storeSubdomain(subdomain: String) = Unit
+    override suspend fun getSubdomain(): String? = null
+    override suspend fun storeIntegrationSecrets(secrets: Map<String, String>) = Unit
+    override suspend fun getIntegrationSecrets(): Map<String, String>? = null
+    override suspend fun clear() = Unit
+    override suspend fun clearCertificates() = Unit
+}


### PR DESCRIPTION
## Summary

- Add `CertRenewalScheduler.enqueueImmediateIfExpiring`: reads cert expiry and, when the cert is near-or-past its expiry (default threshold = 21-day renewal window, matching `CertRenewalWorker.DEFAULT_RENEWAL_WINDOW_DAYS`), enqueues a one-time `CertRenewalWorker` under a new unique-work slot (`cert_renewal_immediate`) using `ExistingWorkPolicy.KEEP`.
- Wire `enqueueImmediateIfExpiring` into `RouseApplication.onCreate` after the existing `enqueuePeriodic` call.
- Before this change the 24h periodic worker was the ONLY renewal trigger, so a user opening the app with an expired cert would sit stuck for up to a day. The new slot is distinct from the periodic slot, so the long-running schedule is preserved as the safety net.

## Test plan

- [x] `:work:testDebugUnitTest` — new `CertRenewalSchedulerTest` covers the no-cert / far-from-expiry / near-expiry / expired / slot-isolation / KEEP semantics.
- [x] `:app:integrationTest` — new `ExpiredCertRenewalOnStartTest` exercises four end-to-end scenarios against the fixture relay: expired cert takes Firebase path, near-expiry takes mTLS path, healthy cert is a no-op, and immediate enqueue does not clobber the periodic slot.
- [x] `:app:testDebugUnitTest` — green.
- [x] `ktlintCheck` — green.
- [ ] `detekt` — already failing with 77 pre-existing weighted issues on `main`; no new issues introduced by this change.

Closes #289.

Generated with [Claude Code](https://claude.com/claude-code)