### PR TITLE
Fix Pages workflow: chmod _site so catalog copy steps can write

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           source: docs/user
           destination: ./_site
+      # Jekyll's container runs as a non-root user and leaves `_site` owned by
+      # that uid, so subsequent steps (running as runner) can't write into it.
+      # Chmod the tree so the catalog copy steps below can land their files.
+      - name: Make _site writable for catalog copy steps
+        run: sudo chmod -R a+w _site
       - name: Include notification catalog
         run: |
           mkdir -p _site/internal/notifications _site/notifications/screenshots


### PR DESCRIPTION
## Summary

Every Pages workflow run since PR #340 (notification catalog publish)
has failed with:

> mkdir: cannot create directory '_site/internal': Permission denied

`actions/jekyll-build-pages@v1` runs inside a container as a non-root
user, which leaves `_site/` with restrictive ownership when subsequent
steps (running as the normal runner user) try to `mkdir` into it. PR #349
(audit-row-variants catalog) added another copy step, which hit the same
wall.

`sudo chmod -R a+w _site` is the standard workaround — the GitHub Actions
runner always has passwordless sudo — and restores working deployment
without restructuring into separate Jekyll and copy jobs.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, trigger `Deploy docs to GitHub Pages` via
      `gh workflow run` and confirm both catalogs land:
  - `rousecontext.com/internal/notifications/`
  - `rousecontext.com/internal/audit-row-variants/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)