### PR TITLE
Fix #319: Cold-start-via-FCM e2e test on real device

### DIFF
--- a/e2e/src/test/kotlin/com/rousecontext/e2e/ColdStartEndToEndTest.kt
+++ b/e2e/src/test/kotlin/com/rousecontext/e2e/ColdStartEndToEndTest.kt
@@ -1,0 +1,431 @@
+package com.rousecontext.e2e
+
+import java.net.URLEncoder
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import okhttp3.FormBody
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestMethodOrder
+
+/**
+ * Cold-start-via-FCM end-to-end test.
+ *
+ * Force-stops the app, then hits the MCP endpoint over HTTPS. The relay delivers
+ * an FCM high-priority message which wakes the device from cold, establishes
+ * the tunnel, and serves the MCP request. Measures wall-clock latency.
+ *
+ * Requires:
+ * - A debug build installed and onboarded on a device
+ * - Device connected via adb through adolin.lan
+ * - The relay running at relay.rousecontext.com
+ * - FCM configured (real Firebase project, not test)
+ *
+ * Run with:
+ * ```
+ * ./gradlew :e2e:e2eTest -Dadb.host=adolin.lan
+ * ```
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class ColdStartEndToEndTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private val adbHost = System.getProperty("adb.host", "adolin.lan")
+    private val integrationId = System.getProperty("mcp.integration", "test")
+
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(25, TimeUnit.SECONDS)
+        .readTimeout(25, TimeUnit.SECONDS)
+        .writeTimeout(25, TimeUnit.SECONDS)
+        .followRedirects(false)
+        .build()
+
+    private lateinit var mcpUrl: String
+    private lateinit var baseUrl: String
+    private lateinit var accessToken: String
+    private var mcpSessionId: String? = null
+
+    @BeforeAll
+    fun setup() {
+        // Skip if no device reachable
+        assumeTrue(deviceIsConnected(), "No device connected via adb")
+
+        // Ensure app is running so we can read device state
+        adb(
+            "shell",
+            "am",
+            "start",
+            "-n",
+            "com.rousecontext.debug/com.rousecontext.app.MainActivity"
+        )
+        Thread.sleep(3000)
+
+        // Check device is onboarded
+        val subdomain = getDeviceSubdomain()
+        assumeTrue(subdomain != null, "Device not onboarded (no subdomain)")
+
+        // Enable integration and discover MCP URL
+        enableIntegration(integrationId)
+        Thread.sleep(1000)
+
+        val explicitUrl = System.getProperty("mcp.url", "")
+        mcpUrl = if (explicitUrl.isNotEmpty()) {
+            explicitUrl
+        } else {
+            discoverMcpUrl(integrationId)
+        }
+        baseUrl = mcpUrl.removeSuffix("/mcp")
+        println("Cold-start test MCP URL: $mcpUrl")
+
+        // Perform OAuth flow while app is warm to get a valid access token
+        accessToken = performOAuthFlow()
+        println("Access token obtained: ${accessToken.take(10)}...")
+    }
+
+    @Test
+    @Order(1)
+    fun `01 - cold start via FCM wake succeeds within latency budget`() {
+        // Force-stop the app — kills process cold
+        adb("shell", "am", "force-stop", "com.rousecontext.debug")
+
+        // Wait for process death
+        val deadline = System.currentTimeMillis() + 10_000
+        while (adb("shell", "pidof", "com.rousecontext.debug").isNotBlank()) {
+            Thread.sleep(500)
+            assertTrue(
+                System.currentTimeMillis() < deadline,
+                "Process did not die within 10 seconds"
+            )
+        }
+
+        // Extra buffer for Android to clean up process state
+        Thread.sleep(2000)
+
+        // Verify process is actually dead
+        val pidCheck = adb("shell", "pidof", "com.rousecontext.debug")
+        assertTrue(pidCheck.isBlank(), "Process still running after force-stop: '$pidCheck'")
+
+        // Hit the MCP endpoint — triggers relay -> FCM -> cold device wake
+        val initBody = buildJsonObject {
+            put("method", "initialize")
+            put("jsonrpc", "2.0")
+            put("id", 1)
+            put(
+                "params",
+                buildJsonObject {
+                    put("protocolVersion", "2025-11-25")
+                    put("capabilities", buildJsonObject {})
+                    put(
+                        "clientInfo",
+                        buildJsonObject {
+                            put("name", "E2E Cold Start Test")
+                            put("version", "1.0.0")
+                        }
+                    )
+                }
+            )
+        }
+
+        val request = Request.Builder()
+            .url(mcpUrl)
+            .post(initBody.toString().toRequestBody("application/json".toMediaType()))
+            .header("Authorization", "Bearer $accessToken")
+            .build()
+
+        val startMs = System.currentTimeMillis()
+        client.newCall(request).execute().use { response ->
+            val latencyMs = System.currentTimeMillis() - startMs
+            val bodyText = response.body?.string() ?: ""
+
+            println("Cold-start-via-FCM latency: ${latencyMs}ms")
+            println("Response code: ${response.code}")
+
+            assertTrue(
+                response.code in listOf(200, 401),
+                "Expected 200 or 401, got ${response.code}: $bodyText"
+            )
+            assertTrue(
+                latencyMs < 20_000,
+                "Cold start latency ${latencyMs}ms exceeded 20s budget"
+            )
+
+            if (response.code == 200) {
+                mcpSessionId = response.header("Mcp-Session-Id")
+                val body = json.parseToJsonElement(bodyText).jsonObject
+                val result = body["result"]?.jsonObject
+                assertNotNull(result, "Missing result in initialize response: $bodyText")
+                println("Server initialized successfully after cold start")
+            }
+        }
+    }
+
+    @Test
+    @Order(2)
+    fun `02 - warm start after cold start is fast`() {
+        // This test depends on test 01 having succeeded (tunnel is now warm)
+        assumeTrue(mcpSessionId != null, "Cold start test did not produce a session")
+
+        // Send a tools/list request — tunnel is already up, no FCM wake needed
+        val listBody = buildJsonObject {
+            put("method", "tools/list")
+            put("jsonrpc", "2.0")
+            put("id", 2)
+        }
+
+        val request = Request.Builder()
+            .url(mcpUrl)
+            .post(listBody.toString().toRequestBody("application/json".toMediaType()))
+            .header("Authorization", "Bearer $accessToken")
+            .header("Mcp-Session-Id", mcpSessionId!!)
+            .build()
+
+        val startMs = System.currentTimeMillis()
+        client.newCall(request).execute().use { response ->
+            val latencyMs = System.currentTimeMillis() - startMs
+            val bodyText = response.body?.string() ?: ""
+
+            println("Warm-start latency: ${latencyMs}ms")
+            println("Response code: ${response.code}")
+
+            assertTrue(
+                response.code == 200,
+                "Expected 200 for warm request, got ${response.code}: $bodyText"
+            )
+            assertTrue(
+                latencyMs < 3_000,
+                "Warm start latency ${latencyMs}ms exceeded 3s budget " +
+                    "(tunnel should already be up)"
+            )
+
+            val body = json.parseToJsonElement(bodyText).jsonObject
+            val tools = body["result"]?.jsonObject?.get("tools")?.jsonArray
+            assertNotNull(tools, "Missing tools in warm-start response")
+            assertTrue(tools!!.isNotEmpty(), "No tools returned on warm start")
+            println("Warm start returned ${tools.size} tools in ${latencyMs}ms")
+        }
+    }
+
+    // --- OAuth flow ---
+
+    private fun performOAuthFlow(): String {
+        // PKCE
+        val random = SecureRandom()
+        val verifierBytes = ByteArray(32)
+        random.nextBytes(verifierBytes)
+        val codeVerifier = Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(verifierBytes)
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(codeVerifier.toByteArray())
+        val codeChallenge = Base64.getUrlEncoder().withoutPadding()
+            .encodeToString(digest)
+
+        // Register client
+        val registerBody = buildJsonObject {
+            put(
+                "redirect_uris",
+                buildJsonArray {
+                    add(JsonPrimitive("http://localhost:9999/callback"))
+                }
+            )
+            put("client_name", "E2E Cold Start Test")
+            put("token_endpoint_auth_method", "client_secret_post")
+            put(
+                "grant_types",
+                buildJsonArray {
+                    add(JsonPrimitive("authorization_code"))
+                    add(JsonPrimitive("refresh_token"))
+                }
+            )
+            put(
+                "response_types",
+                buildJsonArray {
+                    add(JsonPrimitive("code"))
+                }
+            )
+        }
+
+        val regRequest = Request.Builder()
+            .url("$baseUrl/register")
+            .post(registerBody.toString().toRequestBody("application/json".toMediaType()))
+            .build()
+
+        val (clientId, clientSecret) = client.newCall(regRequest).execute().use { response ->
+            val body = json.parseToJsonElement(response.body!!.string()).jsonObject
+            val id = body["client_id"]!!.jsonPrimitive.content
+            val secret = body["client_secret"]?.jsonPrimitive?.content
+            Pair(id, secret)
+        }
+
+        // Authorize
+        val authUrl = "$baseUrl/authorize?" +
+            "response_type=code&" +
+            "client_id=$clientId&" +
+            "redirect_uri=${URLEncoder.encode("http://localhost:9999/callback", "UTF-8")}&" +
+            "code_challenge=$codeChallenge&" +
+            "code_challenge_method=S256&" +
+            "state=e2etest-coldstart"
+
+        val authRequest = Request.Builder().url(authUrl).get().build()
+        val authCode = client.newCall(authRequest).execute().use { response ->
+            val html = response.body!!.string()
+            require(response.code == 200) {
+                "Authorization page failed: $html"
+            }
+
+            val codePattern = Regex("""([A-Z0-9]{6}-[A-Z0-9]{6})""")
+            val match = codePattern.find(html)
+                ?: error("Could not find display code in authorize page")
+            val displayCode = match.value
+            println("Display code: $displayCode")
+
+            approveAuth(displayCode)
+
+            val requestIdPattern = Regex("""request_id=([a-f0-9-]+)""")
+            val requestId = requestIdPattern.find(html)!!.groupValues[1]
+
+            var code: String? = null
+            for (i in 1..10) {
+                Thread.sleep(1000)
+                val statusRequest = Request.Builder()
+                    .url("$baseUrl/authorize/status?request_id=$requestId")
+                    .get().build()
+
+                client.newCall(statusRequest).execute().use { statusResponse ->
+                    val statusBody = json.parseToJsonElement(
+                        statusResponse.body!!.string()
+                    ).jsonObject
+                    val status = statusBody["status"]?.jsonPrimitive?.content
+                    if (status == "approved") {
+                        code = statusBody["code"]?.jsonPrimitive?.content
+                    }
+                }
+                if (code != null) break
+            }
+            requireNotNull(code) { "Authorization was not approved within 10 seconds" }
+            code!!
+        }
+
+        // Token exchange
+        val formBody = FormBody.Builder()
+            .add("grant_type", "authorization_code")
+            .add("code", authCode)
+            .add("client_id", clientId)
+            .add("code_verifier", codeVerifier)
+            .add("redirect_uri", "http://localhost:9999/callback")
+            .apply { clientSecret?.let { add("client_secret", it) } }
+            .build()
+
+        val tokenRequest = Request.Builder()
+            .url("$baseUrl/token")
+            .post(formBody)
+            .build()
+
+        return client.newCall(tokenRequest).execute().use { response ->
+            val body = json.parseToJsonElement(response.body!!.string()).jsonObject
+            require(response.code == 200) { "Token exchange failed: $body" }
+            body["access_token"]!!.jsonPrimitive.content
+        }
+    }
+
+    // --- Device helpers ---
+
+    private fun deviceIsConnected(): Boolean = try {
+        val result = adb("devices")
+        // Look for at least one device line (not just "List of devices attached")
+        result.lines().any { line ->
+            line.contains("\tdevice") || line.contains("\tunauthorized")
+        }
+    } catch (_: Exception) {
+        false
+    }
+
+    private fun getDeviceSubdomain(): String? = try {
+        val subdomain = adb(
+            "shell",
+            "run-as",
+            "com.rousecontext.debug",
+            "cat",
+            "files/rouse_subdomain.txt"
+        ).trim()
+        subdomain.ifEmpty { null }
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun discoverMcpUrl(integration: String): String {
+        val subdomain = getDeviceSubdomain()
+            ?: error("No subdomain found on device")
+
+        val secretsJson = adb(
+            "shell",
+            "run-as",
+            "com.rousecontext.debug",
+            "cat",
+            "files/rouse_integration_secrets.json"
+        ).trim()
+        require(secretsJson.isNotEmpty()) { "No integration secrets found on device" }
+
+        val secrets = json.parseToJsonElement(secretsJson).jsonObject
+        val secret = secrets[integration]?.jsonPrimitive?.content
+            ?: error("No secret for integration '$integration'. Available: ${secrets.keys}")
+
+        return "https://$secret.$subdomain.rousecontext.com/mcp"
+    }
+
+    private fun adb(vararg args: String): String {
+        val serial = System.getProperty("adb.serial", "")
+        val remoteAdb = if (serial.isNotEmpty()) {
+            "ANDROID_SERIAL=$serial /opt/android-sdk/platform-tools/adb"
+        } else {
+            "/opt/android-sdk/platform-tools/adb"
+        }
+        val cmd = listOf("ssh", adbHost, remoteAdb) + args.toList()
+        val process = ProcessBuilder(cmd)
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.bufferedReader().readText()
+        process.waitFor(15, TimeUnit.SECONDS)
+        return output.trim()
+    }
+
+    private fun enableIntegration(id: String) {
+        val result = adb(
+            "shell", "content", "call",
+            "--uri", "content://com.rousecontext.debug.test",
+            "--method", "enable_integration",
+            "--extra", "id:s:$id"
+        )
+        println("Enable integration '$id': $result")
+    }
+
+    private fun approveAuth(displayCode: String) {
+        val result = adb(
+            "shell", "content", "call",
+            "--uri", "content://com.rousecontext.debug.test",
+            "--method", "approve_auth",
+            "--extra", "code:s:$displayCode"
+        )
+        println("Approve auth '$displayCode': $result")
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ColdStartEndToEndTest.kt` in `:e2e` that force-stops the app, confirms process death, then hits the MCP endpoint to exercise the full relay -> FCM -> cold device wake path
- Asserts cold-start response within 20s latency budget and logs wall-clock timing
- Follow-up warm-start test verifies subsequent request completes in <3s (tunnel already up)
- Tests skip via `assumeTrue` when no device is connected — CI compiles but does not execute

## Test plan

- [x] `./gradlew :e2e:compileTestKotlin` passes
- [x] `./gradlew :e2e:ktlintCheck` passes
- [ ] Manual execution against real device when available (skipped in CI)

Closes #319
Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)