### PR TITLE
Fix #325: Eliminate FGS cold-start race

### DIFF
--- a/app/src/main/java/com/rousecontext/app/RouseApplication.kt
+++ b/app/src/main/java/com/rousecontext/app/RouseApplication.kt
@@ -1,6 +1,8 @@
 package com.rousecontext.app
 
 import android.app.Application
+import android.os.Handler
+import android.os.Looper
 import androidx.work.Configuration
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequestBuilder
@@ -65,11 +67,24 @@ class RouseApplication :
             )
         }
 
+        // Notification channels MUST be created before any foreground service
+        // calls startForeground(). On cold-start FCM wakes, the service's
+        // onCreate fires on the next main-looper message after this returns,
+        // so the channel must exist by then. Issue #325.
         NotificationChannels.createAll(this)
-        configureCrashReporting()
-        scheduleSecurityChecks()
-        CertRenewalScheduler.enqueuePeriodic(this)
-        enqueueImmediateCertRenewalIfNeeded()
+
+        // Defer non-critical init to a posted message so that cold-start FCM
+        // wakes reach TunnelForegroundService.startForeground() as fast as
+        // possible. The 5s FGS timer starts when startForegroundService() is
+        // called; Application.onCreate runs BEFORE the service's onCreate, so
+        // every millisecond saved here reduces the risk of
+        // ForegroundServiceDidNotStartInTimeException. Issue #325.
+        Handler(Looper.getMainLooper()).post {
+            configureCrashReporting()
+            scheduleSecurityChecks()
+            CertRenewalScheduler.enqueuePeriodic(this)
+            enqueueImmediateCertRenewalIfNeeded()
+        }
     }
 
     /**

--- a/work/src/main/kotlin/com/rousecontext/work/TunnelForegroundService.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/TunnelForegroundService.kt
@@ -65,8 +65,17 @@ class TunnelForegroundService : LifecycleService() {
 
     override fun onCreate() {
         super.onCreate()
-        NotificationChannels.createAll(this)
 
+        // CRITICAL: startForeground() must be the very first non-trivial call.
+        // Android's ForegroundServiceDidNotStartInTimeException kills the process
+        // if startForeground() isn't called within ~5s of startForegroundService().
+        // On cold-start FCM wakes, Application.onCreate (Koin, Firebase, etc.)
+        // consumes most of that budget, leaving minimal time here. Issue #325.
+        //
+        // NotificationChannels.createAll() is already called in
+        // RouseApplication.onCreate(), so the foreground channel exists by the
+        // time we reach this point. We call createAll() again below as a
+        // defensive no-op for warm-start edge cases, but AFTER startForeground.
         if (!startForegroundSafely()) {
             // FGS daily time-limit exhausted. User notification already posted;
             // stop the service. The next FCM wake will naturally retry
@@ -74,6 +83,8 @@ class TunnelForegroundService : LifecycleService() {
             stopSelf()
             return
         }
+
+        NotificationChannels.createAll(this)
 
         // Launch observer coroutines exactly once. These collect StateFlows and
         // SharedFlows, so they run for the lifetime of the service. Launching them

--- a/work/src/test/kotlin/com/rousecontext/work/TunnelForegroundServiceLifecycleTest.kt
+++ b/work/src/test/kotlin/com/rousecontext/work/TunnelForegroundServiceLifecycleTest.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.junit.After
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -245,6 +246,33 @@ class TunnelForegroundServiceLifecycleTest {
         assertTrue(
             "Should not attempt reconnect when intentionalDisconnect is set",
             fakeTunnelClient.connectCount <= 1
+        )
+    }
+
+    // -- Test 6: startForeground is called immediately in onCreate (issue #325) --
+
+    @Test
+    fun `startForeground is called immediately in onCreate before main looper drains`() {
+        fakeTunnelClient.stateFlow.value = TunnelState.DISCONNECTED
+
+        val controller = Robolectric.buildService(TunnelForegroundService::class.java)
+        val service = controller.get()
+
+        // Call create() WITHOUT draining the main looper afterwards.
+        // If startForeground is deferred to a coroutine or posted message,
+        // the notification will not be present yet.
+        controller.create()
+
+        // Robolectric's shadow tracks the last notification passed to
+        // startForeground(). It should be non-null immediately after
+        // onCreate, proving that startForeground was called synchronously
+        // — not deferred to a coroutine or handler post.
+        val shadow = shadowOf(service)
+        val fgNotification = shadow.lastForegroundNotification
+        assertNotNull(
+            "startForeground must be called synchronously in onCreate " +
+                "before any coroutine or handler work runs (issue #325)",
+            fgNotification
         )
     }
 


### PR DESCRIPTION
## Summary

- Move `startForeground()` to be the very first call in `TunnelForegroundService.onCreate()`, before `NotificationChannels.createAll()` or any coroutine launches. The notification channel already exists from `RouseApplication.onCreate()`.
- Defer non-critical `RouseApplication.onCreate()` work (crash reporting, security-check scheduling, cert renewal scheduling) to a posted `Handler` message, so cold-start FCM wakes reach the service's `startForeground()` faster.
- Add Robolectric test verifying the foreground notification is set synchronously in `onCreate` before the main looper drains.

## Test plan

- [ ] `./gradlew :work:testDebugUnitTest` -- all 6 lifecycle tests pass (including new test 6)
- [ ] `./gradlew :app:testDebugUnitTest` -- no regressions from deferred Application init
- [ ] `./gradlew ktlintCheck` -- clean
- [ ] Cold-start FCM wake test (`am force-stop` + relay wake) no longer drops the WebSocket after ~4s

🤖 Generated with [Claude Code](https://claude.com/claude-code)