### PR TITLE
Fix #344: clientLabel schema + session-level capture foundation

### DIFF
--- a/app/src/main/java/com/rousecontext/app/token/RoomTokenStore.kt
+++ b/app/src/main/java/com/rousecontext/app/token/RoomTokenStore.kt
@@ -45,6 +45,16 @@ class RoomTokenStore(private val dao: TokenDao) : TokenStore {
         return entity.clientId
     }
 
+    override fun resolveClientLabel(integrationId: String, token: String): String? {
+        val hash = hashToken(token)
+        val entity = dao.findByHash(integrationId, hash) ?: return null
+        // TokenEntity.label is set to `clientName ?: clientId` at insert time,
+        // so this always returns a stable non-empty identifier for valid
+        // tokens (see issue #344). Audit rows need this to attribute every
+        // tool call to a client even when DCR did not supply a client_name.
+        return entity.label
+    }
+
     override fun createTokenPair(
         integrationId: String,
         clientId: String,

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/AuditListener.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/AuditListener.kt
@@ -39,6 +39,16 @@ interface AuditListener {
     suspend fun onRequest(event: McpRequestEvent) {}
 }
 
+/**
+ * Audit event emitted for a single `tools/call` completion.
+ *
+ * @property clientLabel Human-readable label for the AI client that invoked
+ *   the tool, captured once per MCP session from the OAuth Bearer token
+ *   (see issue #344). Defaults to the literal `"Unknown"` for unauthenticated
+ *   sessions or callers that have not yet wired label capture. The
+ *   `Unknown (#N)` monotonic numbering for anonymous clients is tracked
+ *   separately in issue #345.
+ */
 data class ToolCallEvent(
     val sessionId: String,
     val providerId: String,
@@ -46,8 +56,17 @@ data class ToolCallEvent(
     val toolName: String,
     val arguments: Map<String, JsonElement>,
     val result: CallToolResult,
-    val durationMs: Long
+    val durationMs: Long,
+    val clientLabel: String = UNKNOWN_CLIENT_LABEL
 )
+
+/**
+ * Fallback client label used when an MCP session has no OAuth token (which
+ * should not happen for tool calls, but is handled defensively) or a
+ * pre-existing caller has not yet wired label capture. Issue #345 replaces
+ * this literal with monotonic `Unknown (#N)` numbering.
+ */
+const val UNKNOWN_CLIENT_LABEL: String = "Unknown"
 
 /**
  * Audit event emitted when an OAuth token is granted to a client.

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/InMemoryTokenStore.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/InMemoryTokenStore.kt
@@ -80,6 +80,14 @@ class InMemoryTokenStore(private val clock: Clock = SystemClock) : TokenStore {
         }
     }
 
+    override fun resolveClientLabel(integrationId: String, token: String): String? {
+        synchronized(this) {
+            val stored = tokens.find { it.token == token && !it.revoked } ?: return null
+            if (stored.integrationId != integrationId) return null
+            return stored.clientName ?: stored.clientId
+        }
+    }
+
     override fun createTokenPair(
         integrationId: String,
         clientId: String,

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/McpRouting.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/McpRouting.kt
@@ -49,13 +49,16 @@ private val mcpJson = Json {
 /**
  * Per-session MCP server state: the SDK Server, its HTTP transport, the
  * integration name, the OAuth client id that initialized the session (see
- * issue #206), and a timestamp used for idle-timeout eviction.
+ * issue #206), a cached human-readable client label captured from the
+ * Bearer token at session creation (see issue #344), and a timestamp used
+ * for idle-timeout eviction.
  */
 private data class SessionEntry(
     val server: Server,
     val transport: HttpTransport,
     val integration: String,
     val clientId: String,
+    val clientLabel: String,
     @Volatile var lastAccessedAt: Long
 )
 
@@ -698,6 +701,16 @@ internal class McpRoutes(
         val sessionId: String
         val session: SessionEntry
 
+        // Capture the client label once at session creation so every
+        // subsequent tool-call audit event in this session carries the same
+        // stable, human-readable identifier (issue #344). Falls back to the
+        // literal "Unknown" if the token store has no label for this token,
+        // which in practice shouldn't happen for authenticated tool calls
+        // but is handled defensively here. Issue #345 replaces the literal
+        // with monotonic `Unknown (#N)` numbering.
+        val resolvedClientLabel = tokenStore.resolveClientLabel(ri, token)
+            ?: UNKNOWN_CLIENT_LABEL
+
         if (method == "initialize" && incomingSessionId == null) {
             // Create a new session
             val newSessionId = UUID.randomUUID().toString()
@@ -708,6 +721,7 @@ internal class McpRoutes(
                 transport = newTransport,
                 integration = ri,
                 clientId = callerClientId,
+                clientLabel = resolvedClientLabel,
                 lastAccessedAt = clock.currentTimeMillis()
             )
             val evicted = sessionsMutex.withLock {
@@ -767,6 +781,7 @@ internal class McpRoutes(
                     parsed,
                     responseJson,
                     ri,
+                    session.clientLabel,
                     startMs,
                     clock,
                     log
@@ -1044,6 +1059,7 @@ private suspend fun emitAuditEvent(
     request: JsonObject,
     responseJson: String,
     integration: String,
+    clientLabel: String,
     startMs: Long,
     clock: Clock,
     log: (LogLevel, String) -> Unit
@@ -1073,6 +1089,7 @@ private suspend fun emitAuditEvent(
             request,
             responseJson,
             integration,
+            clientLabel,
             startMs,
             durationMs,
             log
@@ -1116,6 +1133,7 @@ private suspend fun emitToolCallEvent(
     request: JsonObject,
     responseJson: String,
     integration: String,
+    clientLabel: String,
     startMs: Long,
     durationMs: Long,
     log: (LogLevel, String) -> Unit
@@ -1137,7 +1155,8 @@ private suspend fun emitToolCallEvent(
                 toolName = toolName,
                 arguments = arguments,
                 result = result,
-                durationMs = durationMs
+                durationMs = durationMs,
+                clientLabel = clientLabel
             )
         )
     } catch (e: Exception) {

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/TokenStore.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/TokenStore.kt
@@ -36,6 +36,20 @@ interface TokenStore {
     fun resolveClientId(integrationId: String, token: String): String?
 
     /**
+     * Resolves the audit-facing label for [token] within [integrationId]:
+     * the DCR-supplied `client_name` when present, otherwise the
+     * DCR-assigned `client_id`. Returns null if the token is invalid /
+     * unknown / revoked / scoped to a different integration.
+     *
+     * Unlike [resolveClientName], this never returns null when the token is
+     * valid — callers that persist audit rows need a stable non-empty
+     * identifier per tool call (see issue #344). The `Unknown (#N)`
+     * monotonic fallback for anonymous sessions is follow-up work in
+     * issue #345.
+     */
+    fun resolveClientLabel(integrationId: String, token: String): String?
+
+    /**
      * Creates a new access token + refresh token pair for [integrationId], associated
      * with the given [clientId]. The optional [clientName] is a human-readable label
      * for display in the authorized clients UI.

--- a/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/core/ClientLabelCaptureTest.kt
+++ b/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/core/ClientLabelCaptureTest.kt
@@ -1,0 +1,191 @@
+package com.rousecontext.mcp.core
+
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for the `clientLabel` propagation on every [ToolCallEvent]
+ * emitted from an MCP session (issue #344).
+ *
+ * The label is captured once per session from the OAuth Bearer token (via
+ * [TokenStore.resolveClientLabel]) and every tool call emitted within the
+ * session carries that same cached label. Sessions without a resolvable
+ * label fall back to the literal [UNKNOWN_CLIENT_LABEL] -- the
+ * `Unknown (#N)` monotonic numbering is follow-up work in issue #345.
+ */
+class ClientLabelCaptureTest {
+
+    private class EchoProvider : McpServerProvider {
+        override val id = "health"
+        override val displayName = "Health Connect"
+
+        override fun register(server: Server) {
+            server.addTool(
+                name = "echo",
+                description = "Echoes the provided message",
+                inputSchema = ToolSchema(
+                    properties = buildJsonObject {
+                        put(
+                            "message",
+                            buildJsonObject {
+                                put("type", JsonPrimitive("string"))
+                            }
+                        )
+                    },
+                    required = listOf("message")
+                )
+            ) { _ ->
+                CallToolResult(content = listOf(TextContent("ok")))
+            }
+        }
+    }
+
+    private class RecordingAuditListener : AuditListener {
+        val toolCalls: MutableList<ToolCallEvent> = CopyOnWriteArrayList()
+
+        override suspend fun onToolCall(event: ToolCallEvent) {
+            toolCalls += event
+        }
+    }
+
+    private fun mcpJsonRpc(method: String, params: String? = null, id: Int = 1): String {
+        val paramsStr = if (params != null) ""","params":$params""" else ""
+        return """{"jsonrpc":"2.0","method":"$method"$paramsStr,"id":$id}"""
+    }
+
+    private fun initJson(): String = mcpJsonRpc(
+        "initialize",
+        """{"protocolVersion":"2025-03-26","capabilities":{}""" +
+            ""","clientInfo":{"name":"test","version":"1.0"}}"""
+    )
+
+    private fun toolCallJson(id: Int, message: String): String = mcpJsonRpc(
+        "tools/call",
+        """{"name":"echo","arguments":{"message":"$message"}}""",
+        id = id
+    )
+
+    @Test
+    fun `clientLabel is populated from TokenStore label on every tool call`() = testApplication {
+        val registry = InMemoryProviderRegistry().apply {
+            register("health", EchoProvider())
+            setEnabled("health", true)
+        }
+        val tokenStore = InMemoryTokenStore()
+        val token = tokenStore
+            .createTokenPair("health", clientId = "client-42", clientName = "Claude Desktop")
+            .accessToken
+        val audit = RecordingAuditListener()
+
+        application {
+            configureMcpRouting(
+                registry = registry,
+                tokenStore = tokenStore,
+                deviceCodeManager = DeviceCodeManager(tokenStore = tokenStore),
+                hostname = "test.rousecontext.com",
+                integration = "health",
+                auditListener = audit
+            )
+        }
+
+        // initialize -> sessionId
+        val initResp = client.post("/mcp") {
+            header("Authorization", "Bearer $token")
+            contentType(ContentType.Application.Json)
+            setBody(initJson())
+        }
+        assertEquals(HttpStatusCode.OK, initResp.status)
+        val sessionId = initResp.headers["Mcp-Session-Id"]
+        assertNotNull(sessionId)
+
+        // Three tool calls within the same session
+        repeat(3) { idx ->
+            val r = client.post("/mcp") {
+                header("Authorization", "Bearer $token")
+                header("Mcp-Session-Id", sessionId!!)
+                contentType(ContentType.Application.Json)
+                setBody(toolCallJson(id = idx + 2, message = "m$idx"))
+            }
+            assertEquals(HttpStatusCode.OK, r.status)
+            // drain
+            Json.parseToJsonElement(r.bodyAsText()).jsonObject
+        }
+
+        assertEquals(3, audit.toolCalls.size)
+        assertTrue(
+            "All three tool calls should carry the cached clientLabel",
+            audit.toolCalls.all { it.clientLabel == "Claude Desktop" }
+        )
+    }
+
+    @Test
+    fun `clientLabel falls back to client id label when clientName unset`() = testApplication {
+        val registry = InMemoryProviderRegistry().apply {
+            register("health", EchoProvider())
+            setEnabled("health", true)
+        }
+        val tokenStore = InMemoryTokenStore()
+        val token = tokenStore
+            .createTokenPair("health", clientId = "bare-client", clientName = null)
+            .accessToken
+        val audit = RecordingAuditListener()
+
+        application {
+            configureMcpRouting(
+                registry = registry,
+                tokenStore = tokenStore,
+                deviceCodeManager = DeviceCodeManager(tokenStore = tokenStore),
+                hostname = "test.rousecontext.com",
+                integration = "health",
+                auditListener = audit
+            )
+        }
+
+        val initResp = client.post("/mcp") {
+            header("Authorization", "Bearer $token")
+            contentType(ContentType.Application.Json)
+            setBody(initJson())
+        }
+        val sessionId = initResp.headers["Mcp-Session-Id"]!!
+
+        val r = client.post("/mcp") {
+            header("Authorization", "Bearer $token")
+            header("Mcp-Session-Id", sessionId)
+            contentType(ContentType.Application.Json)
+            setBody(toolCallJson(id = 2, message = "hi"))
+        }
+        assertEquals(HttpStatusCode.OK, r.status)
+        Json.parseToJsonElement(r.bodyAsText()).jsonObject
+
+        assertEquals(1, audit.toolCalls.size)
+        // When clientName isn't set at DCR, TokenStore.resolveClientLabel
+        // falls back to the clientId so the audit row still carries a
+        // stable, non-empty identifier.
+        assertEquals("bare-client", audit.toolCalls.single().clientLabel)
+    }
+
+    @Test
+    fun `TokenStore resolveClientLabel returns null for invalid token`() {
+        val store = InMemoryTokenStore()
+        assertEquals(null, store.resolveClientLabel("health", "not-a-real-token"))
+    }
+}

--- a/notifications/build.gradle.kts
+++ b/notifications/build.gradle.kts
@@ -38,6 +38,14 @@ android {
     }
 }
 
+// Room schema exports land under notifications/schemas/<db-class-fqn>/<version>.json.
+// Migration tests and the migration-review workflow in issue #344 read these
+// schema snapshots to validate that each ALTER TABLE / CREATE INDEX matches
+// the @Entity definition at the corresponding version.
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
+}
+
 dependencies {
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 

--- a/notifications/schemas/com.rousecontext.notifications.audit.AuditDatabase/4.json
+++ b/notifications/schemas/com.rousecontext.notifications.audit.AuditDatabase/4.json
@@ -1,0 +1,145 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "963f3fcbbd1c9c32c33494c4559962d0",
+    "entities": [
+      {
+        "tableName": "audit_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` TEXT NOT NULL, `toolName` TEXT NOT NULL, `provider` TEXT NOT NULL, `timestampMillis` INTEGER NOT NULL, `durationMillis` INTEGER NOT NULL, `success` INTEGER NOT NULL, `errorMessage` TEXT, `argumentsJson` TEXT, `resultJson` TEXT, `clientLabel` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toolName",
+            "columnName": "toolName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMillis",
+            "columnName": "timestampMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMillis",
+            "columnName": "durationMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "success",
+            "columnName": "success",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "errorMessage",
+            "columnName": "errorMessage",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "argumentsJson",
+            "columnName": "argumentsJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "resultJson",
+            "columnName": "resultJson",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "clientLabel",
+            "columnName": "clientLabel",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "mcp_request_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` TEXT NOT NULL, `provider` TEXT NOT NULL, `method` TEXT NOT NULL, `timestampMillis` INTEGER NOT NULL, `durationMillis` INTEGER NOT NULL, `resultBytes` INTEGER, `paramsJson` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provider",
+            "columnName": "provider",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "method",
+            "columnName": "method",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestampMillis",
+            "columnName": "timestampMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "durationMillis",
+            "columnName": "durationMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resultBytes",
+            "columnName": "resultBytes",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "paramsJson",
+            "columnName": "paramsJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '963f3fcbbd1c9c32c33494c4559962d0')"
+    ]
+  }
+}

--- a/notifications/src/main/java/com/rousecontext/notifications/audit/AuditDatabase.kt
+++ b/notifications/src/main/java/com/rousecontext/notifications/audit/AuditDatabase.kt
@@ -12,8 +12,8 @@ import androidx.sqlite.db.SupportSQLiteDatabase
  */
 @Database(
     entities = [AuditEntry::class, McpRequestEntry::class],
-    version = 3,
-    exportSchema = false
+    version = 4,
+    exportSchema = true
 )
 abstract class AuditDatabase : RoomDatabase() {
 
@@ -52,9 +52,21 @@ abstract class AuditDatabase : RoomDatabase() {
             }
         }
 
+        /**
+         * Adds the nullable `clientLabel` column to `audit_entries` so every
+         * persisted tool call can be attributed to the AI client that
+         * invoked it. Nullable because pre-migration rows predate
+         * session-level capture. See issue #344.
+         */
+        val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE audit_entries ADD COLUMN clientLabel TEXT")
+            }
+        }
+
         fun create(context: Context): AuditDatabase =
             Room.databaseBuilder(context.applicationContext, AuditDatabase::class.java, DB_NAME)
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
                 .build()
 
         /**

--- a/notifications/src/main/java/com/rousecontext/notifications/audit/AuditEntry.kt
+++ b/notifications/src/main/java/com/rousecontext/notifications/audit/AuditEntry.kt
@@ -5,6 +5,11 @@ import androidx.room.PrimaryKey
 
 /**
  * Room entity representing a single MCP tool call audit record.
+ *
+ * @property clientLabel Human-readable label for the AI client that invoked
+ *   the tool, captured once per MCP session from the OAuth Bearer token
+ *   (issue #344). Nullable so rows created before the v3 -> v4 migration
+ *   survive unchanged.
  */
 @Entity(tableName = "audit_entries")
 data class AuditEntry(
@@ -18,5 +23,6 @@ data class AuditEntry(
     val success: Boolean,
     val errorMessage: String? = null,
     val argumentsJson: String? = null,
-    val resultJson: String? = null
+    val resultJson: String? = null,
+    val clientLabel: String? = null
 )

--- a/notifications/src/main/java/com/rousecontext/notifications/audit/RoomAuditListener.kt
+++ b/notifications/src/main/java/com/rousecontext/notifications/audit/RoomAuditListener.kt
@@ -52,7 +52,8 @@ class RoomAuditListener(
                 success = true,
                 errorMessage = fieldEncryptor?.encrypt(null),
                 argumentsJson = fieldEncryptor?.encrypt(argsJson) ?: argsJson,
-                resultJson = fieldEncryptor?.encrypt(resultJson) ?: resultJson
+                resultJson = fieldEncryptor?.encrypt(resultJson) ?: resultJson,
+                clientLabel = event.clientLabel
             )
         )
         perCallObserver?.onToolCallRecorded(event)

--- a/notifications/src/test/java/com/rousecontext/notifications/audit/AuditMigrationTest.kt
+++ b/notifications/src/test/java/com/rousecontext/notifications/audit/AuditMigrationTest.kt
@@ -1,0 +1,161 @@
+package com.rousecontext.notifications.audit
+
+import android.content.Context
+import androidx.room.Room
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Unit tests for the `audit_entries` schema migration from v3 -> v4 that adds
+ * the nullable `clientLabel` column (see issue #344). Runs under Robolectric so
+ * a real SQLite engine is available without needing an instrumented device.
+ *
+ * The test hand-builds a v3 database using the pre-migration DDL, inserts a
+ * row, executes [AuditDatabase.MIGRATION_3_4] directly, then:
+ *   1. Opens the now-v4 database with Room so Room's built-in schema validation
+ *      accepts the result -- this would fail with a `migration didn't properly
+ *      handle` exception if the migration drifted from the entity definition.
+ *   2. Verifies the pre-existing row is readable and its new `clientLabel`
+ *      column is `null` (nullable column default).
+ *   3. Verifies that inserting a fresh row with `clientLabel` populated
+ *      round-trips correctly.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AuditMigrationTest {
+
+    private lateinit var context: Context
+    private lateinit var dbFile: java.io.File
+    private var helper: SupportSQLiteOpenHelper? = null
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        dbFile = java.io.File.createTempFile("audit-migration", ".db").apply { delete() }
+    }
+
+    @After
+    fun tearDown() {
+        helper?.close()
+        dbFile.delete()
+    }
+
+    @Test
+    fun `migrate from v3 to v4 adds clientLabel column without dropping rows`() {
+        // 1) Create a v3-shaped database using raw DDL that matches the
+        //    entity schema before this migration.
+        val factory = FrameworkSQLiteOpenHelperFactory()
+        val v3Helper = factory.create(
+            SupportSQLiteOpenHelper.Configuration.builder(context)
+                .name(dbFile.absolutePath)
+                .callback(
+                    object : SupportSQLiteOpenHelper.Callback(V3_VERSION) {
+                        override fun onCreate(db: SupportSQLiteDatabase) {
+                            db.execSQL(AUDIT_V3_DDL)
+                            db.execSQL(MCP_REQUEST_V3_DDL)
+                        }
+
+                        override fun onUpgrade(
+                            db: SupportSQLiteDatabase,
+                            oldVersion: Int,
+                            newVersion: Int
+                        ) {
+                            // No-op; the test controls upgrades manually.
+                        }
+                    }
+                )
+                .build()
+        )
+
+        v3Helper.writableDatabase.use { db ->
+            db.execSQL(
+                "INSERT INTO audit_entries " +
+                    "(sessionId, toolName, provider, timestampMillis, " +
+                    "durationMillis, success, errorMessage, argumentsJson, resultJson) " +
+                    "VALUES " +
+                    "('session-pre', 'get_steps', 'health', 1000, 5, 1, NULL, '{}', '{}')"
+            )
+        }
+        v3Helper.close()
+
+        // 2) Re-open with Room at v4 -- this triggers MIGRATION_3_4
+        //    automatically. Room's runtime validator then runs over the
+        //    migrated schema and throws `IllegalStateException: ... didn't
+        //    properly handle ...` if the migrated columns drift from the
+        //    @Entity definition, so a clean open is itself a regression
+        //    check that the ALTER TABLE leaves a schema compatible with
+        //    AuditEntry.
+        val roomDb = Room.databaseBuilder(context, AuditDatabase::class.java, dbFile.absolutePath)
+            .addMigrations(
+                AuditDatabase.MIGRATION_1_2,
+                AuditDatabase.MIGRATION_2_3,
+                AuditDatabase.MIGRATION_3_4
+            )
+            .allowMainThreadQueries()
+            .build()
+
+        try {
+            val dao = roomDb.auditDao()
+            val all = kotlinx.coroutines.runBlocking { dao.queryBySession("session-pre") }
+            assertEquals(1, all.size)
+            assertNull("Pre-migration row's clientLabel must be null", all.first().clientLabel)
+
+            // Fresh row with clientLabel populated round-trips.
+            val id = kotlinx.coroutines.runBlocking {
+                dao.insert(
+                    AuditEntry(
+                        sessionId = "session-post",
+                        toolName = "get_steps",
+                        provider = "health",
+                        timestampMillis = 2000,
+                        durationMillis = 7,
+                        success = true,
+                        clientLabel = "Claude Desktop"
+                    )
+                )
+            }
+            val inserted = kotlinx.coroutines.runBlocking { dao.getById(id) }
+            assertEquals("Claude Desktop", inserted?.clientLabel)
+        } finally {
+            roomDb.close()
+        }
+    }
+
+    private companion object {
+        private const val V3_VERSION = 3
+
+        /** The audit_entries CREATE TABLE matching the @Entity at Room v3. */
+        private const val AUDIT_V3_DDL =
+            "CREATE TABLE IF NOT EXISTS `audit_entries` (" +
+                "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                "`sessionId` TEXT NOT NULL, " +
+                "`toolName` TEXT NOT NULL, " +
+                "`provider` TEXT NOT NULL, " +
+                "`timestampMillis` INTEGER NOT NULL, " +
+                "`durationMillis` INTEGER NOT NULL, " +
+                "`success` INTEGER NOT NULL, " +
+                "`errorMessage` TEXT, " +
+                "`argumentsJson` TEXT, " +
+                "`resultJson` TEXT" +
+                ")"
+
+        private const val MCP_REQUEST_V3_DDL =
+            "CREATE TABLE IF NOT EXISTS `mcp_request_entries` (" +
+                "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                "`sessionId` TEXT NOT NULL, " +
+                "`provider` TEXT NOT NULL, " +
+                "`method` TEXT NOT NULL, " +
+                "`timestampMillis` INTEGER NOT NULL, " +
+                "`durationMillis` INTEGER NOT NULL, " +
+                "`resultBytes` INTEGER, " +
+                "`paramsJson` TEXT)"
+    }
+}

--- a/notifications/src/test/java/com/rousecontext/notifications/audit/RoomAuditListenerTest.kt
+++ b/notifications/src/test/java/com/rousecontext/notifications/audit/RoomAuditListenerTest.kt
@@ -107,6 +107,20 @@ class RoomAuditListenerTest {
     }
 
     @Test
+    fun `onToolCall persists clientLabel on the audit entry`() = runBlocking {
+        val dao = FakeAuditDao()
+        val listener = RoomAuditListener(dao = dao)
+
+        listener.onToolCall(
+            makeEvent(provider = "health", toolName = "get_steps")
+                .copy(clientLabel = "Claude Desktop")
+        )
+
+        assertEquals(1, dao.entries.size)
+        assertEquals("Claude Desktop", dao.entries.first().clientLabel)
+    }
+
+    @Test
     fun `onRequest persists to mcp request dao`() = runBlocking {
         val dao = FakeAuditDao()
         val requestDao = FakeMcpRequestDao()


### PR DESCRIPTION
## Summary

Part of the #342 umbrella. Lays the foundation for attributing every tool call to the AI client that invoked it.

- `ToolCallEvent` gains a non-null `clientLabel: String` (default `"Unknown"` literal); `AuditEntry` gains a nullable `clientLabel` column (null for pre-migration rows).
- `TokenStore.resolveClientLabel()` exposes the audit-facing label (DCR `client_name` fallback to `client_id`) for valid Bearer tokens.
- `McpRouting.handleMcp()` resolves the label once on successful auth, caches it on `SessionEntry`, and stamps every `ToolCallEvent` emitted in the session with that cached value.
- `AuditDatabase` bumps to v4 with `MIGRATION_3_4: ALTER TABLE audit_entries ADD COLUMN clientLabel TEXT`. Room schema export is enabled and v4 is checked in under `notifications/schemas/`.

Non-goals (tracked separately):
- `Unknown (#N)` monotonic numbering is #345.
- Notification copy is #347.
- Audit-row UI is the follow-up to #343.
- Wiring `ToolNameHumanizer` is #347.

Closes #344

## Test plan

- [x] `:core:mcp:jvmTest` -- new `ClientLabelCaptureTest` drives `configureMcpRouting` end-to-end and asserts three tool calls in the same session all carry the cached label, clientName-less DCR falls back to the clientId label, and invalid tokens yield `null`.
- [x] `:notifications:testDebugUnitTest` -- new `onToolCall persists clientLabel on the audit entry` regression and the full existing `RoomAuditListenerTest` suite still green.
- [x] `:notifications:testDebugUnitTest` -- new `AuditMigrationTest` (Robolectric) hand-builds a v3 `audit_entries`, reopens the DB at v4 to run `MIGRATION_3_4`, and verifies pre-migration rows survive with `clientLabel = null` while a fresh row round-trips. Room's schema validator running over the reopened DB doubles as a regression check that the ALTER TABLE matches the entity definition.
- [x] `:app:testDebugUnitTest` -- green (confirms `RoomTokenStore.resolveClientLabel` doesn't break existing token-store tests).
- [x] `./gradlew ktlintCheck` -- green.
- [x] `./gradlew :app:assembleDebug` -- green.

Instrumented migration coverage is out of scope for this repo (no `androidTest` source set on `:notifications`); the Robolectric + Room schema-validator combination above covers the real SQLite engine path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)