### PR TITLE
Fix #323: Remove personal machine identifiers from public repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,28 @@ cd relay
 cargo build --release
 ```
 
+### End-to-end tests
+
+The e2e tests drive a real device over `adb` via a (typically LAN-local) host
+running `adb`. The `adb.host` system property is required and defaults to empty
+— the `:e2e:e2eTest` task fails fast if unset. Device serial is optional and
+only needed if multiple devices are connected to that host.
+
+```bash
+./gradlew :e2e:e2eTest \
+    -Dadb.host=<your-dev-host> \
+    -Dadb.serial=<your-device-serial>
+```
+
+The `:device-tests` module has a separate runner that builds an APK pointed at a
+locally-running relay. It also requires a LAN IP reachable from the device:
+
+```bash
+./gradlew :device-tests:test -Dlan.ip=<your-lan-ip>
+```
+
+Without `lan.ip`, the device-tests skip cleanly via JUnit assumptions.
+
 ## Status
 
 Active development. The core flow works end-to-end: Claude can connect, wake the phone, authorize via OAuth, and call MCP tools. See `docs/design/` for detailed design documents.

--- a/app/src/test/java/com/rousecontext/app/cert/AndroidKeystoreDeviceKeyManagerTest.kt
+++ b/app/src/test/java/com/rousecontext/app/cert/AndroidKeystoreDeviceKeyManagerTest.kt
@@ -24,8 +24,8 @@ import org.robolectric.RobolectricTestRunner
  * - the returned private key can produce SHA256withECDSA signatures that verify under
  *   the returned public key -- i.e. the `KeyPair` is self-consistent
  *
- * The StrongBox-vs-TEE fallback path is exercised by hand on real hardware (see adolin
- * smoke-test instructions in issue #200). Robolectric does not simulate the
+ * The StrongBox-vs-TEE fallback path is exercised by hand on real hardware (see the
+ * device smoke-test instructions in issue #200). Robolectric does not simulate the
  * StrongBoxUnavailableException code path faithfully.
  */
 @RunWith(RobolectricTestRunner::class)

--- a/device-tests/src/test/kotlin/com/rousecontext/device/ApkBuilder.kt
+++ b/device-tests/src/test/kotlin/com/rousecontext/device/ApkBuilder.kt
@@ -19,7 +19,7 @@ class ApkBuilder(private val repoRoot: File) {
     /**
      * Build the debug APK configured to connect to the given relay host and port.
      *
-     * @param relayHost The IP/hostname the device should connect to (e.g., "192.168.68.92")
+     * @param relayHost The IP/hostname the device should connect to (e.g., "<your-lan-ip>")
      * @param relayPort The port the relay is listening on
      * @param relayScheme WebSocket scheme: "ws" for plain, "wss" for TLS (default: "ws")
      * @return The path to the built APK file

--- a/device-tests/src/test/kotlin/com/rousecontext/device/DeviceIntegrationTest.kt
+++ b/device-tests/src/test/kotlin/com/rousecontext/device/DeviceIntegrationTest.kt
@@ -22,8 +22,13 @@ import org.junit.Test
 class DeviceIntegrationTest {
 
     companion object {
-        /** LAN IP that the device can reach this machine on. */
-        private const val LAN_IP = "192.168.68.92"
+        /**
+         * LAN IP that the device can reach this machine on. Must be provided via the
+         * `lan.ip` system property (or `LAN_IP` env var). Example:
+         * `./gradlew :device-tests:deviceTest -Dlan.ip=<your-lan-ip>`.
+         */
+        private val LAN_IP: String? =
+            System.getProperty("lan.ip") ?: System.getenv("LAN_IP")
 
         /** How long to wait for the device to connect to the relay after a wake broadcast. */
         private const val WAKE_TIMEOUT_MS = 30_000L
@@ -41,6 +46,12 @@ class DeviceIntegrationTest {
     @Before
     fun setUp() {
         repoRoot = findRepoRoot()
+
+        assumeTrue(
+            "lan.ip system property (or LAN_IP env var) not set; " +
+                "pass -Dlan.ip=<your-lan-ip> reachable from the connected device",
+            LAN_IP != null
+        )
 
         device = DeviceController()
         assumeTrue(
@@ -100,7 +111,7 @@ class DeviceIntegrationTest {
         println("Fake FCM server started on port ${fcmServer.port}")
 
         // 2. Build APK pointing at local relay
-        val apk = apkBuilder.build(relayHost = LAN_IP, relayPort = relay.port)
+        val apk = apkBuilder.build(relayHost = requireNotNull(LAN_IP), relayPort = relay.port)
 
         // Install on device
         device.installApk(apk.absolutePath).requireSuccess("APK install")
@@ -161,7 +172,7 @@ class DeviceIntegrationTest {
      */
     @Test
     fun `apk builds and installs with custom relay config`() {
-        val apk = apkBuilder.build(relayHost = LAN_IP, relayPort = 9999)
+        val apk = apkBuilder.build(relayHost = requireNotNull(LAN_IP), relayPort = 9999)
         assertTrue("APK should exist after build", apk.exists())
         assertTrue("APK should not be empty", apk.length() > 0)
 

--- a/docs/device-test-report.md
+++ b/docs/device-test-report.md
@@ -1,7 +1,7 @@
 # Device Integration Test Report
 
 **Date:** 2026-04-07
-**Device:** Pixel 3 XL (serial: 84TY004PW, Android 12, SDK 31)
+**Device:** Pixel 3 XL (serial: `<your-device-serial>`, Android 12, SDK 31)
 **Build:** `app-debug.apk` built from commit `a3a0c1a` (main)
 **Package:** `com.rousecontext.debug`
 **Relay:** `relay.rousecontext.com` (uptime ~14h at test start)

--- a/docs/e2e-status.md
+++ b/docs/e2e-status.md
@@ -50,6 +50,6 @@ No log entries about the AI client connection arriving or being routed.
 
 ## Device info
 - Pixel 3 XL, API 31, package `com.rousecontext.debug`
-- Wireless ADB: `192.168.68.112:38285`
+- Wireless ADB: `<your-lan-ip>:<port>`
 - Subdomain: `main-board`
 - Relay: `relay.rousecontext.com` (35.209.161.222)

--- a/docs/overnight-plan-2.md
+++ b/docs/overnight-plan-2.md
@@ -76,9 +76,9 @@ Each integration needs: module, MCP provider, setup UI, permission handling, tes
 **5b. Lower minSdk** — Investigate what breaks below API 28, add feature flags.
 
 ### Phase 6: Device Integration Testing
-Run after all implementation is complete. Uses the Pixel 3 XL attached to adolin.lan via ADB (`~/Android/Sdk/platform-tools/adb -s 84TY004PW`).
+Run after all implementation is complete. Uses the Pixel 3 XL attached to `<your-dev-host>` via ADB (`~/Android/Sdk/platform-tools/adb -s <your-device-serial>`).
 
-**6a. Build, deploy, and smoke test** — `./gradlew :app:assembleDebug`, scp to adolin, adb install. Launch app, verify it starts without crash.
+**6a. Build, deploy, and smoke test** — `./gradlew :app:assembleDebug`, scp to `<your-dev-host>`, adb install. Launch app, verify it starts without crash.
 
 **6b. Onboarding flow** — If not already onboarded, walk through: Firebase auth → relay registration → cert issuance → subdomain assignment. Verify dashboard shows after.
 

--- a/e2e/build.gradle.kts
+++ b/e2e/build.gradle.kts
@@ -18,7 +18,7 @@ tasks.test {
     useJUnitPlatform()
 }
 
-// Run with: ./gradlew :e2e:e2eTest
+// Run with: ./gradlew :e2e:e2eTest -Dadb.host=<your-dev-host> [-Dadb.serial=<your-device-serial>]
 tasks.register<Test>("e2eTest") {
     group = "verification"
     description = "Run end-to-end MCP tests against a real device"
@@ -26,10 +26,23 @@ tasks.register<Test>("e2eTest") {
     classpath = sourceSets.test.get().runtimeClasspath
     useJUnitPlatform()
 
+    // Fail fast if adb.host is not provided. The e2e tests need to talk to a real
+    // device over adb; there is no sensible default. See README for usage.
+    doFirst {
+        val adbHost = System.getProperty("adb.host", "")
+        if (adbHost.isBlank()) {
+            throw GradleException(
+                "adb.host system property is required. " +
+                    "Example: ./gradlew :e2e:e2eTest -Dadb.host=<your-dev-host> " +
+                    "[-Dadb.serial=<your-device-serial>]"
+            )
+        }
+    }
+
     // Pass device URL via system property
     // ./gradlew :e2e:e2eTest -Dmcp.url=https://foo-test.device.rousecontext.com/mcp
     systemProperty("mcp.url", System.getProperty("mcp.url", ""))
     systemProperty("mcp.integration", System.getProperty("mcp.integration", "test"))
-    systemProperty("adb.host", System.getProperty("adb.host", "adolin.lan"))
+    systemProperty("adb.host", System.getProperty("adb.host", ""))
     systemProperty("adb.serial", System.getProperty("adb.serial", ""))
 }

--- a/e2e/src/test/kotlin/com/rousecontext/e2e/ColdStartEndToEndTest.kt
+++ b/e2e/src/test/kotlin/com/rousecontext/e2e/ColdStartEndToEndTest.kt
@@ -37,13 +37,13 @@ import org.junit.jupiter.api.TestMethodOrder
  *
  * Requires:
  * - A debug build installed and onboarded on a device
- * - Device connected via adb through adolin.lan
+ * - Device connected via adb through <your-dev-host>
  * - The relay running at relay.rousecontext.com
  * - FCM configured (real Firebase project, not test)
  *
  * Run with:
  * ```
