### PR TITLE
Fix #339: Publish notification catalog via GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,7 +3,7 @@ name: Deploy docs to GitHub Pages
 on:
   push:
     branches: [main]
-    paths: ['docs/user/**']
+    paths: ['docs/user/**', 'docs/notifications/**', 'notifications/screenshots/**']
   workflow_dispatch:
 
 permissions:
@@ -25,6 +25,11 @@ jobs:
         with:
           source: docs/user
           destination: ./_site
+      - name: Include notification catalog
+        run: |
+          mkdir -p _site/internal/notifications _site/notifications/screenshots
+          cp -r docs/notifications/. _site/internal/notifications/
+          cp -r notifications/screenshots/. _site/notifications/screenshots/
       - uses: actions/upload-pages-artifact@v3
 
   deploy:


### PR DESCRIPTION
## Summary

- Extend `.github/workflows/pages.yml` so the auto-generated notification catalog is published at `rousecontext.com/internal/notifications/` alongside the existing user docs.
- Adds a post-Jekyll copy step that lays `docs/notifications/` into `_site/internal/notifications/` and `notifications/screenshots/` into `_site/notifications/screenshots/`. This keeps the HTML's existing `../../notifications/screenshots/...` relative paths resolving correctly from `/internal/notifications/index.html`.
- Expands the `paths:` trigger to include `docs/notifications/**` and `notifications/screenshots/**` so catalog/screenshot updates also trigger a Pages deploy.

Closes #339.

## Test plan

- [x] YAML validated locally with `python3 -c 'import yaml; yaml.safe_load(...)'`
- [ ] After merge, next Pages deploy publishes `rousecontext.com/internal/notifications/` with images resolving from `rousecontext.com/notifications/screenshots/`
- [ ] Workflow run log shows the new "Include notification catalog" step

No test/product code touched; only the Pages workflow.

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>