### PR TITLE
Fix #324: Empty stream drain burned session-summary per-cycle gate

### DIFF
--- a/notifications/src/main/java/com/rousecontext/notifications/SessionSummaryNotifier.kt
+++ b/notifications/src/main/java/com/rousecontext/notifications/SessionSummaryNotifier.kt
@@ -45,10 +45,18 @@ import kotlinx.coroutines.flow.Flow
  * ## Repeated drains in one connection cycle
  *
  * We post at most once per connection cycle (from DISCONNECTED to DISCONNECTED).
- * If an AI client reopens streams after draining, we do NOT re-capture a cursor
- * and do NOT re-post. The cursor is re-armed only after the tunnel fully
- * disconnects and reconnects. This prevents notification spam when clients
+ * If an AI client reopens streams after a *posted* drain, we do NOT re-capture
+ * a cursor and do NOT re-post. The cursor is re-armed only after the tunnel
+ * fully disconnects and reconnects. This prevents notification spam when clients
  * churn streams and matches the user-visible notion of "one session".
+ *
+ * An *empty* drain — a stream that opened and closed without producing any
+ * audit-tool-call rows (for example a probe client that calls only
+ * `tools/list` or `resources/list`, which go to `mcp_request_entries` not
+ * `audit_entries`) — does NOT burn the per-cycle gate. The next ACTIVE
+ * transition re-arms the cursor so any real tool-call activity in later
+ * streams still surfaces a summary. See issue #324 for the regression this
+ * distinction closes.
  */
 class SessionSummaryNotifier(
     private val context: Context,
@@ -88,9 +96,19 @@ class SessionSummaryNotifier(
                     val startCursor = cursorId!!
                     val sessionEndMillis = System.currentTimeMillis()
                     val entries = auditDao.queryCreatedAfter(startCursor)
-                    postForMode(entries, sessionStartMillis, sessionEndMillis)
+                    val didPost = postForMode(entries, sessionStartMillis, sessionEndMillis)
                     cursorId = null
-                    posted = true
+                    // Only burn the per-cycle gate when we actually posted.
+                    // An empty drain (no audit rows since the cursor) can
+                    // happen when an AI client opens a probe stream that
+                    // only calls tools/list or resources/list — those go to
+                    // mcp_request_entries, not audit_entries. Burning the
+                    // gate on an empty drain would silently drop summaries
+                    // for any subsequent stream in the same connection
+                    // cycle that DOES have tool calls. See issue #324.
+                    if (didPost) {
+                        posted = true
+                    }
                 }
                 // Reset when the tunnel fully disconnects. Defensive: if we
                 // went ACTIVE -> DISCONNECTED without a CONNECTED drain, we
@@ -105,14 +123,31 @@ class SessionSummaryNotifier(
         }
     }
 