- * ./gradlew :e2e:e2eTest -Dadb.host=adolin.lan
+ * ./gradlew :e2e:e2eTest -Dadb.host=<your-dev-host>
  * ```
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -51,7 +51,8 @@ import org.junit.jupiter.api.TestMethodOrder
 class ColdStartEndToEndTest {
 
     private val json = Json { ignoreUnknownKeys = true }
-    private val adbHost = System.getProperty("adb.host", "adolin.lan")
+    private val adbHost = System.getProperty("adb.host")
+        ?: error("adb.host system property required, e.g. -Dadb.host=<your-dev-host>")
     private val integrationId = System.getProperty("mcp.integration", "test")
 
     private val client = OkHttpClient.Builder()

--- a/e2e/src/test/kotlin/com/rousecontext/e2e/IntegrationToolsTest.kt
+++ b/e2e/src/test/kotlin/com/rousecontext/e2e/IntegrationToolsTest.kt
@@ -31,13 +31,14 @@ import org.junit.jupiter.api.TestFactory
  *
  * Run with:
  * ```
- * ./gradlew :e2e:e2eTest -Dadb.host=adolin.lan
+ * ./gradlew :e2e:e2eTest -Dadb.host=<your-dev-host>
  * ```
  */
 class IntegrationToolsTest {
 
     private val json = Json { ignoreUnknownKeys = true }
-    private val adbHost = System.getProperty("adb.host", "adolin.lan")
+    private val adbHost = System.getProperty("adb.host")
+        ?: error("adb.host system property required, e.g. -Dadb.host=<your-dev-host>")
 
     /**
      * Expected tools per integration. Integrations not listed here still get a

--- a/e2e/src/test/kotlin/com/rousecontext/e2e/McpEndToEndTest.kt
+++ b/e2e/src/test/kotlin/com/rousecontext/e2e/McpEndToEndTest.kt
@@ -31,14 +31,14 @@ import org.junit.jupiter.api.TestMethodOrder
  *
  * Requires:
  * - A debug build installed on a device with test integration available
- * - Device connected via adb through adolin.lan
+ * - Device connected via adb through <your-dev-host>
  * - The relay running at relay.rousecontext.com
  *
  * Run with:
  * ```
  * ./gradlew :e2e:e2eTest \
  *   -Dmcp.url=https://foo-test.wet-scone.rousecontext.com/mcp \
