### PR TITLE
Fix #298: Exclude debug-only + Compose-navigation packages from Kover

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,20 @@ kover {
                 // Room generated DAOs / databases
                 classes("*_Impl")
                 classes("*_Impl\$*")
+                // Debug-only ContentProvider exposing adb-driven test hooks. Built
+                // only in debug variants; not exercised by unit/integration tests.
+                classes("com.rousecontext.app.testing.*")
+                // `debug` flavor source set — debug-only receivers, Koin modules,
+                // and stubs. Not present in release builds.
+                classes("com.rousecontext.app.debug.*")
+                // Compose screen destination glue. Testing requires an Espresso /
+                // Paparazzi / Roborazzi harness, out of scope for JVM-tier coverage.
+                classes("com.rousecontext.app.ui.navigation.destinations.*")
+                // Trivial Firebase static-call wrappers introduced solely to make
+                // callers testable by hiding FirebaseAuth / FirebaseMessaging
+                // singletons behind interfaces. The wrappers themselves are the
+                // Firebase boundary and can't be meaningfully tested at the JVM tier.
+                classes("com.rousecontext.app.auth.Firebase*")
             }
         }
     }


### PR DESCRIPTION
## Summary

Part of #297. Tightens Kover's class-level exclusions so structurally untestable code no longer depresses the aggregate line %.

Excluded packages (all 0% in the pre-change report):

- `com.rousecontext.app.testing.*` (72 lines) - `TestCommandProvider` adb-driven debug ContentProvider; not built into release, not exercised by unit/integration tests.
- `com.rousecontext.app.debug.*` (96 lines) - `debug` flavor source set (debug receivers, Koin stubs); not present in release.
- `com.rousecontext.app.ui.navigation.destinations.*` (728 lines) - Compose screen destination glue; testing requires Espresso / Paparazzi / Roborazzi, out of scope for the JVM tier.
- `com.rousecontext.app.auth.Firebase*` (5 lines) - trivial Firebase static-call wrappers whose sole purpose is to hide `FirebaseAuth`/`FirebaseMessaging` singletons behind interfaces. The wrapper classes themselves are the Firebase boundary and can't be meaningfully tested at the JVM tier. Only the `Firebase*` impls are excluded; the (uncoverable) interfaces remain in-scope.

No `koverVerify` threshold added yet (explicit non-goal in #298).

## Coverage effect

| | Covered | Total | Line % |
|---|---|---|---|
| Before | 8677 | 12128 | 71.55% |
| After  | 8677 | 11227 | **77.29%** |

+5.74pp; exactly 901 uncovered lines excluded.

Verified by parsing aggregated `build/reports/kover/report.xml` before and after. All four packages are absent from both the aggregated HTML and XML reports after the change.

## Test plan

- [x] `./gradlew koverXmlReport koverHtmlReport` succeeds
- [x] Aggregate LINE % moves from 71.55% -> 77.29%
- [x] Excluded packages no longer appear in `build/reports/kover/html/` or `report.xml`
- [x] `./gradlew ktlintCheck` green
- [x] `./gradlew :app:compileDebugKotlin` green

Notes:
- `assembleDebug` wasn't run locally because the worktree lacks `.signing/debug.keystore` (keystore must not be regenerated); CI has it.
- `./gradlew detekt` fails due to pre-existing `UnusedParameter` findings on `main` (e.g. `NotificationPreferencesScreen.kt`, `SettingsViewModel.kt`, `McpRouting.kt`, `MuxStreamImpl.kt`); unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)