-    private suspend fun postForMode(entries: List<AuditEntry>, startMillis: Long, endMillis: Long) {
+    /**
+     * Post a session-end notification for [entries] according to the user's
+     * current [PostSessionMode] preference.
+     *
+     * Returns `true` when a notification was actually posted, `false`
+     * otherwise. The caller uses this to decide whether to burn the
+     * per-connection-cycle `posted` gate — see [observe]'s handling of the
+     * ACTIVE → CONNECTED branch.
+     */
+    private suspend fun postForMode(
+        entries: List<AuditEntry>,
+        startMillis: Long,
+        endMillis: Long
+    ): Boolean {
         val mode = settingsProvider.settings().postSessionMode
-        when (mode) {
-            PostSessionMode.SUPPRESS -> return
-            PostSessionMode.EACH_USAGE -> return
+        return when (mode) {
+            PostSessionMode.SUPPRESS -> false
+            PostSessionMode.EACH_USAGE -> false
             PostSessionMode.SUMMARY -> {
-                if (entries.isEmpty()) return
-                postSummary(entries, startMillis, endMillis)
+                if (entries.isEmpty()) {
+                    false
+                } else {
+                    postSummary(entries, startMillis, endMillis)
+                    true
+                }
             }
         }
     }

--- a/notifications/src/test/java/com/rousecontext/notifications/SessionSummaryNotifierTest.kt
+++ b/notifications/src/test/java/com/rousecontext/notifications/SessionSummaryNotifierTest.kt
@@ -257,6 +257,89 @@ class SessionSummaryNotifierTest {
         coroutineContext.cancelChildren()
     }
 
+    /**
+     * Regression test for issue #324.
+     *
+     * Symptom: a user had tool uses in the morning but no session-summary
+     * notification fired. The post-#244 suspend-insert fix had closed the
+     * audit-insert race, so rows were present; something else was dropping
+     * the notification.
+     *
+     * Root cause: when a stream drained with zero audit entries (e.g. an
+     * AI client opened a probe stream, listed tools/resources via
+     * `tools/list` — which does NOT write to the audit-tool-call table —
+     * and closed), [SessionSummaryNotifier] still set the per-cycle
+     * `posted` gate to true. Any subsequent stream within the SAME tunnel
+     * connection cycle (no full tunnel DISCONNECTED in between) would see
+     * `posted = true` and skip arming its cursor, so real tool-call
+     * activity in later streams never produced a summary notification.
+     *
+     * Fix: only burn the `posted` gate when we actually posted a
+     * notification. An empty drain (no audit rows since the cursor) must
+     * leave `posted = false` so the next ACTIVE can re-arm.
+     *
+     * Scenario modelled here: one full tunnel cycle, two ACTIVE → CONNECTED
+     * drains inside it; the first drain has no entries, the second has
+     * entries. Post-fix: one summary notification fires on the second
+     * drain. Pre-fix: the probe drain silently burns the gate and no
+     * summary ever fires.
+     */
+    @Test
+    fun `Summary posts on later drain when first drain of cycle has no entries`() = runBlocking {
+        settings.mode = PostSessionMode.SUMMARY
+        val states = MutableSharedFlow<TunnelState>(replay = 16, extraBufferCapacity = 16)
+        val postedSignal = CompletableDeferred<Unit>()
+        dao.onQueryCreatedAfter = {
+            // Second drain of the cycle is the one we expect to post.
+            if (dao.queryCreatedAfterCount >= 2 && !postedSignal.isCompleted) {
+                postedSignal.complete(Unit)
+            }
+        }
+
+        val job = launch { notifier.observe(states) }
+
+        // Cycle start. First stream opens...
+        states.emit(TunnelState.ACTIVE)
+        awaitLatestId()
+
+        // ...and drains with no tool-call rows. This is the "probe" stream
+        // (e.g. tools/list only, which doesn't insert into audit_entries).
+        states.emit(TunnelState.CONNECTED)
+
+        // Give the observer a turn to process the empty drain. We can't rely
+        // on awaitLatestId() here because that's only hit on a cursor arm,
+        // and the whole question of this test is whether the next ACTIVE
+        // re-arms.
+        kotlinx.coroutines.yield()
+
+        // Second stream opens within the same tunnel cycle — no
+        // DISCONNECTED in between. Pre-fix, `posted = true` from the empty
+        // drain blocks the cursor arm here.
+        states.emit(TunnelState.ACTIVE)
+        awaitLatestId()
+        dao.insert(entry(provider = "health", toolName = "get_steps"))
+
+        states.emit(TunnelState.CONNECTED)
+        withTimeout(TIMEOUT_MS) { postedSignal.await() }
+
+        val shadow = Shadows.shadowOf(manager)
+        val notification = shadow.getNotification(SessionSummaryNotifier.NOTIFICATION_ID)
+        assertNotNull(
+            "Summary should post on the second drain when the first drain " +
+                "had no entries (issue #324 — empty drain must not burn the " +
+                "per-cycle gate)",
+            notification
+        )
+        val title = notification.extras.getCharSequence("android.title")?.toString() ?: ""
+        val text = notification.extras.getCharSequence("android.text")?.toString() ?: ""
+        val all = "$title $text"
+        assertTrue("Expected 1 tool call in summary text, was: $all", all.contains("1"))
+        assertTrue("Expected health provider in summary text, was: $all", all.contains("health"))
+
+        job.cancel()
+        coroutineContext.cancelChildren()
+    }
+
     @Test
     fun `Summary mode posts once per connection cycle even with repeated drains`() = runBlocking {
         settings.mode = PostSessionMode.SUMMARY


### PR DESCRIPTION
## Summary
- `SessionSummaryNotifier` burned its per-connection-cycle `posted` gate on every `ACTIVE -> CONNECTED` drain, even when the drain had zero audit-tool-call rows. Any subsequent stream in the same tunnel cycle then saw `posted = true`, skipped arming its cursor, and never surfaced a summary — even with real tool-call activity.
- Empty drains are realistic: an AI client probe stream that calls only `tools/list` or `resources/list` writes to `mcp_request_entries`, **not** `audit_entries`.
- Fix: `postForMode` now returns whether it actually posted. The observer only sets `posted = true` when a summary was posted. Empty drains leave the gate open so the next ACTIVE re-arms.

Closes #324.

## Analysis (also posted on the issue)
- #244's suspend-insert landed correctly; the audit insert happens before `respondText`, so rows ARE in the DB by the time the mux stream drains. That race is closed.
- Before this fix, the bug was an order-of-operations issue in the observer itself. Sequence that reproduces the user's silent-morning report:
  1. Tunnel connects, stream 1 opens.
  2. Client only issues `tools/list` / `resources/list` / `initialize` (all `onRequest`, none `onToolCall`). `audit_entries` stays empty.
  3. Stream 1 closes → ACTIVE → CONNECTED drain. `queryCreatedAfter` returns empty, `postSummary` short-circuits via `entries.isEmpty()`, BUT the observer still set `cursorId = null; posted = true`.
  4. A second stream opens within the idle-timeout window — same tunnel cycle, no DISCONNECTED in between.
  5. Observer checks `state == ACTIVE && cursorId == null && !posted`; `posted` is `true` so the cursor is never armed.
  6. Real tool calls happen in stream 2. Audit rows get inserted.
  7. Stream 2 drains. Observer checks `cursorId != null`; it's null, so the post branch is skipped. No summary.

## Test plan
- [x] `:notifications:testDebugUnitTest` — new `Summary posts on later drain when first drain of cycle has no entries` test added; fails pre-fix (timeout waiting for the second-drain post), passes post-fix.
- [x] `:app:testDebugUnitTest` + `:app:integrationTest` — all existing scenarios (including `Summary mode posts once per connection cycle even with repeated drains`, `No post when tunnel goes ACTIVE to DISCONNECTED without stream drain`, `Summary mode posts nothing when no tool calls occurred`, `Summary mode posts again on a new connection cycle`, and `AuditRaceRegressionTest`) still pass unchanged.
- [ ] Would be nice (follow-up): the unit tests here drive `MutableSharedFlow`; production passes a conflating `StateFlow<TunnelState>`. Not causing #324 but worth a separate test someday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)