### PR TITLE
Fix #302: raise app/state + app/registry coverage (55%/0% -> 97%/81%)

### DIFF
--- a/app/src/test/java/com/rousecontext/app/registry/HealthConnectIntegrationTest.kt
+++ b/app/src/test/java/com/rousecontext/app/registry/HealthConnectIntegrationTest.kt
@@ -1,0 +1,44 @@
+package com.rousecontext.app.registry
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class HealthConnectIntegrationTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `exposes canonical health metadata`() {
+        val integration = HealthConnectIntegration(context)
+
+        assertEquals("health", integration.id)
+        assertEquals("Health Connect", integration.displayName)
+        assertEquals("/health", integration.path)
+        assertEquals("setup", integration.onboardingRoute)
+        assertEquals("settings", integration.settingsRoute)
+        assertTrue(integration.description.isNotBlank())
+    }
+
+    @Test
+    fun `provider exposes a non-blank id`() {
+        val integration = HealthConnectIntegration(context)
+        // HealthConnectMcpServer uses its own id ("health-connect") for MCP
+        // protocol advertising. The integration keeps the shorter path id.
+        assertTrue(integration.provider.id.isNotBlank())
+        assertTrue(integration.provider.displayName.isNotBlank())
+    }
+
+    @Test
+    fun `isAvailable returns true on API P+`() = runBlocking {
+        // Robolectric defaults to a modern SDK level (well above API 28).
+        val integration = HealthConnectIntegration(context)
+        assertTrue(integration.isAvailable())
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/registry/IntegrationProviderRegistryTest.kt
+++ b/app/src/test/java/com/rousecontext/app/registry/IntegrationProviderRegistryTest.kt
@@ -1,0 +1,165 @@
+package com.rousecontext.app.registry
+
+import com.rousecontext.api.IntegrationStateStore
+import com.rousecontext.api.McpIntegration
+import com.rousecontext.mcp.core.McpServerProvider
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+
+class IntegrationProviderRegistryTest {
+
+    private lateinit var scope: CoroutineScope
+    private lateinit var job: Job
+
+    @Before
+    fun setUp() {
+        job = SupervisorJob()
+        scope = CoroutineScope(Dispatchers.Unconfined + job)
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    @Test
+    fun `providerForPath returns null when integration disabled`() = runBlocking {
+        val health = fakeIntegration("health", "/health")
+        val store = FakeStateStore()
+        val registry = IntegrationProviderRegistry(listOf(health), store, scope)
+
+        // Wait for the init collector to seed enabledIds.
+        withTimeout(TIMEOUT_MS) { registry.enabledIds.first() }
+        assertNull(registry.providerForPath("health"))
+        assertEquals(emptySet<String>(), registry.enabledPaths())
+    }
+
+    @Test
+    fun `providerForPath returns provider when enabled`() = runBlocking {
+        val health = fakeIntegration("health", "/health")
+        val store = FakeStateStore()
+        val registry = IntegrationProviderRegistry(listOf(health), store, scope)
+
+        store.enabledFor("health").value = true
+        withTimeout(TIMEOUT_MS) {
+            registry.enabledIds.first { "health" in it }
+        }
+
+        assertSame(health.provider, registry.providerForPath("health"))
+        assertEquals(setOf("health"), registry.enabledPaths())
+    }
+
+    @Test
+    fun `providerForPath returns null for unknown path`() = runBlocking {
+        val health = fakeIntegration("health", "/health")
+        val store = FakeStateStore()
+        val registry = IntegrationProviderRegistry(listOf(health), store, scope)
+
+        store.enabledFor("health").value = true
+        withTimeout(TIMEOUT_MS) {
+            registry.enabledIds.first { "health" in it }
+        }
+
+        assertNull(registry.providerForPath("nonexistent"))
+    }
+
+    @Test
+    fun `disabling an integration removes it from enabledPaths`() = runBlocking {
+        val health = fakeIntegration("health", "/health")
+        val usage = fakeIntegration("usage", "/usage")
+        val store = FakeStateStore()
+        val registry = IntegrationProviderRegistry(listOf(health, usage), store, scope)
+
+        store.enabledFor("health").value = true
+        store.enabledFor("usage").value = true
+        withTimeout(TIMEOUT_MS) {
+            registry.enabledIds.first { it.size == 2 }
+        }
+        assertEquals(setOf("health", "usage"), registry.enabledPaths())
+
+        store.enabledFor("usage").value = false
+        withTimeout(TIMEOUT_MS) {
+            registry.enabledIds.first { "usage" !in it }
+        }
+        assertEquals(setOf("health"), registry.enabledPaths())
+        assertNull(registry.providerForPath("usage"))
+    }
+
+    @Test
+    fun `empty integration list does not fail`() = runBlocking {
+        val store = FakeStateStore()
+        val registry = IntegrationProviderRegistry(emptyList(), store, scope)
+
+        assertNull(registry.providerForPath("health"))
+        assertEquals(emptySet<String>(), registry.enabledPaths())
+        // No need to await — flow never launches and enabledIds stays empty.
+        assertEquals(emptySet<String>(), registry.enabledIds.value)
+    }
+
+    private fun fakeIntegration(integrationId: String, integrationPath: String): McpIntegration =
+        object : McpIntegration {
+            override val id = integrationId
+            override val displayName = integrationId
+            override val description = ""
+            override val path = integrationPath
+            override val onboardingRoute = "setup"
+            override val settingsRoute = "settings"
+            override val provider: McpServerProvider = object : McpServerProvider {
+                override val id = integrationId
+                override val displayName = integrationId
+                override fun register(server: Server) = Unit
+            }
+
+            override suspend fun isAvailable(): Boolean = true
+        }
+
+    private class FakeStateStore : IntegrationStateStore {
+        private val enabled = mutableMapOf<String, MutableStateFlow<Boolean>>()
+        private val ever = mutableMapOf<String, MutableStateFlow<Boolean>>()
+
+        fun enabledFor(id: String): MutableStateFlow<Boolean> =
+            enabled.getOrPut(id) { MutableStateFlow(false) }
+
+        private fun everFor(id: String): MutableStateFlow<Boolean> =
+            ever.getOrPut(id) { MutableStateFlow(false) }
+
+        override suspend fun isUserEnabled(integrationId: String): Boolean =
+            enabledFor(integrationId).value
+
+        override suspend fun setUserEnabled(integrationId: String, enabled: Boolean) {
+            if (enabled) everFor(integrationId).value = true
+            enabledFor(integrationId).value = enabled
+        }
+
+        override fun observeUserEnabled(integrationId: String): Flow<Boolean> =
+            enabledFor(integrationId)
+
+        override suspend fun wasEverEnabled(integrationId: String): Boolean =
+            everFor(integrationId).value
+
+        override fun observeEverEnabled(integrationId: String): Flow<Boolean> =
+            everFor(integrationId)
+
+        override fun observeChanges(): Flow<Unit> = enabledFor("__any__").map { }
+    }
+
+    companion object {
+        private const val TIMEOUT_MS = 5_000L
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/registry/NotificationIntegrationTest.kt
+++ b/app/src/test/java/com/rousecontext/app/registry/NotificationIntegrationTest.kt
@@ -1,0 +1,92 @@
+package com.rousecontext.app.registry
+
+import android.content.Context
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import com.rousecontext.integrations.notifications.NotificationDao
+import com.rousecontext.integrations.notifications.NotificationDatabase
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NotificationIntegrationTest {
+
+    private lateinit var context: Context
+    private lateinit var db: NotificationDatabase
+    private lateinit var dao: NotificationDao
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        db = NotificationDatabase.createInMemory(context)
+        dao = db.notificationDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun `exposes canonical notification metadata`() {
+        val integration = NotificationIntegration(context, dao)
+
+        assertEquals("notifications", integration.id)
+        assertEquals("Notifications", integration.displayName)
+        assertEquals("/notifications", integration.path)
+        assertEquals("setup", integration.onboardingRoute)
+        assertEquals("settings", integration.settingsRoute)
+        assertTrue(integration.description.isNotBlank())
+    }
+
+    @Test
+    fun `provider id matches integration id`() {
+        val integration = NotificationIntegration(context, dao)
+        assertEquals("notifications", integration.provider.id)
+    }
+
+    @Test
+    fun `isAvailable always true`() = runBlocking {
+        assertTrue(NotificationIntegration(context, dao).isAvailable())
+    }
+
+    @Test
+    fun `isPermissionGranted false when listener not registered`() {
+        val integration = NotificationIntegration(context, dao)
+        // Robolectric default: enabled_notification_listeners is unset.
+        assertFalse(integration.isPermissionGranted())
+    }
+
+    @Test
+    fun `isPermissionGranted true when listener registered in Settings Secure`() {
+        val integration = NotificationIntegration(context, dao)
+
+        // Fake a grant by writing the component flattening into the
+        // "enabled_notification_listeners" secure setting that the code reads.
+        val component = "${context.packageName}/" +
+            "com.rousecontext.integrations.notifications.NotificationCaptureService"
+        Settings.Secure.putString(
+            context.contentResolver,
+            "enabled_notification_listeners",
+            component
+        )
+
+        assertTrue(integration.isPermissionGranted())
+    }
+
+    @Test
+    fun `constructor accepts allowActions override without crashing`() {
+        // This exercises the branch that toggles action-execution tools in
+        // the provider. We don't assert on the provider's private state;
+        // constructing it is enough to cover the wiring.
+        val integration = NotificationIntegration(context, dao, allowActions = false)
+        assertEquals("notifications", integration.id)
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/registry/OutreachIntegrationTest.kt
+++ b/app/src/test/java/com/rousecontext/app/registry/OutreachIntegrationTest.kt
@@ -1,0 +1,112 @@
+package com.rousecontext.app.registry
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import com.rousecontext.api.LaunchRequestNotifierApi
+import com.rousecontext.app.state.IntegrationSettingsStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class OutreachIntegrationTest {
+
+    private lateinit var context: Context
+    private lateinit var settingsStore: IntegrationSettingsStore
+    private lateinit var scope: CoroutineScope
+    private lateinit var job: Job
+
+    @Before
+    fun setUp() = runBlocking {
+        context = ApplicationProvider.getApplicationContext()
+        context.filesDir.listFiles()?.forEach { it.deleteRecursively() }
+        settingsStore = IntegrationSettingsStore(context)
+        job = SupervisorJob()
+        scope = CoroutineScope(Dispatchers.Unconfined + job)
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
+    }
+
+    @Test
+    fun `exposes canonical outreach metadata`() {
+        val integration = OutreachIntegration(context, settingsStore, NoopNotifier, scope)
+
+        assertEquals("outreach", integration.id)
+        assertEquals("Outreach", integration.displayName)
+        assertEquals("/outreach", integration.path)
+        assertEquals("setup", integration.onboardingRoute)
+        assertEquals("settings", integration.settingsRoute)
+        assertTrue(integration.description.isNotBlank())
+    }
+
+    @Test
+    fun `provider id matches integration id`() {
+        val integration = OutreachIntegration(context, settingsStore, NoopNotifier, scope)
+        assertEquals("outreach", integration.provider.id)
+    }
+
+    @Test
+    fun `isAvailable always true`() = runBlocking {
+        val integration = OutreachIntegration(context, settingsStore, NoopNotifier, scope)
+        assertTrue(integration.isAvailable())
+    }
+
+    @Test
+    fun `directLaunchEnabled starts false and follows settings store`() = runBlocking {
+        val integration = OutreachIntegration(context, settingsStore, NoopNotifier, scope)
+
+        assertFalse(integration.directLaunchEnabled.value)
+
+        settingsStore.setBoolean(
+            integration.id,
+            IntegrationSettingsStore.KEY_DIRECT_LAUNCH_ENABLED,
+            true
+        )
+
+        withTimeout(TIMEOUT_MS) {
+            integration.directLaunchEnabled.first { it }
+        }
+        assertTrue(integration.directLaunchEnabled.value)
+
+        settingsStore.setBoolean(
+            integration.id,
+            IntegrationSettingsStore.KEY_DIRECT_LAUNCH_ENABLED,
+            false
+        )
+        withTimeout(TIMEOUT_MS) {
+            integration.directLaunchEnabled.first { !it }
+        }
+        assertFalse(integration.directLaunchEnabled.value)
+    }
+
+    private object NoopNotifier : LaunchRequestNotifierApi {
+        override fun postLaunchApp(
+            launchIntent: Intent,
+            packageName: String,
+            clientName: String?
+        ): Int = 0
+
+        override fun postOpenLink(viewIntent: Intent, url: String, clientName: String?): Int = 0
+    }
+
+    companion object {
+        private const val TIMEOUT_MS = 5_000L
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/registry/UsageIntegrationTest.kt
+++ b/app/src/test/java/com/rousecontext/app/registry/UsageIntegrationTest.kt
@@ -1,0 +1,39 @@
+package com.rousecontext.app.registry
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class UsageIntegrationTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `exposes canonical usage metadata`() {
+        val integration = UsageIntegration(context)
+
+        assertEquals("usage", integration.id)
+        assertEquals("Usage Stats", integration.displayName)
+        assertEquals("/usage", integration.path)
+        assertEquals("setup", integration.onboardingRoute)
+        assertEquals("settings", integration.settingsRoute)
+        assertTrue(integration.description.isNotBlank())
+    }
+
+    @Test
+    fun `provider id matches integration id`() {
+        val integration = UsageIntegration(context)
+        assertEquals("usage", integration.provider.id)
+    }
+
+    @Test
+    fun `isAvailable always true`() = runBlocking {
+        assertTrue(UsageIntegration(context).isAvailable())
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/state/DataStoreIntegrationStateStoreTest.kt
+++ b/app/src/test/java/com/rousecontext/app/state/DataStoreIntegrationStateStoreTest.kt
@@ -1,0 +1,127 @@
+package com.rousecontext.app.state
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Unit tests for [DataStoreIntegrationStateStore]. Exercises the
+ * [com.rousecontext.api.IntegrationStateStore] contract against a real
+ * Preferences DataStore backed by the Robolectric in-process filesystem.
+ *
+ * Note: every test gets a fresh app filesDir via [Robolectric], but
+ * DataStore files are cached per-Context on disk across tests, so we
+ * set/reset values explicitly rather than relying on a pristine store.
+ */
+@RunWith(RobolectricTestRunner::class)
+class DataStoreIntegrationStateStoreTest {
+
+    private lateinit var context: Context
+    private lateinit var store: DataStoreIntegrationStateStore
+
+    @Before
+    fun setUp() = runBlocking {
+        context = ApplicationProvider.getApplicationContext()
+        store = DataStoreIntegrationStateStore(context)
+    }
+
+    @Test
+    fun `defaults are false for unknown id`() = runTest {
+        // Use a fresh-per-test id so cross-test state does not leak
+        // through the process-wide DataStore instance.
+        val id = "unknown-${System.nanoTime()}"
+        assertFalse(store.isUserEnabled(id))
+        assertFalse(store.wasEverEnabled(id))
+    }
+
+    @Test
+    fun `setUserEnabled true persists and flips everEnabled`() = runTest {
+        val id = "enable-${System.nanoTime()}"
+        store.setUserEnabled(id, true)
+
+        assertTrue(store.isUserEnabled(id))
+        assertTrue(store.wasEverEnabled(id))
+    }
+
+    @Test
+    fun `setUserEnabled false keeps everEnabled true once flipped`() = runTest {
+        val id = "sticky-${System.nanoTime()}"
+        store.setUserEnabled(id, true)
+        store.setUserEnabled(id, false)
+
+        assertFalse(store.isUserEnabled(id))
+        assertTrue(store.wasEverEnabled(id))
+    }
+
+    @Test
+    fun `setUserEnabled does not set everEnabled when disabled first time`() = runTest {
+        val id = "never-${System.nanoTime()}"
+        store.setUserEnabled(id, false)
+
+        assertFalse(store.isUserEnabled(id))
+        assertFalse(store.wasEverEnabled(id))
+    }
+
+    @Test
+    fun `observeUserEnabled emits initial then updates`() = runTest {
+        val id = "obs-user-${System.nanoTime()}"
+        store.observeUserEnabled(id).test {
+            assertFalse(awaitItem())
+            store.setUserEnabled(id, true)
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeEverEnabled emits initial then flips on first enable`() = runTest {
+        val id = "obs-ever-${System.nanoTime()}"
+        store.observeEverEnabled(id).test {
+            assertFalse(awaitItem())
+            store.setUserEnabled(id, true)
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeChanges emits Unit for every edit`() = runTest {
+        // First element is the initial preferences read.
+        val initial = store.observeChanges().first()
+        assertEquals(Unit, initial)
+
+        store.observeChanges().test {
+            awaitItem() // initial value
+            store.setUserEnabled("a", true)
+            awaitItem() // after edit
+            store.setUserEnabled("b", false)
+            // "b=false" edits the preferences store but may not emit a new
+            // snapshot if the value is unchanged from implicit default;
+            // tolerate that by cancelling without a strict count.
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `independent integration ids do not collide`() = runTest {
+        val a = "a-${System.nanoTime()}"
+        val b = "b-${System.nanoTime()}"
+        store.setUserEnabled(a, true)
+        store.setUserEnabled(b, false)
+
+        assertTrue(store.isUserEnabled(a))
+        assertFalse(store.isUserEnabled(b))
+        assertTrue(store.wasEverEnabled(a))
+        assertFalse(store.wasEverEnabled(b))
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/state/DataStoreNotificationSettingsProviderTest.kt
+++ b/app/src/test/java/com/rousecontext/app/state/DataStoreNotificationSettingsProviderTest.kt
@@ -1,0 +1,82 @@
+package com.rousecontext.app.state
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import com.rousecontext.api.PostSessionMode
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class DataStoreNotificationSettingsProviderTest {
+
+    private lateinit var context: Context
+    private lateinit var provider: DataStoreNotificationSettingsProvider
+
+    @Before
+    fun setUp() = runBlocking {
+        context = ApplicationProvider.getApplicationContext()
+        provider = DataStoreNotificationSettingsProvider(context)
+        // Normalize baseline — DataStore instance is process-wide and
+        // values can leak from prior tests.
+        provider.setPostSessionMode(PostSessionMode.SUMMARY)
+        provider.setShowAllMcpMessages(false)
+    }
+
+    @Test
+    fun `baseline settings reflect explicit defaults`() = runTest {
+        val settings = provider.settings()
+        assertEquals(PostSessionMode.SUMMARY, settings.postSessionMode)
+        assertFalse(settings.showAllMcpMessages)
+        // Robolectric has notifications enabled globally but no runtime
+        // POST_NOTIFICATIONS permission granted on API 33+.
+        assertFalse(settings.notificationPermissionGranted)
+    }
+
+    @Test
+    fun `setPostSessionMode persists each enum value`() = runTest {
+        provider.setPostSessionMode(PostSessionMode.EACH_USAGE)
+        assertEquals(PostSessionMode.EACH_USAGE, provider.settings().postSessionMode)
+
+        provider.setPostSessionMode(PostSessionMode.SUPPRESS)
+        assertEquals(PostSessionMode.SUPPRESS, provider.settings().postSessionMode)
+
+        provider.setPostSessionMode(PostSessionMode.SUMMARY)
+        assertEquals(PostSessionMode.SUMMARY, provider.settings().postSessionMode)
+    }
+
+    @Test
+    fun `setShowAllMcpMessages persists value`() = runTest {
+        provider.setShowAllMcpMessages(true)
+        assertTrue(provider.settings().showAllMcpMessages)
+
+        provider.setShowAllMcpMessages(false)
+        assertFalse(provider.settings().showAllMcpMessages)
+    }
+
+    @Test
+    fun `observeSettings emits initial and every change`() = runTest {
+        provider.observeSettings().test {
+            val first = awaitItem()
+            assertEquals(PostSessionMode.SUMMARY, first.postSessionMode)
+
+            provider.setPostSessionMode(PostSessionMode.SUPPRESS)
+            val second = awaitItem()
+            assertEquals(PostSessionMode.SUPPRESS, second.postSessionMode)
+
+            provider.setShowAllMcpMessages(true)
+            val third = awaitItem()
+            assertTrue(third.showAllMcpMessages)
+            assertEquals(PostSessionMode.SUPPRESS, third.postSessionMode)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/state/DeviceRegistrationStatusTest.kt
+++ b/app/src/test/java/com/rousecontext/app/state/DeviceRegistrationStatusTest.kt
@@ -1,0 +1,67 @@
+package com.rousecontext.app.state
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeviceRegistrationStatusTest {
+
+    @Test
+    fun `default is not complete`() {
+        val status = DeviceRegistrationStatus()
+        assertFalse(status.complete.value)
+    }
+
+    @Test
+    fun `constructor honors initiallyRegistered`() {
+        val status = DeviceRegistrationStatus(initiallyRegistered = true)
+        assertTrue(status.complete.value)
+    }
+
+    @Test
+    fun `markComplete flips observable`() {
+        val status = DeviceRegistrationStatus()
+        status.markComplete()
+        assertTrue(status.complete.value)
+    }
+
+    @Test
+    fun `awaitComplete returns immediately when already complete`() = runBlocking {
+        val status = DeviceRegistrationStatus(initiallyRegistered = true)
+        withTimeout(TIMEOUT_MS) {
+            status.awaitComplete()
+        }
+    }
+
+    @Test
+    fun `awaitComplete suspends until markComplete`() = runBlocking {
+        val status = DeviceRegistrationStatus()
+        val suspended = CompletableDeferred<Unit>()
+        val job = launch(Dispatchers.Default) {
+            status.awaitComplete()
+            suspended.complete(Unit)
+        }
+
+        // Give the awaiter a chance to suspend on the StateFlow.
+        delay(SUSPEND_DELAY_MS)
+        assertFalse(suspended.isCompleted)
+
+        status.markComplete()
+        withTimeout(TIMEOUT_MS) {
+            suspended.await()
+        }
+        assertEquals(true, job.isCompleted || job.isActive)
+    }
+
+    companion object {
+        private const val TIMEOUT_MS = 5_000L
+        private const val SUSPEND_DELAY_MS = 100L
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/state/IntegrationSettingsStoreTest.kt
+++ b/app/src/test/java/com/rousecontext/app/state/IntegrationSettingsStoreTest.kt
@@ -1,0 +1,119 @@
+package com.rousecontext.app.state
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class IntegrationSettingsStoreTest {
+
+    private lateinit var context: Context
+    private lateinit var store: IntegrationSettingsStore
+
+    @Before
+    fun setUp() = runBlocking {
+        context = ApplicationProvider.getApplicationContext()
+        store = IntegrationSettingsStore(context)
+    }
+
+    @Test
+    fun `getBoolean returns default when unset`() = runTest {
+        val id = "id-${System.nanoTime()}"
+        assertFalse(store.getBoolean(id, "allow_actions"))
+        assertTrue(store.getBoolean(id, "allow_actions", default = true))
+    }
+
+    @Test
+    fun `setBoolean persists and reads back`() = runTest {
+        val id = "id-${System.nanoTime()}"
+        store.setBoolean(id, IntegrationSettingsStore.KEY_ALLOW_ACTIONS, true)
+        assertTrue(store.getBoolean(id, IntegrationSettingsStore.KEY_ALLOW_ACTIONS))
+    }
+
+    @Test
+    fun `getInt returns default when unset`() = runTest {
+        val id = "id-${System.nanoTime()}"
+        assertEquals(7, store.getInt(id, "retention_days", default = 7))
+        assertEquals(30, store.getInt(id, "retention_days", default = 30))
+    }
+
+    @Test
+    fun `setInt persists and reads back`() = runTest {
+        val id = "id-${System.nanoTime()}"
+        store.setInt(id, IntegrationSettingsStore.KEY_RETENTION_DAYS, 14)
+        assertEquals(
+            14,
+            store.getInt(id, IntegrationSettingsStore.KEY_RETENTION_DAYS, default = 7)
+        )
+    }
+
+    @Test
+    fun `observeBoolean emits initial default and every write`() = runTest {
+        val id = "id-${System.nanoTime()}"
+        store.observeBoolean(id, IntegrationSettingsStore.KEY_DND_TOGGLED).test {
+            assertFalse(awaitItem())
+            store.setBoolean(id, IntegrationSettingsStore.KEY_DND_TOGGLED, true)
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeInt emits initial default and every write`() = runTest {
+        val id = "id-${System.nanoTime()}"
+        store.observeInt(id, IntegrationSettingsStore.KEY_RETENTION_DAYS, 7).test {
+            assertEquals(7, awaitItem())
+            store.setInt(id, IntegrationSettingsStore.KEY_RETENTION_DAYS, 30)
+            assertEquals(30, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `different integration ids do not collide`() = runTest {
+        val a = "a-${System.nanoTime()}"
+        val b = "b-${System.nanoTime()}"
+        store.setBoolean(a, IntegrationSettingsStore.KEY_DND_TOGGLED, true)
+        store.setBoolean(b, IntegrationSettingsStore.KEY_DND_TOGGLED, false)
+
+        assertTrue(store.getBoolean(a, IntegrationSettingsStore.KEY_DND_TOGGLED))
+        assertFalse(store.getBoolean(b, IntegrationSettingsStore.KEY_DND_TOGGLED))
+    }
+
+    @Test
+    fun `booleanKey and intKey namespace by integration id`() {
+        val aBool = IntegrationSettingsStore.booleanKey("outreach", "x")
+        val bBool = IntegrationSettingsStore.booleanKey("notifications", "x")
+        assertNotEquals(aBool, bBool)
+
+        val aInt = IntegrationSettingsStore.intKey("outreach", "x")
+        val bInt = IntegrationSettingsStore.intKey("notifications", "x")
+        assertNotEquals(aInt, bInt)
+    }
+
+    @Test
+    fun `observeAll emits preferences snapshot reflecting writes`() = runTest {
+        val id = "obs-all-${System.nanoTime()}"
+        store.observeAll().test {
+            awaitItem() // Initial snapshot (may be non-empty from prior tests).
+            store.setBoolean(id, IntegrationSettingsStore.KEY_DND_TOGGLED, true)
+            val updated = awaitItem()
+            val key = IntegrationSettingsStore.booleanKey(
+                id,
+                IntegrationSettingsStore.KEY_DND_TOGGLED
+            )
+            assertEquals(true, updated[key])
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/state/NotificationPermissionMonitorTest.kt
+++ b/app/src/test/java/com/rousecontext/app/state/NotificationPermissionMonitorTest.kt
@@ -1,0 +1,72 @@
+package com.rousecontext.app.state
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NotificationPermissionMonitorTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `areNotificationsEnabled returns false without runtime permission on API 33+`() {
+        // Robolectric simulates API 35 by default; POST_NOTIFICATIONS is not
+        // auto-granted, so the runtime check returns DENIED.
+        assertFalse(NotificationPermissionMonitor.areNotificationsEnabled(context))
+    }
+
+    @Test
+    fun `notificationPermissionFlow emits current state immediately on collection`() = runTest {
+        val triggers = MutableSharedFlow<Unit>()
+        val flow = notificationPermissionFlow(context, triggers)
+
+        val first = flow.first()
+        assertFalse(first)
+    }
+
+    @Test
+    fun `notificationPermissionFlow deduplicates on re-triggering the same result`() = runTest {
+        val triggers = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+        notificationPermissionFlow(context, triggers).test {
+            assertFalse(awaitItem())
+            triggers.tryEmit(Unit)
+            triggers.tryEmit(Unit)
+            // distinctUntilChanged swallows identical repeats.
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `refresher emits tick on refresh`() = runBlocking {
+        val refresher = NotificationPermissionRefresher()
+        // Use tryEmit behavior: refresh() pushes into the extraBufferCapacity=1
+        // buffer, so the collector below observes the tick synchronously.
+        refresher.ticks.test {
+            refresher.refresh()
+            assertEquals(Unit, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `refresher does not over-buffer when no collector`() {
+        val refresher = NotificationPermissionRefresher()
+        // Two refreshes with buffer=1 — the second should coalesce, not crash.
+        refresher.refresh()
+        refresher.refresh()
+        assertTrue(true)
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/state/OAuthHostnameProviderTest.kt
+++ b/app/src/test/java/com/rousecontext/app/state/OAuthHostnameProviderTest.kt
@@ -1,0 +1,129 @@
+package com.rousecontext.app.state
+
+import com.rousecontext.api.McpIntegration
+import com.rousecontext.mcp.core.McpServerProvider
+import com.rousecontext.tunnel.CertificateStore
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Unit tests for [OAuthHostnameProvider]. Exercises the subdomain/secret
+ * resolution paths without any Android framework dependencies.
+ */
+class OAuthHostnameProviderTest {
+
+    @Test
+    fun `resolve returns localhost when subdomain is null`() = runBlocking {
+        val store = FakeStore(subdomain = null, secrets = mapOf("health" to "happy"))
+        val provider = OAuthHostnameProvider(
+            certStore = store,
+            baseDomain = "rousecontext.com",
+            integrations = listOf(fakeIntegration("health"))
+        )
+
+        assertEquals("localhost", provider.resolve())
+    }
+
+    @Test
+    fun `resolve returns localhost when secret is missing`() = runBlocking {
+        val store = FakeStore(subdomain = "abc123", secrets = emptyMap())
+        val provider = OAuthHostnameProvider(
+            certStore = store,
+            baseDomain = "rousecontext.com",
+            integrations = listOf(fakeIntegration("health"))
+        )
+
+        assertEquals("localhost", provider.resolve())
+    }
+
+    @Test
+    fun `resolve joins secret subdomain and base domain`() = runBlocking {
+        val store = FakeStore(
+            subdomain = "abc123",
+            secrets = mapOf("health" to "happy")
+        )
+        val provider = OAuthHostnameProvider(
+            certStore = store,
+            baseDomain = "rousecontext.com",
+            integrations = listOf(fakeIntegration("health"))
+        )
+
+        assertEquals("happy.abc123.rousecontext.com", provider.resolve())
+    }
+
+    @Test
+    fun `resolve uses first integration id`() = runBlocking {
+        val store = FakeStore(
+            subdomain = "device1",
+            secrets = mapOf("health" to "apple", "usage" to "banana")
+        )
+        val provider = OAuthHostnameProvider(
+            certStore = store,
+            baseDomain = "example.org",
+            // First integration is usage — provider reads that id's secret.
+            integrations = listOf(fakeIntegration("usage"), fakeIntegration("health"))
+        )
+
+        assertEquals("banana.device1.example.org", provider.resolve())
+    }
+
+    @Test
+    fun `resolve defaults to health id when integrations list empty`() = runBlocking {
+        val store = FakeStore(
+            subdomain = "device1",
+            secrets = mapOf("health" to "orange")
+        )
+        val provider = OAuthHostnameProvider(
+            certStore = store,
+            baseDomain = "example.org",
+            integrations = emptyList()
+        )
+
+        assertEquals("orange.device1.example.org", provider.resolve())
+    }
+
+    private fun fakeIntegration(integrationId: String): McpIntegration = object : McpIntegration {
+        override val id = integrationId
+        override val displayName = integrationId
+        override val description = ""
+        override val path = "/$integrationId"
+        override val onboardingRoute = "setup"
+        override val settingsRoute = "settings"
+        override val provider: McpServerProvider = object : McpServerProvider {
+            override val id = integrationId
+            override val displayName = integrationId
+            override fun register(server: Server) = Unit
+        }
+
+        override suspend fun isAvailable(): Boolean = true
+    }
+
+    private class FakeStore(
+        private val subdomain: String?,
+        private val secrets: Map<String, String>
+    ) : CertificateStore {
+        override suspend fun getSubdomain(): String? = subdomain
+        override suspend fun getIntegrationSecrets(): Map<String, String>? =
+            if (secrets.isEmpty()) null else secrets
+        override suspend fun storeIntegrationSecrets(secrets: Map<String, String>) = Unit
+        override suspend fun getCertChain(): List<ByteArray>? = null
+        override suspend fun getPrivateKeyBytes(): ByteArray? = null
+        override suspend fun storeCertChain(chain: List<ByteArray>) = Unit
+        override suspend fun getCertExpiry(): Long? = null
+        override suspend fun getKnownFingerprints(): Set<String> = emptySet()
+        override suspend fun storeFingerprint(fingerprint: String) = Unit
+        override suspend fun hasFingerprintBootstrapMarker(): Boolean = false
+        override suspend fun writeFingerprintBootstrapMarker() = Unit
+        override suspend fun storeCertificate(pemChain: String) = Unit
+        override suspend fun getCertificate(): String? = null
+        override suspend fun storeClientCertificate(pemChain: String) = Unit
+        override suspend fun getClientCertificate(): String? = null
+        override suspend fun storeRelayCaCert(pem: String) = Unit
+        override suspend fun getRelayCaCert(): String? = null
+        override suspend fun storeSubdomain(subdomain: String) = Unit
+        override suspend fun clear() = Unit
+        override suspend fun clearCertificates() = Unit
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/state/ThemePreferenceTest.kt
+++ b/app/src/test/java/com/rousecontext/app/state/ThemePreferenceTest.kt
@@ -1,0 +1,68 @@
+package com.rousecontext.app.state
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ThemePreferenceTest {
+
+    private lateinit var context: Context
+    private lateinit var pref: ThemePreference
+
+    @Before
+    fun setUp() = runBlocking {
+        context = ApplicationProvider.getApplicationContext()
+        context.filesDir.listFiles()?.forEach { it.deleteRecursively() }
+        pref = ThemePreference(context)
+    }
+
+    @Test
+    fun `default theme is AUTO when explicitly set`() = runTest {
+        pref.setThemeMode(ThemeMode.AUTO)
+        pref.themeMode.test {
+            assertEquals(ThemeMode.AUTO, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setThemeMode persists each enum value`() = runTest {
+        pref.setThemeMode(ThemeMode.LIGHT)
+        pref.themeMode.test {
+            assertEquals(ThemeMode.LIGHT, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        pref.setThemeMode(ThemeMode.DARK)
+        pref.themeMode.test {
+            assertEquals(ThemeMode.DARK, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        pref.setThemeMode(ThemeMode.AUTO)
+        pref.themeMode.test {
+            assertEquals(ThemeMode.AUTO, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `themeMode emits updates as setter runs`() = runTest {
+        pref.themeMode.test {
+            assertEquals(ThemeMode.AUTO, awaitItem())
+            pref.setThemeMode(ThemeMode.DARK)
+            assertEquals(ThemeMode.DARK, awaitItem())
+            pref.setThemeMode(ThemeMode.LIGHT)
+            assertEquals(ThemeMode.LIGHT, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #302 (part of #297).

Adds unit tests for the two Koin-wired state packages flagged in the coverage triage. All tests use Robolectric for Android SDK types and real Preferences DataStore instances (no mocks of DataStore internals).

## Coverage

### app/state: 55.4% -> 97.4% line

| Class | Before | After |
|---|---|---|
| AppStatePreferences | 100% | 100% |
| DataStoreIntegrationStateStore | 0% | 100% |
| DataStoreNotificationSettingsProvider | 0% | 92.6% |
| DeviceRegistrationStatus | 100% | 100% |
| IntegrationSettingsStore | 46.7% | 100% |
| NotificationPermissionMonitor | 0% | 83.3% |
| NotificationPermissionMonitorKt (top-level) | 0% | 100% |
| NotificationPermissionRefresher | 0% | 100% |
| OAuthHostnameProvider | 0% | 100% |
| PreferenceValue / PreferencesSnapshot | 100% | 100% |
| PreferencesSnapshotHolder | 96.3% | 96.3% |
| ThemePreference | 7.1% | 100% |

### app/registry: 0% -> 81.2% line

| Class | Before | After |
|---|---|---|
| HealthConnectIntegration | 0% | 100% |
| IntegrationProviderRegistry | 0% | 100% |
| NotificationIntegration | 0% | 56.1% |
| OutreachIntegration | 0% | 87.9% |
| UsageIntegration | 0% | 100% |

`NotificationIntegration` plateaus at 56% because its action-execution paths (`performAction`, `dismissNotification`, `getActiveNotifications`) reference the `NotificationCaptureService` singleton, which is not instantiable from unit tests. The package still clears the 70% target for wiring classes.

## New test files

- `app/src/test/java/com/rousecontext/app/state/DataStoreIntegrationStateStoreTest.kt`
- `app/src/test/java/com/rousecontext/app/state/DataStoreNotificationSettingsProviderTest.kt`
- `app/src/test/java/com/rousecontext/app/state/DeviceRegistrationStatusTest.kt`
- `app/src/test/java/com/rousecontext/app/state/IntegrationSettingsStoreTest.kt`
- `app/src/test/java/com/rousecontext/app/state/NotificationPermissionMonitorTest.kt`
- `app/src/test/java/com/rousecontext/app/state/OAuthHostnameProviderTest.kt`
- `app/src/test/java/com/rousecontext/app/state/ThemePreferenceTest.kt`
- `app/src/test/java/com/rousecontext/app/registry/HealthConnectIntegrationTest.kt`
- `app/src/test/java/com/rousecontext/app/registry/IntegrationProviderRegistryTest.kt`
- `app/src/test/java/com/rousecontext/app/registry/NotificationIntegrationTest.kt`
- `app/src/test/java/com/rousecontext/app/registry/OutreachIntegrationTest.kt`
- `app/src/test/java/com/rousecontext/app/registry/UsageIntegrationTest.kt`

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` passes
- [x] `./gradlew :app:koverHtmlReport` shows state at 97%, registry at 81%
- [x] `./gradlew ktlintCheck` clean on new files
- [x] `./gradlew detekt` clean on new files (pre-existing unrelated failures on main)

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>