- *   -Dadb.host=adolin.lan
+ *   -Dadb.host=<your-dev-host>
  * ```
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -71,7 +71,8 @@ class McpEndToEndTest {
 
     @BeforeAll
     fun setup() {
-        adbHost = System.getProperty("adb.host", "adolin.lan")
+        adbHost = System.getProperty("adb.host")
+            ?: error("adb.host system property required, e.g. -Dadb.host=<your-dev-host>")
         integrationId = System.getProperty("mcp.integration", "test")
 
         // Ensure app is running and Koin is initialized


### PR DESCRIPTION
## Summary
- Replace hardcoded `adolin.lan` / device serial `84TY004PW` / LAN IP `192.168.68.*` with `<your-dev-host>`, `<your-device-serial>`, `<your-lan-ip>` placeholders across e2e tests, device-tests, docs, and one comment.
- `:e2e:e2eTest` Gradle task now requires `-Dadb.host=...` and fails fast with a helpful message instead of silently defaulting to the author's LAN host.
- e2e test classes throw on missing `adb.host`; `:device-tests` reads `lan.ip` and skips via `assumeTrue` when unset.
- README grows an "End-to-end tests" section documenting the required system properties.

## Test plan
- [x] `grep` for `adolin.lan`, `84TY004PW`, `192.168.68.` in the tree returns zero hits
- [x] `./gradlew :e2e:compileTestKotlin :device-tests:compileTestKotlin` passes
- [x] `./gradlew assembleDebug ktlintCheck` passes
- [x] detekt baseline unchanged (81 pre-existing issues, nothing new from this PR)

Fixes #323