### PR TITLE
Fix #330: Add network constraint to SecurityCheckWorker

### DIFF
--- a/app/src/main/java/com/rousecontext/app/RouseApplication.kt
+++ b/app/src/main/java/com/rousecontext/app/RouseApplication.kt
@@ -4,9 +4,6 @@ import android.app.Application
 import android.os.Handler
 import android.os.Looper
 import androidx.work.Configuration
-import androidx.work.ExistingPeriodicWorkPolicy
-import androidx.work.PeriodicWorkRequestBuilder
-import androidx.work.WorkManager
 import com.rousecontext.api.CrashReporter
 import com.rousecontext.app.debug.debugModules
 import com.rousecontext.app.di.appModule
@@ -15,8 +12,7 @@ import com.rousecontext.notifications.NotificationChannels
 import com.rousecontext.tunnel.CertificateStore
 import com.rousecontext.work.CertRenewalScheduler
 import com.rousecontext.work.KoinWorkerFactory
-import com.rousecontext.work.SecurityCheckWorker
-import java.util.concurrent.TimeUnit
+import com.rousecontext.work.SecurityCheckScheduler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -134,16 +130,10 @@ class RouseApplication :
             val appState = AppStatePreferences(this@RouseApplication)
             val intervalHours = appState.securityCheckIntervalHours()
             val flexHours = (intervalHours / 4).coerceAtLeast(1)
-            val request = PeriodicWorkRequestBuilder<SecurityCheckWorker>(
-                intervalHours.toLong(),
-                TimeUnit.HOURS,
-                flexHours.toLong(),
-                TimeUnit.HOURS
-            ).build()
-            WorkManager.getInstance(this@RouseApplication).enqueueUniquePeriodicWork(
-                "security-check",
-                ExistingPeriodicWorkPolicy.UPDATE,
-                request
+            SecurityCheckScheduler.enqueuePeriodic(
+                this@RouseApplication,
+                intervalHours = intervalHours,
+                flexHours = flexHours
             )
         }
     }

--- a/work/src/main/kotlin/com/rousecontext/work/SecurityCheckScheduler.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/SecurityCheckScheduler.kt
@@ -1,0 +1,65 @@
+package com.rousecontext.work
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import java.util.concurrent.TimeUnit
+
+/**
+ * Enqueues the periodic [SecurityCheckWorker] (self-cert fingerprint match + CT log
+ * monitoring). Extracted out of `RouseApplication` so the constraints are unit-testable
+ * in isolation — the `Application` subclass drives real Koin + Firebase init and is
+ * awkward to exercise under Robolectric just for a scheduling assertion.
+ *
+ * Mirrors [CertRenewalScheduler.enqueuePeriodic]:
+ * - `NetworkType.CONNECTED` — required. Without it the worker fires offline or behind
+ *   a captive portal; the captive portal's HTML response gets mis-reported as a
+ *   "crt.sh returned HTTP 404" alert, spamming the user on every network transition
+ *   (issue #330).
+ * - `requiresBatteryNotLow=true` — consistent with renewal; no reason to burn the
+ *   last 10% on a monitoring check.
+ * - Charging is NOT required: this is a routine check, not a heavy task.
+ */
+object SecurityCheckScheduler {
+
+    /**
+     * Unique-work slot name. Kept as the hyphenated form used by production since
+     * the pre-extraction code in `RouseApplication` — changing the slot would orphan
+     * any already-scheduled work on existing installs until the next Android
+     * process recycle. Intentionally different from [SecurityCheckWorker.WORK_NAME]
+     * (underscore), which names the opportunistic one-time run from
+     * `TunnelForegroundService`.
+     */
+    const val WORK_NAME = "security-check"
+
+    /**
+     * Enqueue the periodic security-check. Safe to call every app startup.
+     *
+     * @param intervalHours how often the worker runs. Read from user preferences.
+     * @param flexHours how much slack WorkManager has to align with other jobs.
+     *   Caller is responsible for enforcing the `>= 1` minimum; this method accepts
+     *   the value as-is so the test can drive representative values.
+     */
+    fun enqueuePeriodic(context: Context, intervalHours: Int, flexHours: Int) {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .setRequiresBatteryNotLow(true)
+            .build()
+        val request = PeriodicWorkRequestBuilder<SecurityCheckWorker>(
+            intervalHours.toLong(),
+            TimeUnit.HOURS,
+            flexHours.toLong(),
+            TimeUnit.HOURS
+        )
+            .setConstraints(constraints)
+            .build()
+        WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+            WORK_NAME,
+            ExistingPeriodicWorkPolicy.UPDATE,
+            request
+        )
+    }
+}

