### PR TITLE
Fix #346: Add ToolNameHumanizer utility + all-tools validation test

### DIFF
--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/ToolNameHumanizer.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/ToolNameHumanizer.kt
@@ -1,0 +1,60 @@
+package com.rousecontext.mcp.core
+
+/**
+ * Converts snake_case MCP tool names to human-readable titles for display in
+ * notifications and audit UI.
+ *
+ * Examples:
+ *  - `get_steps` -> `Get Steps`
+ *  - `set_dnd_state` -> `Set DND State`
+ *  - `steps` -> `Steps`
+ *  - `dnd` -> `DND`
+ *
+ * ## Contract
+ *
+ * Input MUST be snake_case: lowercase ASCII letters and digits separated by
+ * single underscores, no leading/trailing underscores, no double underscores,
+ * no other characters. Anything else throws [IllegalArgumentException]; a tool
+ * name that violates the format is a bug and should surface loudly rather
+ * than silently render as garbled UI copy.
+ *
+ * ## Algorithm
+ *
+ *  1. Validate the input is snake_case.
+ *  2. Split on `_`.
+ *  3. For each word: if it appears in [ACRONYMS], uppercase it; otherwise
+ *     capitalise the first letter and lowercase the rest.
+ *  4. Join with single spaces.
+ *
+ * The acronym set is an ordinary constant; extend it as new tools ship with
+ * abbreviations that should render in uppercase.
+ */
+object ToolNameHumanizer {
+
+    /** Lowercase acronyms that should render as UPPERCASE in the output. */
+    private val ACRONYMS = setOf("dnd")
+
+    private val SNAKE_CASE = Regex("^[a-z0-9]+(_[a-z0-9]+)*$")
+
+    /**
+     * Convert [toolName] to a human-readable title.
+     *
+     * @throws IllegalArgumentException if [toolName] is not valid snake_case.
+     */
+    fun humanize(toolName: String): String {
+        require(toolName.isNotEmpty()) {
+            "Tool name must be non-empty snake_case; got empty string"
+        }
+        require(SNAKE_CASE.matches(toolName)) {
+            "Tool name must be snake_case (lowercase letters/digits separated " +
+                "by single underscores); got '$toolName'"
+        }
+        return toolName.split('_').joinToString(separator = " ") { word ->
+            if (word in ACRONYMS) {
+                word.uppercase()
+            } else {
+                word.replaceFirstChar { it.uppercaseChar() }
+            }
+        }
+    }
+}

--- a/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/core/ToolNameHumanizerTest.kt
+++ b/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/core/ToolNameHumanizerTest.kt
@@ -1,0 +1,100 @@
+package com.rousecontext.mcp.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * Unit tests for [ToolNameHumanizer].
+ *
+ * Exercises the snake_case -> Title Case (with acronym set) algorithm and
+ * the fail-loud validation on any input that is not valid snake_case.
+ */
+class ToolNameHumanizerTest {
+
+    @Test
+    fun `humanize converts simple snake_case to Title Case`() {
+        assertEquals("Get Steps", ToolNameHumanizer.humanize("get_steps"))
+        assertEquals("Get Sleep", ToolNameHumanizer.humanize("get_sleep"))
+        assertEquals("Get Summary", ToolNameHumanizer.humanize("get_summary"))
+    }
+
+    @Test
+    fun `humanize uppercases known acronyms`() {
+        assertEquals("Set DND State", ToolNameHumanizer.humanize("set_dnd_state"))
+        assertEquals("Get DND State", ToolNameHumanizer.humanize("get_dnd_state"))
+    }
+
+    @Test
+    fun `humanize capitalises a single word`() {
+        assertEquals("Steps", ToolNameHumanizer.humanize("steps"))
+    }
+
+    @Test
+    fun `humanize uppercases a standalone acronym`() {
+        assertEquals("DND", ToolNameHumanizer.humanize("dnd"))
+    }
+
+    @Test
+    fun `humanize throws on empty input`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ToolNameHumanizer.humanize("")
+        }
+    }
+
+    @Test
+    fun `humanize throws on camelCase input`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ToolNameHumanizer.humanize("GetSteps")
+        }
+    }
+
+    @Test
+    fun `humanize throws on mixed uppercase in underscored input`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ToolNameHumanizer.humanize("Get_Steps")
+        }
+    }
+
+    @Test
+    fun `humanize throws on kebab-case input`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ToolNameHumanizer.humanize("get-steps")
+        }
+    }
+
+    @Test
+    fun `humanize throws on double underscores`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ToolNameHumanizer.humanize("get__steps")
+        }
+    }
+
+    @Test
+    fun `humanize throws on leading underscore`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ToolNameHumanizer.humanize("_get_steps")
+        }
+    }
+
+    @Test
+    fun `humanize throws on trailing underscore`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ToolNameHumanizer.humanize("get_steps_")
+        }
+    }
+
+    @Test
+    fun `humanize throws on punctuation`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ToolNameHumanizer.humanize("get.steps")
+        }
+    }
+
+    @Test
+    fun `humanize throws on whitespace`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ToolNameHumanizer.humanize("get steps")
+        }
+    }
+}

