### PR TITLE
Fix #331: Persist per-tool-call notification ID counter + drop group stacking

### DIFF
--- a/app/src/main/java/com/rousecontext/app/di/AppModule.kt
+++ b/app/src/main/java/com/rousecontext/app/di/AppModule.kt
@@ -68,12 +68,14 @@ import com.rousecontext.notifications.AndroidSecurityCheckNotifier
 import com.rousecontext.notifications.AuthRequestNotifier
 import com.rousecontext.notifications.FieldEncryptor
 import com.rousecontext.notifications.LaunchRequestNotifier
+import com.rousecontext.notifications.NotificationIdCounter
 import com.rousecontext.notifications.PerToolCallNotifier
 import com.rousecontext.notifications.SecurityCheckNotifier
 import com.rousecontext.notifications.SessionSummaryNotifier
 import com.rousecontext.notifications.audit.AuditDatabase
 import com.rousecontext.notifications.audit.PerCallObserver
 import com.rousecontext.notifications.audit.RoomAuditListener
+import com.rousecontext.notifications.create
 import com.rousecontext.tunnel.CertProvisioningFlow
 import com.rousecontext.tunnel.CertRenewalFlow
 import com.rousecontext.tunnel.CertificateStore
@@ -354,6 +356,9 @@ val appModule = module {
         )
     }
 
+    // --- Per-tool-call notification id counter (persisted — see issue #331) ---
+    single { NotificationIdCounter.create(androidContext()) }
+
     // --- Per-tool-call notifier (EACH_USAGE mode) ---
     single {
         val integrations: List<McpIntegration> = get()
@@ -361,7 +366,8 @@ val appModule = module {
             context = androidContext(),
             settingsProvider = get(),
             integrationDisplayNames = integrations.associate { it.id to it.displayName },
-            activityClass = MainActivity::class.java
+            activityClass = MainActivity::class.java,
+            idCounter = get()
         )
     } bind PerCallObserver::class
 

--- a/notifications/build.gradle.kts
+++ b/notifications/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(project(":api"))
 
     implementation(libs.androidx.core.ktx)
+    implementation(libs.datastore.preferences)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.room.runtime)

--- a/notifications/src/main/java/com/rousecontext/notifications/NotificationIdCounter.kt
+++ b/notifications/src/main/java/com/rousecontext/notifications/NotificationIdCounter.kt
@@ -1,0 +1,73 @@
+package com.rousecontext.notifications
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import kotlinx.coroutines.flow.first
+
+/**
+ * Monotonic notification id allocator persisted in DataStore.
+ *
+ * Fixes issue #331: the previous in-memory [java.util.concurrent.atomic.AtomicInteger]
+ * counter reset to 0 on every process cold start. Because this app is woken
+ * from FCM on demand and frequently torn down between tool calls, two
+ * notifications posted in separate processes both landed on id
+ * [PerToolCallNotifier.BASE_ID] + 0 and the second overwrote the first.
+ *
+ * Each call to [next] reads the current value, writes back value+1 (wrapping
+ * at [WRAP_AT]), and returns the read value. DataStore's [DataStore.edit]
+ * guarantees atomicity across concurrent callers within a process, and the
+ * write is durable on disk so subsequent processes continue the sequence.
+ *
+ * Wraparound is bounded at [WRAP_AT] (10,000) so ids stay within the
+ * [PerToolCallNotifier.BASE_ID]..[PerToolCallNotifier.BASE_ID] + 9999 window
+ * and never collide with other modules' notification id allocations. In
+ * practice 10,000 per-call notifications between wraparounds is far more than
+ * any realistic retention horizon — by the time we wrap, the earliest ids have
+ * long since been dismissed or auto-cancelled.
+ */
+class NotificationIdCounter(private val dataStore: DataStore<Preferences>) {
+
+    /**
+     * Atomically read, increment, and return the next counter value.
+     *
+     * Returns the value BEFORE the increment, so a fresh counter returns 0
+     * on the first call.
+     */
+    suspend fun next(): Int {
+        var captured = 0
+        dataStore.edit { prefs ->
+            val current = prefs[COUNTER_KEY] ?: 0
+            captured = current
+            prefs[COUNTER_KEY] = (current + 1) % WRAP_AT
+        }
+        return captured
+    }
+
+    /**
+     * Test-only: force the next [next] call to return [value]. Useful for
+     * exercising the wraparound path without invoking [next] 10,000 times.
+     */
+    internal suspend fun seedForTest(value: Int) {
+        dataStore.edit { prefs ->
+            prefs[COUNTER_KEY] = value
+        }
+    }
+
+    /**
+     * Read the current counter value without advancing it. Intended for
+     * debugging/diagnostics only; production code should call [next].
+     */
+    suspend fun peek(): Int = dataStore.data.first()[COUNTER_KEY] ?: 0
+
+    companion object {
+        /**
+         * Id space per-call notifications are confined to. Matches the
+         * range allocation in [PerToolCallNotifier].
+         */
+        const val WRAP_AT: Int = 10_000
+
+        private val COUNTER_KEY = intPreferencesKey("per_tool_call_counter")
+    }
+}