--- a/work/src/test/kotlin/com/rousecontext/work/SecurityCheckSchedulerTest.kt
+++ b/work/src/test/kotlin/com/rousecontext/work/SecurityCheckSchedulerTest.kt
@@ -1,0 +1,125 @@
+package com.rousecontext.work
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.Configuration
+import androidx.work.NetworkType
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.testing.SynchronousExecutor
+import androidx.work.testing.WorkManagerTestInitHelper
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Issue #330: verify the periodic [SecurityCheckWorker] is scheduled with a
+ * network constraint so it doesn't fire while the device is offline or behind
+ * a captive portal. Without `NetworkType.CONNECTED` the worker runs, issues
+ * an HTTP request, and captive-portal HTML comes back as a "crt.sh returned
+ * HTTP 404" notification — a false positive that spams users on every metro
+ * ride or hotel check-in.
+ *
+ * Mirrors [CertRenewalSchedulerTest] — the renewal worker already had the
+ * right constraints and is the pattern we're bringing the security check in
+ * line with.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SecurityCheckSchedulerTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var workManager: WorkManager
+
+    @Before
+    fun setUp() {
+        val config = Configuration.Builder()
+            .setExecutor(SynchronousExecutor())
+            .setTaskExecutor(SynchronousExecutor())
+            .setMinimumLoggingLevel(android.util.Log.DEBUG)
+            .build()
+        WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
+        workManager = WorkManager.getInstance(context)
+    }
+
+    @After
+    fun tearDown() {
+        workManager.cancelAllWork().result.get()
+    }
+
+    @Test
+    fun `enqueuePeriodic schedules unique periodic work with network and battery constraints`() {
+        SecurityCheckScheduler.enqueuePeriodic(
+            context,
+            intervalHours = DEFAULT_INTERVAL_HOURS,
+            flexHours = DEFAULT_FLEX_HOURS
+        )
+
+        val infos = workManager
+            .getWorkInfosForUniqueWork(SecurityCheckScheduler.WORK_NAME)
+            .get()
+
+        assertEquals(
+            "SecurityCheckScheduler.enqueuePeriodic must create exactly one unique " +
+                "work entry under `${SecurityCheckScheduler.WORK_NAME}`",
+            1,
+            infos.size
+        )
+        val info = infos.single()
+        assertEquals(
+            "Freshly-enqueued periodic work should be ENQUEUED (waiting for next run)",
+            WorkInfo.State.ENQUEUED,
+            info.state
+        )
+        val constraints = info.constraints
+        assertEquals(
+            "Security check must require network connectivity — otherwise crt.sh " +
+                "lookups hit captive-portal HTML and report false positives (issue #330)",
+            NetworkType.CONNECTED,
+            constraints.requiredNetworkType
+        )
+        assertTrue(
+            "Security check must not fire on a dying phone — the notification is " +
+                "background noise during low-battery states",
+            constraints.requiresBatteryNotLow()
+        )
+        assertFalse(
+            "Charging must NOT be required — this is a routine monitoring check, not " +
+                "a power-hungry task that needs to wait for the charger",
+            constraints.requiresCharging()
+        )
+    }
+
+    @Test
+    fun `enqueuePeriodic replaces existing periodic work in the same slot`() {
+        SecurityCheckScheduler.enqueuePeriodic(
+            context,
+            intervalHours = DEFAULT_INTERVAL_HOURS,
+            flexHours = DEFAULT_FLEX_HOURS
+        )
+        SecurityCheckScheduler.enqueuePeriodic(
+            context,
+            intervalHours = DEFAULT_INTERVAL_HOURS,
+            flexHours = DEFAULT_FLEX_HOURS
+        )
+
+        val infos = workManager
+            .getWorkInfosForUniqueWork(SecurityCheckScheduler.WORK_NAME)
+            .get()
+
+        assertEquals(
+            "Re-enqueueing must keep the slot at exactly one entry (UPDATE policy)",
+            1,
+            infos.size
+        )
+    }
+
+    private companion object {
+        const val DEFAULT_INTERVAL_HOURS = 24
+        const val DEFAULT_FLEX_HOURS = 6
+    }
+}


### PR DESCRIPTION
## Summary

- `SecurityCheckWorker` was enqueued with no `Constraints`, so it fired offline or behind captive portals and misreported the interstitial HTML as a crt.sh HTTP 404 alert.
- Add `NetworkType.CONNECTED` and `requiresBatteryNotLow=true`, matching the `CertRenewalScheduler` pattern.
- Extract a `SecurityCheckScheduler` object in `:work` so the constraints are unit-testable in Robolectric without driving the full `Application` subclass.

Closes #330

## Test plan

- [x] New `SecurityCheckSchedulerTest` in `:work` asserts `NetworkType.CONNECTED`, `requiresBatteryNotLow=true`, `!requiresCharging`, single-slot UPDATE semantics.
- [x] Test fails against the pre-fix code (scheduler doesn't exist yet), passes after the fix.
- [x] `./gradlew :work:testDebugUnitTest :app:testDebugUnitTest` green.
- [x] `./gradlew :work:ktlintCheck :app:ktlintCheck` green.

Detekt failures on this branch are pre-existing in unrelated `core/tunnel` files (reproduce on clean `main`).

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>