--- a/integrations/src/test/java/com/rousecontext/integrations/AllToolsHumanizerValidationTest.kt
+++ b/integrations/src/test/java/com/rousecontext/integrations/AllToolsHumanizerValidationTest.kt
@@ -1,0 +1,107 @@
+package com.rousecontext.integrations
+
+import android.content.Context
+import android.service.notification.StatusBarNotification
+import androidx.test.core.app.ApplicationProvider
+import com.rousecontext.integrations.health.FakeHealthConnectRepository
+import com.rousecontext.integrations.health.HealthConnectMcpServer
+import com.rousecontext.integrations.notifications.NotificationMcpProvider
+import com.rousecontext.integrations.outreach.OutreachMcpProvider
+import com.rousecontext.integrations.usage.UsageMcpProvider
+import com.rousecontext.mcp.core.McpServerProvider
+import com.rousecontext.mcp.core.ToolNameHumanizer
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * All-tools validation test for [ToolNameHumanizer].
+ *
+ * Dynamically enumerates every tool registered by every [McpServerProvider]
+ * in this module, calls [ToolNameHumanizer.humanize] on each name, and
+ * asserts none of them throw. This is the guard rail that keeps all live
+ * tool names inside the snake_case contract: if a new tool lands with
+ * CamelCase, punctuation, or any other format the humanizer rejects, this
+ * test fails and the author must either fix the tool name or extend the
+ * humanizer's grammar before the notification copy work in #347 can rely
+ * on it.
+ *
+ * Tool names are discovered by wiring each provider up against a recording
+ * [Server] mock and capturing `addTool(name, ...)` calls -- no hand
+ * enumeration, so new tools are picked up automatically.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AllToolsHumanizerValidationTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `every registered tool name is accepted by the humanizer`() {
+        val providers: List<McpServerProvider> = listOf(
+            NotificationMcpProvider(
+                dao = mockk(relaxed = true),
+                activeNotificationSource = { emptyArray<StatusBarNotification>() },
+                actionPerformer = { _, _ -> false },
+                notificationDismisser = { _ -> false }
+            ),
+            // dndEnabled = true so the DND tools are registered and validated.
+            OutreachMcpProvider(context = context, dndEnabled = true),
+            UsageMcpProvider(context = context),
+            HealthConnectMcpServer(repository = FakeHealthConnectRepository())
+        )
+
+        val toolNames = providers.flatMap { provider ->
+            val recorder = recordingServer()
+            provider.register(recorder.server)
+            recorder.capturedToolNames
+        }
+
+        // Sanity: each provider should contribute at least one tool; an empty
+        // registry would cause the loop below to vacuously pass.
+        assertTrue(
+            "No tool names captured -- provider wiring or recording is broken",
+            toolNames.isNotEmpty()
+        )
+
+        val failures = toolNames.mapNotNull { name ->
+            try {
+                ToolNameHumanizer.humanize(name)
+                null
+            } catch (iae: IllegalArgumentException) {
+                name to iae.message
+            }
+        }
+
+        assertTrue(
+            "Tool names rejected by ToolNameHumanizer: " +
+                failures.joinToString { "'${it.first}' (${it.second})" },
+            failures.isEmpty()
+        )
+    }
+
+    // ---------- helpers ----------
+
+    private class RecordingServer(val server: Server, val capturedToolNames: MutableList<String>)
+
+    private fun recordingServer(): RecordingServer {
+        val server = mockk<Server>(relaxed = true)
+        val names = mutableListOf<String>()
+        val nameSlot = slot<String>()
+        every {
+            server.addTool(
+                name = capture(nameSlot),
+                description = any(),
+                inputSchema = any(),
+                handler = any()
+            )
+        } answers {
+            names.add(nameSlot.captured)
+        }
+        return RecordingServer(server, names)
+    }
+}


### PR DESCRIPTION
Closes #346.

## Summary

- New `ToolNameHumanizer` object in `:core:mcp` that converts snake_case tool names to human-readable titles for display in notifications (`get_steps` -> `Get Steps`, `set_dnd_state` -> `Set DND State`). Acronym set starts with `dnd`; extend as new tools with abbreviations land.
- Non-snake_case input throws `IllegalArgumentException` - fail-loud contract so a malformed tool name surfaces as a test failure rather than garbled UI copy.
- `:integrations` validation test dynamically enumerates every tool registered by every `McpServerProvider` (notifications, outreach with DND enabled, usage, health) by recording `Server.addTool` calls and runs each captured name through the humanizer. A new tool landing with a non-snake_case name will fail this test.
- This PR does not wire the humanizer into notification copy - that's #347.

## Test plan

- [x] `:core:mcp:jvmTest` - unit table tests for success cases and every rejection path (empty, camelCase, kebab-case, double/leading/trailing underscore, punctuation, whitespace).
- [x] `:integrations:testDebugUnitTest` - all-tools validation test exercises every currently registered tool name.
- [x] `:core:mcp:ktlintCheck` and `:integrations:ktlintCheck` pass.
- [x] Root `detekt` fails only on pre-existing issues (verified against `main` with new files stashed).

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>