--- a/notifications/src/main/java/com/rousecontext/notifications/NotificationIdCounterStore.kt
+++ b/notifications/src/main/java/com/rousecontext/notifications/NotificationIdCounterStore.kt
@@ -1,0 +1,23 @@
+package com.rousecontext.notifications
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+/**
+ * Context-scoped DataStore that backs the per-tool-call notification id
+ * counter. Split into its own file so the [preferencesDataStore] delegate's
+ * singleton-per-name contract is obvious and the DataStore file name
+ * (`per_tool_call_counter`) is easy to locate.
+ */
+private val Context.perToolCallCounterDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "per_tool_call_counter")
+
+/**
+ * Production factory for [NotificationIdCounter]. Koin calls this to obtain
+ * the app-wide counter bound to the DataStore file named
+ * `per_tool_call_counter.preferences_pb` under the app's files dir.
+ */
+fun NotificationIdCounter.Companion.create(context: Context): NotificationIdCounter =
+    NotificationIdCounter(context.perToolCallCounterDataStore)

--- a/notifications/src/main/java/com/rousecontext/notifications/PerToolCallNotifier.kt
+++ b/notifications/src/main/java/com/rousecontext/notifications/PerToolCallNotifier.kt
@@ -12,7 +12,6 @@ import com.rousecontext.api.R as ApiR
 import com.rousecontext.mcp.core.ToolCallEvent
 import com.rousecontext.notifications.audit.PerCallObserver
 import java.util.Date
-import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Posts a low-priority notification for each MCP tool call while the user has
@@ -34,8 +33,14 @@ import java.util.concurrent.atomic.AtomicInteger
  *
  * ## Grouping
  *
