### PR TITLE
Fix #306: Raise firebase_auth.rs + google_auth.rs coverage

### DIFF
--- a/relay/src/firebase_auth.rs
+++ b/relay/src/firebase_auth.rs
@@ -13,7 +13,9 @@ use tokio::sync::Mutex;
 use tracing::debug;
 
 /// URL for Google's public keys used to verify Firebase ID tokens.
-const GOOGLE_CERTS_URL: &str =
+///
+/// Overridable for tests via [`RealFirebaseAuth::with_certs_url`].
+pub(crate) const GOOGLE_CERTS_URL: &str =
     "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com";
 
 #[derive(Debug, Error)]
@@ -55,14 +57,22 @@ pub struct RealFirebaseAuth {
     project_id: String,
     http: reqwest::Client,
     cached_keys: Arc<Mutex<Option<CachedKeys>>>,
+    certs_url: String,
 }
 
 impl RealFirebaseAuth {
     pub fn new(project_id: String) -> Self {
+        Self::with_certs_url(project_id, GOOGLE_CERTS_URL.to_string())
+    }
+
+    /// Construct a verifier pointed at an arbitrary certs URL. Used by
+    /// tests to redirect traffic at an in-process mock server.
+    pub(crate) fn with_certs_url(project_id: String, certs_url: String) -> Self {
         Self {
             project_id,
             http: reqwest::Client::new(),
             cached_keys: Arc::new(Mutex::new(None)),
+            certs_url,
         }
     }
 
@@ -85,10 +95,17 @@ impl RealFirebaseAuth {
 
         let resp = self
             .http
-            .get(GOOGLE_CERTS_URL)
+            .get(&self.certs_url)
             .send()
             .await
             .map_err(|e| FirebaseAuthError::KeyFetch(e.to_string()))?;
+
+        if !resp.status().is_success() {
+            return Err(FirebaseAuthError::KeyFetch(format!(
+                "certs endpoint returned {}",
+                resp.status()
+            )));
+        }
 
         // Parse max-age from Cache-Control header for cache duration
         let max_age = resp
@@ -188,7 +205,204 @@ impl FirebaseAuth for RealFirebaseAuth {
 
 #[cfg(test)]
 mod tests {
+    //! Firebase ID token verification tests (issue #306).
+    //!
+    //! Exercises [`RealFirebaseAuth::verify_id_token`] against an in-process
+    //! axum mock that serves Google public-key PEM bundles. Tokens are
+    //! signed with a test RSA keypair embedded in this module.
+
     use super::*;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use axum::routing::get;
+    use axum::Router;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+    use jsonwebtoken::{EncodingKey, Header};
+    use std::net::SocketAddr;
+    use std::sync::{Arc, Mutex};
+    use tokio::net::TcpListener;
+
+    /// Test RSA private key (PKCS#8 PEM). Used to sign JWTs in tests.
+    const TEST_PRIV_KEY: &str = "-----BEGIN PRIVATE KEY-----\n\
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCZuvETqv/fL7dn\n\
+WcA6ABLuYpQyp+ClSpttt6VOcVxS6DDK8GJ7zO8/f6OefMBlZnNQAgA8mlY5aNWQ\n\
+lPBxPBbuxNlT7Jj0CkLiFUi+zbPE/ejFwwd9WZAFQhUDtSMrzyB7SWNbrqhRcz5s\n\
+nygNJAfdVzlf0gBGO0j1V5zQTqvLmFzm6l8EKdQyqtzMJZ6pegozwuA7khwJR5Mb\n\
+QsfwkCNfHDyp0zMd372N2YMbsA/r9eCuJMom4826nU54IXWeCY2njlWE9KJXC0EI\n\
+jPaosAym2Nvdk/ebxnK62OHb6fbJDOc4rgTDwUP9lIje0b05rCAz3rt1q1TDAHb2\n\
+h/+80pDjAgMBAAECggEAS520byQxb6qc3+05rE3VAgTjOHdy/FrSUQl/+jGwY+dp\n\
++Kh9CMAo/mbeKFrcmAPovHX/f8+6kcqLIe7gxhH0hcW10J4ULhXOCD7H5XJw9nie\n\
+QohH6tRfDvcONyCmCCp9o6bZhINIr6esEOnIXY5Xf/wjcIpvMByBKozJyXyo7B9m\n\
+icJ0+pTfhLxcCIksDFb+vNEdbVlOM55eHO3PlBG3A9cLRNAnwda+e9ot+ac82BvE\n\
+NANLk+YQ1G8bYBRyIFRKOmsLqVi9GVEBv4SkP+ygI3RsiAP5Ljl9jcrivIjgRaJa\n\
+x0SGUN2MBR9MDTB+GpnyXJQUSJZouiHd2b0UH4N+4QKBgQDHCQ8+MZfAfqt6qli6\n\
+1XXwEehRGeidTprNpSZwXqAAK/HjL0/Tm3uYjONLV0rQjhYIUqtTr92SMa3sPaSN\n\
+rWUJZZDj0efSQPFKbm5LLCeT/pddVNkqEKBrXLs6DW9Kj+xH6aOXp5LLkY9rWgGD\n\
+TREMO/BEJt7in5P2xgxSzx43bwKBgQDFunYHJcg4ieCQgL0Q5EmlA3SCgD0dK1fp\n\
+THdpDtzEhpDdVthHQZnbmrPgYYfqdkwhzSsBMTjUXynlzv5+H0mNETAP6+Axv+d+\n\
+tskIA/mm8HRyVSNdvhReaVNd/NQWPLpVWGKoqOegNAW9xeWkWLxkgZ3WeP5vRnDa\n\
+T9gpmrQjzQKBgEzE48o7Wqr2sLGJjtvRhcHpRlAxzBUQwojbUG47MT+fs5bLIuEd\n\
+sZhvjyP6MXMrurfPGyIWTUIcQ1dBl3zGCpiLQk19Iwtn3Sm2WnhIOaPNqRhop7Kf\n\
+4yBGDjkgAXMi/CHorh7KlcZLCKSBfN/mE9NCMzQ2QfXrUyj1zr8KAD+lAoGBAIYB\n\
+WPx/HrMyvn8wwPIxxbeQH+ZSAxlBxtLWgBcze2u1x3g641lnnF64+i+X6gV9JxvB\n\
+cOPd+CX2WO7m2pOfoLl6bJhdxBPze3DlcFl+WDRLwp+6E730lNlniJiqQRLRFXfB\n\
+7xtfXZu1pi53cKtxeDylm9M/LTE9DD7o3hdUQcIBAoGAVIJAsLc+VEHvmUvAC+sP\n\
+lQEWb1+8RXHV7/YIqAHHljxcYo8nHO8LivVDY9iLULFfwm32UKWCvnLHIladRb1F\n\
+L/Mi6VARahG0Y25KHRB9D0SMZHXG+efH6+iDRYiO++bzJ83PwZp+HlfdgF7ZQ17o\n\
+fw8/8IuqJW21qI3USWr5qTU=\n\
+-----END PRIVATE KEY-----\n";
+
+    /// x509 self-signed cert matching [`TEST_PRIV_KEY`]. Google returns
+    /// cert PEM (not raw public keys) from the certs endpoint; we match
+    /// that shape.
+    const TEST_CERT_PEM: &str = "-----BEGIN CERTIFICATE-----\n\
+MIIC/zCCAeegAwIBAgIUE6y5B632gz35tRKlEOWBa9SuCr8wDQYJKoZIhvcNAQEL\n\
+BQAwDzENMAsGA1UEAwwEdGVzdDAeFw0yNjA0MjAwMzI1MTFaFw0zNjA0MTcwMzI1\n\
+MTFaMA8xDTALBgNVBAMMBHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK\n\
+AoIBAQCZuvETqv/fL7dnWcA6ABLuYpQyp+ClSpttt6VOcVxS6DDK8GJ7zO8/f6Oe\n\
+fMBlZnNQAgA8mlY5aNWQlPBxPBbuxNlT7Jj0CkLiFUi+zbPE/ejFwwd9WZAFQhUD\n\
+tSMrzyB7SWNbrqhRcz5snygNJAfdVzlf0gBGO0j1V5zQTqvLmFzm6l8EKdQyqtzM\n\
+JZ6pegozwuA7khwJR5MbQsfwkCNfHDyp0zMd372N2YMbsA/r9eCuJMom4826nU54\n\
+IXWeCY2njlWE9KJXC0EIjPaosAym2Nvdk/ebxnK62OHb6fbJDOc4rgTDwUP9lIje\n\
+0b05rCAz3rt1q1TDAHb2h/+80pDjAgMBAAGjUzBRMB0GA1UdDgQWBBRn80SHqIOl\n\
+qokHmPz3pz9Z/8QzkjAfBgNVHSMEGDAWgBRn80SHqIOlqokHmPz3pz9Z/8QzkjAP\n\
+BgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQA8gXfqGqaXSgfrY1va\n\
+WiqlSDXQpb94yr5fhH099geSRlAJ5/HCo643TVJXQEVeTWkXDrE3jJu18JSX2F1x\n\
+R+m7MJt8sY0pFdJ8JJ5103AT9D6mbA/XH1zrTnKQiXuVPtZqIBn2a9hQpH7mmrLM\n\
+G22q+Xzp3qXTyUA/2yjuQ3CoZW+NrIZWOoeFzqwlNddhKOqHykmUXLQSuCo1dS6Q\n\
+O1KveQzapIUpr79mdtKZAVktt72kannvb/tdGFJsLFrj3HqWhMQANOptBqRWZbkI\n\
+Vzek/LM0aq/Oo1MWw/mmpXIChCk11YkUXTcSlryieAmiCeROq9T938K6KLB0W/V6\n\
+4aQM\n\
+-----END CERTIFICATE-----\n";
+
+    const TEST_KID: &str = "test-kid-1";
+    const TEST_PROJECT: &str = "test-project";
+
+    fn now_secs() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    /// JWT payload matching what Firebase issues. `iat`/`exp` are seconds.
+    #[derive(serde::Serialize)]
+    struct Payload {
+        iss: String,
+        aud: String,
+        sub: String,
+        iat: u64,
+        exp: u64,
+    }
+
+    fn sign_token(kid: &str, payload: &Payload) -> String {
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(kid.to_string());
+        let key =
+            EncodingKey::from_rsa_pem(TEST_PRIV_KEY.as_bytes()).expect("test priv key must parse");
+        jsonwebtoken::encode(&header, payload, &key).expect("encode must succeed")
+    }
+
+    fn valid_payload() -> Payload {
+        let now = now_secs();
+        Payload {
+            iss: format!("https://securetoken.google.com/{TEST_PROJECT}"),
+            aud: TEST_PROJECT.to_string(),
+            sub: "test-uid".to_string(),
+            iat: now,
+            exp: now + 3600,
+        }
+    }
+
+    /// State shared between the mock certs endpoint and the test.
+    #[derive(Clone)]
+    struct MockCertsState {
+        body: Arc<Mutex<serde_json::Value>>,
+        cache_control: Arc<Mutex<Option<String>>>,
+        status: Arc<Mutex<StatusCode>>,
+        /// When true, the endpoint returns malformed JSON so we can test
+        /// parse failures.
+        malformed: Arc<Mutex<bool>>,
+        /// How many times the endpoint has been hit.
+        hits: Arc<Mutex<u32>>,
+    }
+
+    impl MockCertsState {
+        fn new() -> Self {
+            let body = serde_json::json!({ TEST_KID: TEST_CERT_PEM });
+            Self {
+                body: Arc::new(Mutex::new(body)),
+                cache_control: Arc::new(Mutex::new(Some("public, max-age=3600".to_string()))),
+                status: Arc::new(Mutex::new(StatusCode::OK)),
+                malformed: Arc::new(Mutex::new(false)),
+                hits: Arc::new(Mutex::new(0)),
+            }
+        }
+
+        fn hits(&self) -> u32 {
+            *self.hits.lock().unwrap()
+        }
+
+        fn set_body(&self, body: serde_json::Value) {
+            *self.body.lock().unwrap() = body;
+        }
+
+        fn set_status(&self, status: StatusCode) {
+            *self.status.lock().unwrap() = status;
+        }
+
+        fn set_malformed(&self, yes: bool) {
+            *self.malformed.lock().unwrap() = yes;
+        }
+
+        fn set_cache_control(&self, value: Option<String>) {
+            *self.cache_control.lock().unwrap() = value;
+        }
+    }
+
+    async fn mock_certs_handler(
+        axum::extract::State(state): axum::extract::State<MockCertsState>,
+    ) -> axum::response::Response {
+        *state.hits.lock().unwrap() += 1;
+        let status = *state.status.lock().unwrap();
+        if !status.is_success() {
+            return (status, "error").into_response();
+        }
+        let malformed = *state.malformed.lock().unwrap();
+        let cache_control = state.cache_control.lock().unwrap().clone();
+        let body = state.body.lock().unwrap().clone();
+
+        let mut builder = axum::response::Response::builder().status(StatusCode::OK);
+        if let Some(cc) = cache_control {
+            builder = builder.header("cache-control", cc);
+        }
+        if malformed {
+            builder = builder.header("content-type", "application/json");
+            builder.body(axum::body::Body::from("{not json")).unwrap()
+        } else {
+            builder = builder.header("content-type", "application/json");
+            builder
+                .body(axum::body::Body::from(body.to_string()))
+                .unwrap()
+        }
+    }
+
+    async fn spawn_mock_certs(state: MockCertsState) -> String {
+        let app = Router::new()
+            .route("/certs", get(mock_certs_handler))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}/certs")
+    }
+
+    fn test_auth(certs_url: String) -> RealFirebaseAuth {
+        RealFirebaseAuth::with_certs_url(TEST_PROJECT.to_string(), certs_url)
+    }
 
     #[test]
     fn parse_max_age_from_cache_control() {
@@ -198,5 +412,305 @@ mod tests {
         );
         assert_eq!(parse_max_age("max-age=600"), Some(600));
         assert_eq!(parse_max_age("no-cache"), None);
+        assert_eq!(parse_max_age("max-age=abc"), None);
+        assert_eq!(parse_max_age(""), None);
+    }
+
+    #[tokio::test]
+    async fn verify_id_token_accepts_well_formed_token() {
+        let state = MockCertsState::new();
+        let url = spawn_mock_certs(state).await;
+        let auth = test_auth(url);
+
+        let token = sign_token(TEST_KID, &valid_payload());
+        let claims = auth.verify_id_token(&token).await.expect("must verify");
+        assert_eq!(claims.uid, "test-uid");
+    }
+
+    #[tokio::test]
+    async fn verify_id_token_rejects_expired_token() {
+        let state = MockCertsState::new();
+        let url = spawn_mock_certs(state).await;
+        let auth = test_auth(url);
+
+        let mut payload = valid_payload();
+        payload.iat = now_secs() - 7200;
+        payload.exp = now_secs() - 3600;
+        let token = sign_token(TEST_KID, &payload);
+
+        let err = auth
+            .verify_id_token(&token)
+            .await
+            .expect_err("expired token must fail");
+        assert!(matches!(err, FirebaseAuthError::Expired), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn verify_id_token_rejects_wrong_audience() {
+        let state = MockCertsState::new();
+        let url = spawn_mock_certs(state).await;
+        let auth = test_auth(url);
+
+        let mut payload = valid_payload();
+        payload.aud = "some-other-project".to_string();
+        let token = sign_token(TEST_KID, &payload);
+
+        let err = auth
+            .verify_id_token(&token)
+            .await
+            .expect_err("wrong aud must fail");
+        // jsonwebtoken surfaces as InvalidToken because aud validation is
+        // internal. We don't care which variant as long as it's not Expired.
+        assert!(!matches!(err, FirebaseAuthError::Expired), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn verify_id_token_rejects_wrong_issuer() {
+        let state = MockCertsState::new();
+        let url = spawn_mock_certs(state).await;
+        let auth = test_auth(url);
+
+        let mut payload = valid_payload();
+        payload.iss = "https://evil.example.com/".to_string();
+        let token = sign_token(TEST_KID, &payload);
+
+        let err = auth
+            .verify_id_token(&token)
+            .await
+            .expect_err("wrong iss must fail");
+        assert!(
+            matches!(err, FirebaseAuthError::InvalidToken(_)),
+            "got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_id_token_rejects_mangled_jwt() {
+        let state = MockCertsState::new();
+        let url = spawn_mock_certs(state).await;
+        let auth = test_auth(url);
+
+        let err = auth
+            .verify_id_token("not-a-jwt")
+            .await
+            .expect_err("mangled jwt must fail");
+        assert!(
+            matches!(err, FirebaseAuthError::InvalidToken(_)),
+            "got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_id_token_rejects_missing_kid() {
+        let state = MockCertsState::new();
+        let url = spawn_mock_certs(state).await;
+        let auth = test_auth(url);
+
+        // Hand-craft a JWT with no kid in header.
+        let header = serde_json::json!({"alg": "RS256", "typ": "JWT"}).to_string();
+        let payload = serde_json::to_string(&valid_payload()).unwrap();
+        let signing_input = format!(
+            "{}.{}",
+            URL_SAFE_NO_PAD.encode(header),
+            URL_SAFE_NO_PAD.encode(payload)
+        );
+        let key = jsonwebtoken::EncodingKey::from_rsa_pem(TEST_PRIV_KEY.as_bytes()).unwrap();
+        let sig = jsonwebtoken::crypto::sign(
+            signing_input.as_bytes(),
+            &key,
+            jsonwebtoken::Algorithm::RS256,
+        )
+        .unwrap();
+        let token = format!("{signing_input}.{sig}");
+
+        let err = auth
+            .verify_id_token(&token)
+            .await
+            .expect_err("missing kid must fail");
+        match err {
+            FirebaseAuthError::InvalidToken(msg) => assert!(msg.contains("kid")),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn verify_id_token_rejects_unknown_kid() {
+        let state = MockCertsState::new();
+        let url = spawn_mock_certs(state).await;
+        let auth = test_auth(url);
+
+        let token = sign_token("unknown-kid", &valid_payload());
+        let err = auth
+            .verify_id_token(&token)
+            .await
+            .expect_err("unknown kid must fail");
+        match err {
+            FirebaseAuthError::InvalidToken(msg) => {
+                assert!(msg.contains("unknown kid"), "got: {msg}");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn verify_id_token_rejects_hs256_algorithm() {
+        let state = MockCertsState::new();
+        let url = spawn_mock_certs(state).await;
+        let auth = test_auth(url);
+
+        // Sign an HS256 token with a symmetric key — must be rejected.
+        let mut header = Header::new(Algorithm::HS256);
+        header.kid = Some(TEST_KID.to_string());
+        let key = EncodingKey::from_secret(b"shared-secret");
+        let token = jsonwebtoken::encode(&header, &valid_payload(), &key).unwrap();
+
+        let err = auth
+            .verify_id_token(&token)
+            .await
+            .expect_err("wrong alg must fail");
+        assert!(
+            matches!(err, FirebaseAuthError::InvalidToken(_)),
+            "got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_keys_errors_on_non_200_status() {
+        let state = MockCertsState::new();
+        state.set_status(StatusCode::INTERNAL_SERVER_ERROR);
+        let url = spawn_mock_certs(state).await;
+        let auth = test_auth(url);
+
+        let err = auth
+            .verify_id_token(&sign_token(TEST_KID, &valid_payload()))
+            .await
+            .expect_err("5xx on certs must fail");
+        assert!(
+            matches!(err, FirebaseAuthError::KeyFetch(_)),
+            "got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_keys_errors_on_malformed_json() {
+        let state = MockCertsState::new();
+        state.set_malformed(true);
+        let url = spawn_mock_certs(state).await;
+        let auth = test_auth(url);
+
+        let err = auth
+            .verify_id_token(&sign_token(TEST_KID, &valid_payload()))
+            .await
+            .expect_err("malformed certs body must fail");
+        assert!(
+            matches!(err, FirebaseAuthError::KeyFetch(_)),
+            "got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_keys_errors_on_unreachable_endpoint() {
+        // Point at a TCP port that is (virtually) guaranteed to reject:
+        // bind then immediately drop the listener so nothing is listening.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let auth = test_auth(format!("http://{addr}/certs"));
+
+        let err = auth
+            .verify_id_token(&sign_token(TEST_KID, &valid_payload()))
+            .await
+            .expect_err("unreachable endpoint must fail");
+        assert!(
+            matches!(err, FirebaseAuthError::KeyFetch(_)),
+            "got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_keys_skips_unparseable_pem_and_succeeds_with_valid_ones() {
+        let state = MockCertsState::new();
+        state.set_body(serde_json::json!({
+            "garbage-kid": "not a pem",
+            TEST_KID: TEST_CERT_PEM,
+        }));
+        let url = spawn_mock_certs(state).await;
+        let auth = test_auth(url);
+
+        let token = sign_token(TEST_KID, &valid_payload());
+        auth.verify_id_token(&token).await.expect("must verify");
+    }
+
+    #[tokio::test]
+    async fn get_keys_caches_between_calls() {
+        let state = MockCertsState::new();
+        let url = spawn_mock_certs(state.clone()).await;
+        let auth = test_auth(url);
+
+        let token = sign_token(TEST_KID, &valid_payload());
+        auth.verify_id_token(&token).await.unwrap();
+        auth.verify_id_token(&token).await.unwrap();
+        auth.verify_id_token(&token).await.unwrap();
+
+        assert_eq!(state.hits(), 1, "keys should be cached after first fetch");
+    }
+
+    #[tokio::test]
+    async fn get_keys_refetches_when_cache_expired() {
+        let state = MockCertsState::new();
+        // Cache for 0 seconds so second call refetches.
+        state.set_cache_control(Some("max-age=0".to_string()));
+        let url = spawn_mock_certs(state.clone()).await;
+        let auth = test_auth(url);
+
+        let token = sign_token(TEST_KID, &valid_payload());
+        auth.verify_id_token(&token).await.unwrap();
+        // Give the clock a chance to move past `now + 0`.
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        auth.verify_id_token(&token).await.unwrap();
+
+        assert!(state.hits() >= 2, "expired cache should trigger refetch");
+    }
+
+    #[tokio::test]
+    async fn get_keys_uses_default_cache_when_header_missing() {
+        let state = MockCertsState::new();
+        state.set_cache_control(None);
+        let url = spawn_mock_certs(state.clone()).await;
+        let auth = test_auth(url);
+
+        let token = sign_token(TEST_KID, &valid_payload());
+        auth.verify_id_token(&token).await.unwrap();
+        auth.verify_id_token(&token).await.unwrap();
+        // Without max-age, we fall back to 3600s and should cache.
+        assert_eq!(state.hits(), 1);
+    }
+
+    #[test]
+    fn firebase_auth_error_display_is_informative() {
+        let e = FirebaseAuthError::InvalidToken("x".to_string());
+        assert!(format!("{e}").contains("x"));
+
+        let e = FirebaseAuthError::Expired;
+        assert!(format!("{e}").contains("expired"));
+
+        let e = FirebaseAuthError::WrongProject {
+            expected: "a".to_string(),
+            actual: "b".to_string(),
+        };
+        let msg = format!("{e}");
+        assert!(msg.contains('a') && msg.contains('b'));
+
+        let e = FirebaseAuthError::KeyFetch("boom".to_string());
+        assert!(format!("{e}").contains("boom"));
+    }
+
+    #[test]
+    fn new_uses_production_certs_url() {
+        // Smoke test that `new` doesn't panic and records something that
+        // looks like the real URL. We don't hit the network.
+        let auth = RealFirebaseAuth::new("any".to_string());
+        assert_eq!(auth.certs_url, GOOGLE_CERTS_URL);
+        assert_eq!(auth.project_id, "any");
     }
 }

--- a/relay/src/google_auth.rs
+++ b/relay/src/google_auth.rs
@@ -196,7 +196,161 @@ pub fn fcm_auth_manager(key: ServiceAccountKey) -> Arc<GoogleAuthManager> {
 
 #[cfg(test)]
 mod tests {
+    //! Google OAuth2 service-account token exchange tests (issue #306).
+    //!
+    //! Exercises [`GoogleAuthManager::access_token`] and
+    //! [`GoogleAuthManager::make_jwt_assertion`] against an in-process
+    //! axum mock of the Google token endpoint, using the
+    //! [`ServiceAccountKey::token_uri`] field as the injection point.
+
     use super::*;
+    use axum::extract::State;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use axum::routing::post;
+    use axum::{Form, Json, Router};
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+    use std::sync::Mutex as StdMutex;
+    use tokio::net::TcpListener;
+
+    /// Test RSA private key (PKCS#8 PEM). Used to sign the JWT assertion.
+    const TEST_PRIV_KEY: &str = "-----BEGIN PRIVATE KEY-----\n\
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCZuvETqv/fL7dn\n\
+WcA6ABLuYpQyp+ClSpttt6VOcVxS6DDK8GJ7zO8/f6OefMBlZnNQAgA8mlY5aNWQ\n\
+lPBxPBbuxNlT7Jj0CkLiFUi+zbPE/ejFwwd9WZAFQhUDtSMrzyB7SWNbrqhRcz5s\n\
+nygNJAfdVzlf0gBGO0j1V5zQTqvLmFzm6l8EKdQyqtzMJZ6pegozwuA7khwJR5Mb\n\
+QsfwkCNfHDyp0zMd372N2YMbsA/r9eCuJMom4826nU54IXWeCY2njlWE9KJXC0EI\n\
+jPaosAym2Nvdk/ebxnK62OHb6fbJDOc4rgTDwUP9lIje0b05rCAz3rt1q1TDAHb2\n\
+h/+80pDjAgMBAAECggEAS520byQxb6qc3+05rE3VAgTjOHdy/FrSUQl/+jGwY+dp\n\
++Kh9CMAo/mbeKFrcmAPovHX/f8+6kcqLIe7gxhH0hcW10J4ULhXOCD7H5XJw9nie\n\
+QohH6tRfDvcONyCmCCp9o6bZhINIr6esEOnIXY5Xf/wjcIpvMByBKozJyXyo7B9m\n\
+icJ0+pTfhLxcCIksDFb+vNEdbVlOM55eHO3PlBG3A9cLRNAnwda+e9ot+ac82BvE\n\
+NANLk+YQ1G8bYBRyIFRKOmsLqVi9GVEBv4SkP+ygI3RsiAP5Ljl9jcrivIjgRaJa\n\
+x0SGUN2MBR9MDTB+GpnyXJQUSJZouiHd2b0UH4N+4QKBgQDHCQ8+MZfAfqt6qli6\n\
+1XXwEehRGeidTprNpSZwXqAAK/HjL0/Tm3uYjONLV0rQjhYIUqtTr92SMa3sPaSN\n\
+rWUJZZDj0efSQPFKbm5LLCeT/pddVNkqEKBrXLs6DW9Kj+xH6aOXp5LLkY9rWgGD\n\
+TREMO/BEJt7in5P2xgxSzx43bwKBgQDFunYHJcg4ieCQgL0Q5EmlA3SCgD0dK1fp\n\
+THdpDtzEhpDdVthHQZnbmrPgYYfqdkwhzSsBMTjUXynlzv5+H0mNETAP6+Axv+d+\n\
+tskIA/mm8HRyVSNdvhReaVNd/NQWPLpVWGKoqOegNAW9xeWkWLxkgZ3WeP5vRnDa\n\
+T9gpmrQjzQKBgEzE48o7Wqr2sLGJjtvRhcHpRlAxzBUQwojbUG47MT+fs5bLIuEd\n\
+sZhvjyP6MXMrurfPGyIWTUIcQ1dBl3zGCpiLQk19Iwtn3Sm2WnhIOaPNqRhop7Kf\n\
+4yBGDjkgAXMi/CHorh7KlcZLCKSBfN/mE9NCMzQ2QfXrUyj1zr8KAD+lAoGBAIYB\n\
+WPx/HrMyvn8wwPIxxbeQH+ZSAxlBxtLWgBcze2u1x3g641lnnF64+i+X6gV9JxvB\n\
+cOPd+CX2WO7m2pOfoLl6bJhdxBPze3DlcFl+WDRLwp+6E730lNlniJiqQRLRFXfB\n\
+7xtfXZu1pi53cKtxeDylm9M/LTE9DD7o3hdUQcIBAoGAVIJAsLc+VEHvmUvAC+sP\n\
+lQEWb1+8RXHV7/YIqAHHljxcYo8nHO8LivVDY9iLULFfwm32UKWCvnLHIladRb1F\n\
+L/Mi6VARahG0Y25KHRB9D0SMZHXG+efH6+iDRYiO++bzJ83PwZp+HlfdgF7ZQ17o\n\
+fw8/8IuqJW21qI3USWr5qTU=\n\
+-----END PRIVATE KEY-----\n";
+
+    /// Captures what the mock token endpoint saw on the last call.
+    #[derive(Default)]
+    struct MockState {
+        /// Form fields from the last POST.
+        last_form: HashMap<String, String>,
+        /// Number of times the endpoint was hit.
+        hits: u32,
+        /// Token value to return on success.
+        access_token: String,
+        /// Seconds-until-expiry to return.
+        expires_in: u64,
+        /// When set, the endpoint returns this status and an error body.
+        fail_status: Option<StatusCode>,
+        /// When true, return malformed JSON on success.
+        malformed_body: bool,
+    }
+
+    #[derive(Clone)]
+    struct Mock {
+        inner: Arc<StdMutex<MockState>>,
+    }
+
+    impl Mock {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(StdMutex::new(MockState {
+                    access_token: "access-token-xyz".to_string(),
+                    expires_in: 3600,
+                    ..Default::default()
+                })),
+            }
+        }
+
+        fn with_token(self, t: &str) -> Self {
+            self.inner.lock().unwrap().access_token = t.to_string();
+            self
+        }
+
+        fn with_expires_in(self, e: u64) -> Self {
+            self.inner.lock().unwrap().expires_in = e;
+            self
+        }
+
+        fn with_failure(self, s: StatusCode) -> Self {
+            self.inner.lock().unwrap().fail_status = Some(s);
+            self
+        }
+
+        fn with_malformed_body(self) -> Self {
+            self.inner.lock().unwrap().malformed_body = true;
+            self
+        }
+
+        fn hits(&self) -> u32 {
+            self.inner.lock().unwrap().hits
+        }
+
+        fn last_form(&self) -> HashMap<String, String> {
+            self.inner.lock().unwrap().last_form.clone()
+        }
+    }
+
+    async fn mock_token_handler(
+        State(state): State<Mock>,
+        Form(form): Form<HashMap<String, String>>,
+    ) -> axum::response::Response {
+        let mut g = state.inner.lock().unwrap();
+        g.hits += 1;
+        g.last_form = form.clone();
+        if let Some(status) = g.fail_status {
+            return (status, Json(serde_json::json!({"error": "invalid_grant"}))).into_response();
+        }
+        if g.malformed_body {
+            return axum::response::Response::builder()
+                .status(StatusCode::OK)
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from("{malformed"))
+                .unwrap();
+        }
+        Json(serde_json::json!({
+            "access_token": g.access_token,
+            "expires_in": g.expires_in,
+            "token_type": "Bearer",
+        }))
+        .into_response()
+    }
+
+    async fn spawn_mock_token_endpoint(mock: Mock) -> String {
+        let app = Router::new()
+            .route("/token", post(mock_token_handler))
+            .with_state(mock);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}/token")
+    }
+
+    fn make_key(token_uri: &str) -> ServiceAccountKey {
+        ServiceAccountKey {
+            client_email: "test@proj.iam.gserviceaccount.com".to_string(),
+            private_key: TEST_PRIV_KEY.to_string(),
+            project_id: "my-project".to_string(),
+            token_uri: token_uri.to_string(),
+        }
+    }
 
     #[test]
     fn service_account_key_from_json() {
@@ -216,5 +370,222 @@ mod tests {
         let json = r#"{ "client_email": "test@test.com" }"#;
         let result: Result<ServiceAccountKey, _> = serde_json::from_str(json);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn from_file_reads_json_from_disk() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_path_buf();
+        std::fs::write(
+            &path,
+            r#"{
+                "client_email": "a@b.iam.gserviceaccount.com",
+                "private_key": "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n",
+                "project_id": "proj",
+                "token_uri": "https://oauth2.googleapis.com/token"
+            }"#,
+        )
+        .unwrap();
+
+        let key = ServiceAccountKey::from_file(&path).expect("must load");
+        assert_eq!(key.project_id, "proj");
+    }
+
+    #[test]
+    fn from_file_errors_on_missing_file() {
+        let err = ServiceAccountKey::from_file(Path::new("/nonexistent/path/xyz.json"))
+            .expect_err("must fail");
+        assert!(matches!(err, AuthError::Io(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn from_file_errors_on_bad_json() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), "not valid json").unwrap();
+
+        let err = ServiceAccountKey::from_file(tmp.path()).expect_err("must fail");
+        assert!(matches!(err, AuthError::Json(_)), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn access_token_fetches_happy_path() {
+        let mock = Mock::new().with_token("happy-access-token");
+        let url = spawn_mock_token_endpoint(mock.clone()).await;
+        let mgr = GoogleAuthManager::new(make_key(&url), vec!["scope-a".to_string()]);
+
+        let tok = mgr.access_token().await.expect("must mint token");
+        assert_eq!(tok, "happy-access-token");
+        assert_eq!(mock.hits(), 1);
+
+        // Form submitted to the token endpoint must match the OAuth2
+        // JWT-bearer grant type.
+        let form = mock.last_form();
+        assert_eq!(
+            form.get("grant_type").map(|s| s.as_str()),
+            Some("urn:ietf:params:oauth:grant-type:jwt-bearer")
+        );
+        let assertion = form.get("assertion").expect("assertion field");
+        // JWT should have three dot-separated parts.
+        assert_eq!(assertion.split('.').count(), 3);
+    }
+
+    #[tokio::test]
+    async fn access_token_caches_fresh_token() {
+        let mock = Mock::new();
+        let url = spawn_mock_token_endpoint(mock.clone()).await;
+        let mgr = GoogleAuthManager::new(make_key(&url), vec!["scope-a".to_string()]);
+
+        mgr.access_token().await.unwrap();
+        mgr.access_token().await.unwrap();
+        mgr.access_token().await.unwrap();
+
+        assert_eq!(
+            mock.hits(),
+            1,
+            "second+ call should hit cache, not the endpoint"
+        );
+    }
+
+    #[tokio::test]
+    async fn access_token_refreshes_when_close_to_expiry() {
+        // expires_in=60 -> after saturating_sub(60) the cached token is
+        // already considered expired and will refresh every call.
+        let mock = Mock::new().with_expires_in(60);
+        let url = spawn_mock_token_endpoint(mock.clone()).await;
+        let mgr = GoogleAuthManager::new(make_key(&url), vec!["scope-a".to_string()]);
+
+        mgr.access_token().await.unwrap();
+        mgr.access_token().await.unwrap();
+
+        assert_eq!(mock.hits(), 2);
+    }
+
+    #[tokio::test]
+    async fn access_token_surfaces_http_error() {
+        let mock = Mock::new().with_failure(StatusCode::UNAUTHORIZED);
+        let url = spawn_mock_token_endpoint(mock).await;
+        let mgr = GoogleAuthManager::new(make_key(&url), vec!["scope-a".to_string()]);
+
+        let err = mgr.access_token().await.expect_err("expected failure");
+        match err {
+            AuthError::Exchange(msg) => assert!(msg.contains("invalid_grant"), "got: {msg}"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn access_token_surfaces_server_error() {
+        let mock = Mock::new().with_failure(StatusCode::INTERNAL_SERVER_ERROR);
+        let url = spawn_mock_token_endpoint(mock).await;
+        let mgr = GoogleAuthManager::new(make_key(&url), vec!["scope-a".to_string()]);
+
+        let err = mgr.access_token().await.expect_err("expected failure");
+        assert!(matches!(err, AuthError::Exchange(_)), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn access_token_surfaces_malformed_response_body() {
+        let mock = Mock::new().with_malformed_body();
+        let url = spawn_mock_token_endpoint(mock).await;
+        let mgr = GoogleAuthManager::new(make_key(&url), vec!["scope-a".to_string()]);
+
+        let err = mgr.access_token().await.expect_err("expected failure");
+        assert!(matches!(err, AuthError::Exchange(_)), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn access_token_surfaces_network_error() {
+        // Bind then drop so nothing is actually listening.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let mgr = GoogleAuthManager::new(
+            make_key(&format!("http://{addr}/token")),
+            vec!["scope-a".to_string()],
+        );
+
+        let err = mgr.access_token().await.expect_err("expected failure");
+        assert!(matches!(err, AuthError::Exchange(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn make_jwt_assertion_encodes_claims_and_scopes() {
+        let key = make_key("https://oauth2.googleapis.com/token");
+        let mgr = GoogleAuthManager::new(
+            key.clone(),
+            vec!["scope-a".to_string(), "scope-b".to_string()],
+        );
+
+        let jwt = mgr.make_jwt_assertion().expect("must sign");
+        let parts: Vec<&str> = jwt.split('.').collect();
+        assert_eq!(parts.len(), 3);
+
+        // Decode the claims segment (URL-safe, no padding) and sanity-check.
+        let claims_bytes = URL_SAFE_NO_PAD.decode(parts[1]).unwrap();
+        let claims: serde_json::Value = serde_json::from_slice(&claims_bytes).unwrap();
+        assert_eq!(claims["iss"], "test@proj.iam.gserviceaccount.com");
+        assert_eq!(claims["aud"], "https://oauth2.googleapis.com/token");
+        assert_eq!(claims["scope"], "scope-a scope-b");
+        assert!(claims["iat"].is_number());
+        assert!(claims["exp"].is_number());
+        // exp should be 1h after iat.
+        let iat = claims["iat"].as_u64().unwrap();
+        let exp = claims["exp"].as_u64().unwrap();
+        assert_eq!(exp - iat, 3600);
+    }
+
+    #[test]
+    fn make_jwt_assertion_errors_on_invalid_pem() {
+        let mut key = make_key("https://oauth2.googleapis.com/token");
+        key.private_key = "not a pem".to_string();
+        let mgr = GoogleAuthManager::new(key, vec!["scope".to_string()]);
+
+        let err = mgr.make_jwt_assertion().expect_err("must fail");
+        assert!(matches!(err, AuthError::Signing(_)), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn access_token_errors_if_private_key_is_garbage() {
+        let mut key = make_key("https://oauth2.googleapis.com/token");
+        key.private_key =
+            "-----BEGIN PRIVATE KEY-----\nnope\n-----END PRIVATE KEY-----\n".to_string();
+        let mgr = GoogleAuthManager::new(key, vec!["scope".to_string()]);
+
+        let err = mgr.access_token().await.expect_err("must fail");
+        assert!(matches!(err, AuthError::Signing(_)), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn fcm_auth_manager_wires_fcm_scope() {
+        let mock = Mock::new();
+        let url = spawn_mock_token_endpoint(mock.clone()).await;
+        let mgr = fcm_auth_manager(make_key(&url));
+
+        mgr.access_token().await.expect("must mint token");
+        let form = mock.last_form();
+        let assertion = form.get("assertion").unwrap();
+        let payload_b64 = assertion.split('.').nth(1).unwrap();
+        let payload_bytes = URL_SAFE_NO_PAD.decode(payload_b64).unwrap();
+        let claims: serde_json::Value = serde_json::from_slice(&payload_bytes).unwrap();
+        assert_eq!(claims["scope"], FCM_SCOPE);
+    }
+
+    #[test]
+    fn auth_error_display_is_informative() {
+        let e = AuthError::Signing("bad".to_string());
+        assert!(format!("{e}").contains("bad"));
+
+        let e = AuthError::Exchange("nope".to_string());
+        assert!(format!("{e}").contains("nope"));
+
+        // Json / Io errors pick up their inner messages.
+        let json_err: serde_json::Error = serde_json::from_str::<u32>("xyz").unwrap_err();
+        let e = AuthError::Json(json_err);
+        assert!(!format!("{e}").is_empty());
+
+        let io_err = std::io::Error::from(std::io::ErrorKind::NotFound);
+        let e = AuthError::Io(io_err);
+        assert!(!format!("{e}").is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Both modules sit on the `/register`, `/renew`, FCM, and Firestore auth paths — a silent regression in either breaks the whole device + AI-client flow. Coverage was low enough that none of the error paths were exercised.

Approach follows the #304 dns.rs pattern: add a test seam that lets an in-process axum mock stand in for the Google endpoint, then drive the module through happy and error paths.

- `RealFirebaseAuth::with_certs_url(project_id, certs_url)` is the new test-only constructor; `new()` still hardcodes the production URL. Also: non-200 responses from the certs endpoint now surface as `KeyFetch` (was silently fed into `serde_json::from_reader` and surfaced as a confusing parse error).
- `google_auth.rs` needed no new API — `ServiceAccountKey::token_uri` is already the injection point, and tests build a key struct pointed at the in-process mock.

## Coverage deltas

Measured with `cargo llvm-cov --summary-only`:

| File | Before (line) | After (line) |
|---|---|---|
| `firebase_auth.rs` | 25.2% | **99.32%** |
| `google_auth.rs`   | 15.7% | **99.12%** |
| Relay aggregate    | 71.77% | **76.14%** |

## Test coverage detail

`firebase_auth.rs` — 15 new test cases:
- well-formed RS256 token accepted
- expired token -> `FirebaseAuthError::Expired`
- wrong audience / wrong issuer -> `InvalidToken`
- mangled JWT / missing kid / unknown kid -> `InvalidToken`
- HS256 algorithm confusion attempt rejected
- certs endpoint 5xx / malformed JSON / unreachable host -> `KeyFetch`
- unparseable PEMs in cert bundle are skipped (good ones still work)
- cache hit counts (no refetch on 2nd+ call)
- cache expiry triggers refetch
- default cache duration (3600s) when `Cache-Control` header is absent
- error `Display` impls

`google_auth.rs` — 15 new test cases:
- file loading: happy path / missing file -> `Io` / bad JSON -> `Json`
- happy-path token exchange with correct OAuth2 `grant_type` + assertion form
- token caching between calls
- refresh when close to expiry (`expires_in=60` -> `saturating_sub(60)` is already expired)
- 4xx / 5xx / malformed body / network unreachable -> `Exchange`
- `make_jwt_assertion` encodes correct claims + scopes + iat/exp delta
- invalid PEM at assertion level -> `Signing`
- `access_token()` with garbage private key propagates `Signing`
- `fcm_auth_manager` wires `FCM_SCOPE` into the assertion
- error `Display` impls

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo build` + `cargo build --features test-mode`
- [x] `cargo test` (162 tests) + `cargo test --features test-mode`
- [x] `cargo clippy --all-targets -- -D warnings` + with `--features test-mode`
- [x] `cargo llvm-cov --summary-only` confirms 98%+ line on both targets

No live Google endpoints are contacted; RSA keypair + self-signed cert PEMs are baked into the test module so JWTs can be signed deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)