- * All per-call notifications share [GROUP_KEY] so Android collapses them into
- * a single stack in the shade when more than one accumulates.
+ * Per-call notifications intentionally do NOT set a group key. Android
+ * visually collapses same-group children when there is no explicit group
+ * summary notification, which hid most per-call notifications from the user
+ * (issue #331). Dropping the group means each call appears as its own row.
+ *
+ * Android will still visually cluster all notifications from this app under a
+ * single app header in the shade; that is Android's default behaviour for any
+ * process that posts more than one notification and cannot be disabled.
  *
  * ## Tap target
  *
@@ -49,15 +54,16 @@ import java.util.concurrent.atomic.AtomicInteger
  * @param integrationDisplayNames Map from integration id -> human-readable name;
  *   falls back to the raw id when absent.
  * @param activityClass Activity to launch when the notification is tapped.
+ * @param idCounter Persistent counter used to allocate unique notification ids
+ *   across process cold starts. See [NotificationIdCounter] and issue #331.
  */
 class PerToolCallNotifier(
     private val context: Context,
     private val settingsProvider: NotificationSettingsProvider,
     private val integrationDisplayNames: Map<String, String>,
-    private val activityClass: Class<*>
+    private val activityClass: Class<*>,
+    private val idCounter: NotificationIdCounter
 ) : PerCallObserver {
-
-    private val idCounter = AtomicInteger(0)
 
     override suspend fun onToolCallRecorded(event: ToolCallEvent) {
         notifyIfEnabled(event)
@@ -70,7 +76,7 @@ class PerToolCallNotifier(
     suspend fun notifyIfEnabled(event: ToolCallEvent) {
         if (settingsProvider.settings().postSessionMode != PostSessionMode.EACH_USAGE) return
 
-        val notificationId = BASE_ID + idCounter.getAndIncrement()
+        val notificationId = BASE_ID + idCounter.next()
         val displayName = integrationDisplayNames[event.providerId] ?: event.providerId
         val timeText = DateFormat.getTimeFormat(context).format(Date(event.timestamp))
 
@@ -97,7 +103,6 @@ class PerToolCallNotifier(
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setAutoCancel(true)
             .setOnlyAlertOnce(true)
-            .setGroup(GROUP_KEY)
             .setContentIntent(contentIntent)
             .build()
 
@@ -108,8 +113,5 @@ class PerToolCallNotifier(
     companion object {
         /** Base notification id offset for per-call notifications. */
         const val BASE_ID = 7000
-
-        /** Group key used to stack per-call notifications in the shade. */
-        const val GROUP_KEY = "rouse_tool_calls_per_usage"
     }
 }

--- a/notifications/src/test/java/com/rousecontext/notifications/NotificationIdCounterTest.kt
+++ b/notifications/src/test/java/com/rousecontext/notifications/NotificationIdCounterTest.kt
@@ -1,0 +1,115 @@
+package com.rousecontext.notifications
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Unit tests for [NotificationIdCounter].
+ *
+ * Verifies that the counter is persisted across instances backed by the same
+ * DataStore file, so cold-start process recreation does not reset the sequence
+ * and cause notification id collisions (see issue #331).
+ */
+class NotificationIdCounterTest {
+
+    @get:Rule
+    val tmpDir = TemporaryFolder()
+
+    private val scopes = mutableListOf<CoroutineScope>()
+
+    @After
+    fun tearDown() {
+        scopes.forEach { it.cancel() }
+        scopes.clear()
+    }
+
+    @Test
+    fun `fresh counter returns 0 on first call`() = runBlocking {
+        val counter = NotificationIdCounter(makeStore())
+        assertEquals(0, counter.next())
+    }
+
+    @Test
+    fun `successive calls return monotonic values`() = runBlocking {
+        val counter = NotificationIdCounter(makeStore())
+        assertEquals(0, counter.next())
+        assertEquals(1, counter.next())
+        assertEquals(2, counter.next())
+        assertEquals(3, counter.next())
+    }
+
+    @Test
+    fun `a second instance backed by the same file continues the sequence`() = runBlocking {
+        val firstScope = newScope()
+        val first = NotificationIdCounter(storeIn(firstScope))
+        assertEquals(0, first.next())
+        assertEquals(1, first.next())
+        assertEquals(2, first.next())
+        // Simulate process death: DataStore requires only one active instance
+        // per file, so we must release the first before opening a second
+        // pointed at the same path.
+        firstScope.cancel()
+
+        val secondScope = newScope()
+        val second = NotificationIdCounter(storeIn(secondScope))
+        assertEquals(3, second.next())
+        assertEquals(4, second.next())
+    }
+
+    @Test
+    fun `counter wraps back to 0 at WRAP_AT boundary`() = runBlocking {
+        // Seed the store at just below the wrap boundary so we don't need to
+        // call next() 10k times.
+        val store = makeStore()
+        val counter = NotificationIdCounter(store)
+        counter.seedForTest(NotificationIdCounter.WRAP_AT - 2)
+
+        assertEquals(NotificationIdCounter.WRAP_AT - 2, counter.next())
+        assertEquals(NotificationIdCounter.WRAP_AT - 1, counter.next())
+        assertEquals(0, counter.next())
+        assertEquals(1, counter.next())
+    }
+
+    @Test
+    fun `distinct counter files do not share state`() = runBlocking {
+        val storeA = makeStore(name = "a.preferences_pb")
+        val storeB = makeStore(name = "b.preferences_pb")
+        val a = NotificationIdCounter(storeA)
+        val b = NotificationIdCounter(storeB)
+
+        assertEquals(0, a.next())
+        assertEquals(1, a.next())
+        // b is independent.
+        assertEquals(0, b.next())
+        assertNotEquals(a.next(), b.next())
+    }
+
+    private fun newScope(): CoroutineScope {
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        scopes += scope
+        return scope
+    }
+
+    private fun makeStore(name: String = "counter.preferences_pb"): DataStore<Preferences> =
+        storeIn(newScope(), name)
+
+    private fun storeIn(
+        scope: CoroutineScope,
+        name: String = "counter.preferences_pb"
+    ): DataStore<Preferences> = PreferenceDataStoreFactory.create(scope = scope) {
+        File(tmpDir.root, name)
+    }
+}

--- a/notifications/src/test/java/com/rousecontext/notifications/PerToolCallNotifierTest.kt
+++ b/notifications/src/test/java/com/rousecontext/notifications/PerToolCallNotifierTest.kt
@@ -2,6 +2,9 @@ package com.rousecontext.notifications
 
 import android.app.NotificationManager
 import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
 import androidx.test.core.app.ApplicationProvider
 import com.rousecontext.api.NotificationSettings
 import com.rousecontext.api.NotificationSettingsProvider
@@ -9,14 +12,23 @@ import com.rousecontext.api.PostSessionMode
 import com.rousecontext.mcp.core.ToolCallEvent
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.runBlocking
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows
@@ -33,6 +45,12 @@ class PerToolCallNotifierTest {
     private lateinit var manager: NotificationManager
     private lateinit var settings: FakeNotificationSettingsProvider
     private lateinit var notifier: PerToolCallNotifier
+    private lateinit var scopeJob: Job
+    private lateinit var scope: CoroutineScope
+    private lateinit var counterStore: DataStore<Preferences>
+
+    @get:Rule
+    val tmpDir = TemporaryFolder()
 
     class DummyActivity : android.app.Activity()
 
@@ -42,6 +60,11 @@ class PerToolCallNotifierTest {
         manager = context.getSystemService(NotificationManager::class.java)
         NotificationChannels.createAll(context)
         settings = FakeNotificationSettingsProvider(PostSessionMode.EACH_USAGE)
+        scopeJob = SupervisorJob()
+        scope = CoroutineScope(Dispatchers.IO + scopeJob)
+        counterStore = PreferenceDataStoreFactory.create(scope = scope) {
+            File(tmpDir.root, "counter.preferences_pb")
+        }
         notifier = PerToolCallNotifier(
             context = context,
             settingsProvider = settings,
@@ -49,8 +72,14 @@ class PerToolCallNotifierTest {
                 "health" to "Health Connect",
                 "usage" to "App Usage"
             ),
-            activityClass = DummyActivity::class.java
+            activityClass = DummyActivity::class.java,
+            idCounter = NotificationIdCounter(counterStore)
         )
+    }
+
+    @After
+    fun tearDown() {
+        scope.cancel()
     }
 
     @Test
@@ -104,7 +133,7 @@ class PerToolCallNotifierTest {
     }
 
     @Test
-    fun `Multiple calls post distinct grouped notifications`() {
+    fun `Multiple calls post distinct ungrouped notifications`() {
         runBlocking { notifier.notifyIfEnabled(event(provider = "health", toolName = "get_steps")) }
         runBlocking {
             notifier.notifyIfEnabled(event(provider = "usage", toolName = "get_app_usage"))
@@ -117,12 +146,96 @@ class PerToolCallNotifierTest {
             3,
             shadow.allNotifications.size
         )
+        // Per issue #331: no group key — Android collapses grouped children when
+        // there's no explicit summary notification, so dropping the group makes
+        // each per-call notification stand alone in the shade.
         shadow.allNotifications.forEach { n ->
-            assertEquals(
-                PerToolCallNotifier.GROUP_KEY,
-                n.group
-            )
+            assertNull("Per-call notification should not set a group", n.group)
         }
+    }
+
+    @Test
+    fun `Successive calls within a single process use distinct notification ids`() {
+        val shadow = Shadows.shadowOf(manager)
+        runBlocking {
+            notifier.notifyIfEnabled(event(provider = "health", toolName = "get_steps"))
+            notifier.notifyIfEnabled(event(provider = "health", toolName = "get_hr"))
+        }
+
+        val ids = shadow.allNotifications.map {
+            // Robolectric exposes the posted id via the notification id field
+            // on its recorded entries — grab it via the shadow manager.
+            it
+        }
+        // With only 2 notifications and distinct ids, shadow manager retains
+        // both entries. Assert via count:
+        assertEquals(2, ids.size)
+    }
+
+    @Test
+    fun `Cold start with same backing store keeps notification ids distinct`() {
+        // First process: post two notifications via the initial notifier.
+        runBlocking {
+            notifier.notifyIfEnabled(event(provider = "health", toolName = "get_steps"))
+            notifier.notifyIfEnabled(event(provider = "health", toolName = "get_hr"))
+        }
+
+        // Simulate cold start: release the first DataStore (only one active
+        // instance per file is permitted), then open a fresh one from the
+        // same backing file as a new process would.
+        scope.cancel()
+        val coldStartScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            val reopenedStore = PreferenceDataStoreFactory.create(scope = coldStartScope) {
+                File(tmpDir.root, "counter.preferences_pb")
+            }
+            val reopenedNotifier = PerToolCallNotifier(
+                context = context,
+                settingsProvider = settings,
+                integrationDisplayNames = mapOf("health" to "Health Connect"),
+                activityClass = DummyActivity::class.java,
+                idCounter = NotificationIdCounter(reopenedStore)
+            )
+
+            runBlocking {
+                reopenedNotifier.notifyIfEnabled(
+                    event(provider = "health", toolName = "get_sleep")
+                )
+            }
+
+            val shadow = Shadows.shadowOf(manager)
+            assertEquals(
+                "Post-cold-start notification must not overwrite a previous id",
+                3,
+                shadow.allNotifications.size
+            )
+            val titles = shadow.allNotifications.mapNotNull {
+                it.extras.getCharSequence("android.title")?.toString()
+            }
+            assertTrue(
+                "Expected pre-cold-start entries kept",
+                titles.any { it.contains("get_steps") }
+            )
+            assertTrue(
+                "Expected pre-cold-start entries kept",
+                titles.any { it.contains("get_hr") }
+            )
+            assertTrue(
+                "Expected post-cold-start entry present",
+                titles.any { it.contains("get_sleep") }
+            )
+        } finally {
+            coldStartScope.cancel()
+        }
+    }
+
+    @Test
+    fun `Notification has no group key`() {
+        runBlocking { notifier.notifyIfEnabled(event(provider = "health", toolName = "get_steps")) }
+
+        val shadow = Shadows.shadowOf(manager)
+        val notification = shadow.allNotifications.first()
+        assertNull("Per-call notification should not set a group", notification.group)
     }
 
     @Test

--- a/notifications/src/test/java/com/rousecontext/notifications/preview/NotificationScreenshotTest.kt
+++ b/notifications/src/test/java/com/rousecontext/notifications/preview/NotificationScreenshotTest.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onRoot
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.test.core.app.ApplicationProvider
 import com.github.takahirom.roborazzi.captureRoboImage
 import com.rousecontext.api.NotificationSettings
@@ -17,6 +18,7 @@ import com.rousecontext.notifications.AuthRequestNotifier
 import com.rousecontext.notifications.FgsLimitNotifier
 import com.rousecontext.notifications.ForegroundNotifier
 import com.rousecontext.notifications.LaunchRequestNotifier
+import com.rousecontext.notifications.NotificationIdCounter
 import com.rousecontext.notifications.PerToolCallNotifier
 import com.rousecontext.notifications.SecurityCheckNotifier
 import com.rousecontext.notifications.SessionSummaryNotifier
@@ -26,6 +28,10 @@ import com.rousecontext.tunnel.TunnelState
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import java.io.File
+import java.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -273,7 +279,8 @@ class NotificationScreenshotTest {
             context = context,
             settingsProvider = FakeSettingsProvider(PostSessionMode.EACH_USAGE),
             integrationDisplayNames = mapOf("health-connect" to "Health Connect"),
-            activityClass = DummyActivity::class.java
+            activityClass = DummyActivity::class.java,
+            idCounter = freshIdCounter()
         )
         notifier.onToolCallRecorded(sampleToolCallEvent())
         lastPosted()
@@ -300,7 +307,8 @@ class NotificationScreenshotTest {
             context = context,
             settingsProvider = FakeSettingsProvider(PostSessionMode.EACH_USAGE),
             integrationDisplayNames = mapOf("health-connect" to "Health Connect"),
-            activityClass = DummyActivity::class.java
+            activityClass = DummyActivity::class.java,
+            idCounter = freshIdCounter()
         )
         notifier.onToolCallRecorded(
             sampleToolCallEvent().copy(
@@ -334,7 +342,8 @@ class NotificationScreenshotTest {
                 "health-connect" to "Health Connect",
                 "notifications" to "Notifications"
             ),
-            activityClass = DummyActivity::class.java
+            activityClass = DummyActivity::class.java,
+            idCounter = freshIdCounter()
         )
         notifier.onToolCallRecorded(
             sampleToolCallEvent().copy(
@@ -343,6 +352,18 @@ class NotificationScreenshotTest {
             )
         )
         lastPosted()
+    }
+
+    /**
+     * Build a fresh, test-local [NotificationIdCounter]. Each screenshot case
+     * uses its own counter so they don't leak state across tests; the counter's
+     * backing DataStore lives in a tmp file keyed on a random UUID.
+     */
+    private fun freshIdCounter(): NotificationIdCounter {
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        val file = File(context.cacheDir, "per_tool_counter_${UUID.randomUUID()}.preferences_pb")
+        val store = PreferenceDataStoreFactory.create(scope = scope) { file }
+        return NotificationIdCounter(store)
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Closes #331.

Two independent bugs were collapsing/overwriting per-tool-call notifications in EACH_USAGE mode:

- **Notification id reset on cold start.** The in-memory `AtomicInteger` counter restarted at 0 on every FCM-driven process creation, so process B's first per-call notification overwrote process A's id-7000 entry. Replaced with `NotificationIdCounter`, a DataStore-backed monotonic counter that wraps at 10,000 to stay inside the reserved id window.
- **Group stacking without a summary.** `setGroup(GROUP_KEY)` with no group-summary notification made Android hide all but the most recent entry. Dropped `setGroup` so each per-call notification stands alone, matching the documented EACH_USAGE semantics.

Android still clusters same-app notifications under a single shade header — that's OS-level behaviour and out of scope (noted in the KDoc so future readers don't chase it).

## Test plan

- [x] `NotificationIdCounterTest`: fresh start returns 0, monotonic across calls, survives a simulated cold-start (new instance + scope, same DataStore file), wraps at `WRAP_AT`, distinct files don't share state.
- [x] `PerToolCallNotifierTest`: successive calls get distinct ids, a simulated cold-start (cancel first scope, open second DataStore on the same file) keeps all three notifications in the shade, posted `Notification.group` is `null`.
- [x] `:notifications:verifyRoborazziDebug` — screenshot goldens unchanged (removing the group key doesn't affect rendered output).
- [x] `:app:testDebugUnitTest` — existing integration tests (`PerCallNotifierModeTest`, `RuntimeNotificationModeSwitchTest`, `SuppressedModeTest`) still pass with the new DI-wired counter.
- [x] `:work:testDebugUnitTest` — unaffected downstream module builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)