### PR TITLE
Fix #345: Monotonic Unknown (#N) labeler

### DIFF
--- a/app/src/main/java/com/rousecontext/app/di/AppModule.kt
+++ b/app/src/main/java/com/rousecontext/app/di/AppModule.kt
@@ -41,6 +41,7 @@ import com.rousecontext.app.support.BugReportUriBuilder
 import com.rousecontext.app.support.FirebaseCrashReporter
 import com.rousecontext.app.token.RoomTokenStore
 import com.rousecontext.app.token.TokenDatabase
+import com.rousecontext.app.token.createUnknownClientLabeler
 import com.rousecontext.app.ui.viewmodels.AddIntegrationViewModel
 import com.rousecontext.app.ui.viewmodels.AuditHistoryViewModel
 import com.rousecontext.app.ui.viewmodels.AuthorizationApprovalViewModel
@@ -64,6 +65,7 @@ import com.rousecontext.mcp.core.AuditListener
 import com.rousecontext.mcp.core.McpSession
 import com.rousecontext.mcp.core.ProviderRegistry
 import com.rousecontext.mcp.core.TokenStore
+import com.rousecontext.mcp.core.UnknownClientLabeler
 import com.rousecontext.notifications.AndroidSecurityCheckNotifier
 import com.rousecontext.notifications.AuthRequestNotifier
 import com.rousecontext.notifications.FieldEncryptor
@@ -267,6 +269,9 @@ val appModule = module {
     // --- Token store ---
     singleOf(::RoomTokenStore) bind TokenStore::class
 
+    // --- Unknown-client labeler (monotonic `Unknown (#N)`, see issue #345) ---
+    single<UnknownClientLabeler> { createUnknownClientLabeler(androidContext()) }
+
     // --- Integration state ---
     single<IntegrationStateStore> { DataStoreIntegrationStateStore(androidContext()) }
 
@@ -460,6 +465,7 @@ val appModule = module {
             auditListener = get(),
             hostname = initialHostname,
             integration = defaultIntegration,
+            unknownClientLabeler = get(),
             securityAlertCheck = run {
                 val securityPrefs = get<SecurityCheckPreferences>()
                 val alertFlag = combine(

--- a/app/src/main/java/com/rousecontext/app/token/DataStoreUnknownClientLabeler.kt
+++ b/app/src/main/java/com/rousecontext/app/token/DataStoreUnknownClientLabeler.kt
@@ -1,0 +1,76 @@
+package com.rousecontext.app.token
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.rousecontext.mcp.core.UnknownClientLabeler
+
+/**
+ * [UnknownClientLabeler] backed by DataStore preferences.
+ *
+ * Layout:
+ * - One [stringPreferencesKey] per known client, of the form `client_<clientId>`,
+ *   whose value is the already-assigned label (e.g. `Unknown (#3)`). Storing the
+ *   full label (rather than just the number) makes the mapping self-describing
+ *   in on-device dumps and trivially readable without any schema knowledge.
+ * - One [intPreferencesKey] named `next_index`, holding the next integer to
+ *   assign on the first call for a new [clientId]. Starts at 1.
+ *
+ * The [DataStore.edit] block provides atomic read-modify-write semantics
+ * across concurrent callers within a process and persists the result before
+ * returning, so cold-start restarts continue the sequence (see issue #345).
+ * Once a `clientId → N` mapping is written it is never rewritten, so the
+ * counter is monotonic and stable even across token revocations.
+ */
+class DataStoreUnknownClientLabeler(private val dataStore: DataStore<Preferences>) :
+    UnknownClientLabeler {
+
+    override suspend fun labelFor(clientId: String): String {
+        val key = clientKey(clientId)
+        var result = ""
+        dataStore.edit { prefs ->
+            val existing = prefs[key]
+            if (existing != null) {
+                result = existing
+                return@edit
+            }
+            val nextIndex = prefs[NEXT_INDEX_KEY] ?: 1
+            val label = formatLabel(nextIndex)
+            prefs[key] = label
+            prefs[NEXT_INDEX_KEY] = nextIndex + 1
+            result = label
+        }
+        return result
+    }
+
+    companion object {
+        internal val NEXT_INDEX_KEY = intPreferencesKey("next_index")
+
+        internal fun clientKey(clientId: String) = stringPreferencesKey("client_$clientId")
+
+        internal fun formatLabel(index: Int): String = "Unknown (#$index)"
+    }
+}
+
+/**
+ * Context-scoped DataStore backing the unknown-client labeler. Split into
+ * this file so the `preferencesDataStore` singleton-per-name contract is
+ * obvious and the on-disk file name (`unknown_client_labels`) is easy to
+ * locate.
+ */
+private val Context.unknownClientLabelsDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "unknown_client_labels")
+
+/**
+ * Production factory for [DataStoreUnknownClientLabeler] bound to the app-wide
+ * DataStore file named `unknown_client_labels.preferences_pb` under the app's
+ * files dir. Koin calls this. Defined as a plain top-level function (not a
+ * companion extension) so it doesn't collide with similarly-named factories
+ * from other modules that AppModule imports.
+ */
+fun createUnknownClientLabeler(context: Context): DataStoreUnknownClientLabeler =
+    DataStoreUnknownClientLabeler(context.unknownClientLabelsDataStore)

--- a/app/src/main/java/com/rousecontext/app/token/RoomTokenStore.kt
+++ b/app/src/main/java/com/rousecontext/app/token/RoomTokenStore.kt
@@ -108,6 +108,10 @@ class RoomTokenStore(private val dao: TokenDao) : TokenStore {
         dao.deleteByClientId(integrationId, clientId)
     }
 
+    override fun upgradeClientLabel(integrationId: String, clientId: String, newLabel: String) {
+        dao.updateLabelByClientId(integrationId, clientId, newLabel)
+    }
+
     override fun refreshToken(integrationId: String, refreshToken: String): TokenPair? {
         val hash = hashToken(refreshToken)
         val entity = dao.findByRefreshHash(integrationId, hash) ?: return null

--- a/app/src/main/java/com/rousecontext/app/token/TokenDao.kt
+++ b/app/src/main/java/com/rousecontext/app/token/TokenDao.kt
@@ -54,6 +54,17 @@ interface TokenDao {
     fun deleteByClientId(integrationId: String, clientId: String)
 
     /**
+     * Rewrites the display [label] for every row whose `(integrationId,
+     * clientId)` matches. Used by the issue #345 one-shot upgrade from the
+     * literal `"unknown"` label to the monotonic `Unknown (#N)` label.
+     */
+    @Query(
+        "UPDATE tokens SET label = :label " +
+            "WHERE integrationId = :integrationId AND clientId = :clientId"
+    )
+    fun updateLabelByClientId(integrationId: String, clientId: String, label: String)
+
+    /**
      * Revokes an entire token family by deleting every row with the given
      * [familyId]. Used when a rotated refresh token is replayed, per OAuth
      * 2.1 §4.14.

--- a/app/src/test/java/com/rousecontext/app/token/DataStoreUnknownClientLabelerTest.kt
+++ b/app/src/test/java/com/rousecontext/app/token/DataStoreUnknownClientLabelerTest.kt
@@ -1,0 +1,178 @@
+package com.rousecontext.app.token
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import java.io.File
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Unit tests for [DataStoreUnknownClientLabeler].
+ *
+ * Verifies monotonic `Unknown (#N)` assignment keyed on `client_id`:
+ * - Idempotency: same clientId always resolves to the same label.
+ * - Monotonicity: sequential unknown clients get `#1, #2, #3, ...`.
+ * - Persistence: labels survive process restart (same DataStore file).
+ * - Revocation-immunity: by design, assignments are never reused. Even
+ *   if a client's tokens are revoked, its label stays fixed and a new
+ *   unknown client takes the next number.
+ *
+ * See issue #345 and the [NotificationIdCounterTest] pattern for
+ * DataStore-backed test setup.
+ */
+class DataStoreUnknownClientLabelerTest {
+
+    @get:Rule
+    val tmpDir = TemporaryFolder()
+
+    private val scopes = mutableListOf<CoroutineScope>()
+
+    @After
+    fun tearDown() {
+        scopes.forEach { it.cancel() }
+        scopes.clear()
+    }
+
+    @Test
+    fun `fresh labeler assigns Unknown number 1 to first client`() = runBlocking {
+        val labeler = DataStoreUnknownClientLabeler(makeStore())
+        assertEquals("Unknown (#1)", labeler.labelFor("client-A"))
+    }
+
+    @Test
+    fun `same clientId returns the same label on repeat calls`() = runBlocking {
+        val labeler = DataStoreUnknownClientLabeler(makeStore())
+        val first = labeler.labelFor("client-A")
+        val second = labeler.labelFor("client-A")
+        val third = labeler.labelFor("client-A")
+        assertEquals("Unknown (#1)", first)
+        assertEquals(first, second)
+        assertEquals(first, third)
+    }
+
+    @Test
+    fun `distinct clientIds get sequential monotonic numbers`() = runBlocking {
+        val labeler = DataStoreUnknownClientLabeler(makeStore())
+        assertEquals("Unknown (#1)", labeler.labelFor("client-A"))
+        assertEquals("Unknown (#2)", labeler.labelFor("client-B"))
+        assertEquals("Unknown (#3)", labeler.labelFor("client-C"))
+    }
+
+    @Test
+    fun `reordered lookups return the originally assigned numbers`() = runBlocking {
+        val labeler = DataStoreUnknownClientLabeler(makeStore())
+        labeler.labelFor("client-A")
+        labeler.labelFor("client-B")
+        labeler.labelFor("client-C")
+        // Reorder: each clientId still resolves to the label it was assigned
+        // when first seen, regardless of lookup order.
+        assertEquals("Unknown (#3)", labeler.labelFor("client-C"))
+        assertEquals("Unknown (#1)", labeler.labelFor("client-A"))
+        assertEquals("Unknown (#2)", labeler.labelFor("client-B"))
+    }
+
+    @Test
+    fun `ten sequential clients get numbers 1 through 10`() = runBlocking {
+        val labeler = DataStoreUnknownClientLabeler(makeStore())
+        val labels = (1..10).map { labeler.labelFor("client-$it") }
+        assertEquals(
+            (1..10).map { "Unknown (#$it)" },
+            labels
+        )
+    }
+
+    @Test
+    fun `second labeler backed by same file continues sequence and recalls prior assignments`() =
+        runBlocking {
+            val firstScope = newScope()
+            val first = DataStoreUnknownClientLabeler(storeIn(firstScope))
+            assertEquals("Unknown (#1)", first.labelFor("client-A"))
+            assertEquals("Unknown (#2)", first.labelFor("client-B"))
+            // Simulate process death: DataStore requires only one active instance
+            // per file, so release the first before opening a second pointed at
+            // the same path.
+            firstScope.cancel()
+
+            val secondScope = newScope()
+            val second = DataStoreUnknownClientLabeler(storeIn(secondScope))
+            // Previously-seen clients still resolve to their original labels.
+            assertEquals("Unknown (#1)", second.labelFor("client-A"))
+            assertEquals("Unknown (#2)", second.labelFor("client-B"))
+            // A new client continues the sequence from the persisted counter.
+            assertEquals("Unknown (#3)", second.labelFor("client-C"))
+        }
+
+    @Test
+    fun `distinct stores do not share state`() = runBlocking {
+        val storeA = makeStore(name = "a.preferences_pb")
+        val storeB = makeStore(name = "b.preferences_pb")
+        val a = DataStoreUnknownClientLabeler(storeA)
+        val b = DataStoreUnknownClientLabeler(storeB)
+
+        assertEquals("Unknown (#1)", a.labelFor("x"))
+        assertEquals("Unknown (#2)", a.labelFor("y"))
+        // Store B is independent.
+        assertEquals("Unknown (#1)", b.labelFor("x"))
+    }
+
+    @Test
+    fun `concurrent assignments for distinct clients all succeed without collision`() =
+        runBlocking {
+            val labeler = DataStoreUnknownClientLabeler(makeStore())
+            val ids = (1..20).map { "client-$it" }
+            val labels = ids.map { id ->
+                async(Dispatchers.IO) { labeler.labelFor(id) }
+            }.awaitAll()
+            // All 20 labels are distinct and fill the range #1..#20 exactly.
+            assertEquals(20, labels.toSet().size)
+            assertEquals(
+                (1..20).map { "Unknown (#$it)" }.toSet(),
+                labels.toSet()
+            )
+            // And every id is stably assigned on re-query.
+            val recheck = ids.map { labeler.labelFor(it) }
+            assertEquals(labels, recheck)
+        }
+
+    @Test
+    fun `label format matches the locked design`() = runBlocking {
+        val labeler = DataStoreUnknownClientLabeler(makeStore())
+        val label = labeler.labelFor("any-client")
+        // Per the issue design, the format is "Unknown (#N)" exactly.
+        assertTrue(
+            "label=$label should match the Unknown (#N) format",
+            Regex("^Unknown \\(#\\d+\\)\$").matches(label)
+        )
+        assertNotEquals("Unknown", label)
+        assertNotEquals("unknown", label)
+    }
+
+    private fun newScope(): CoroutineScope {
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        scopes += scope
+        return scope
+    }
+
+    private fun makeStore(name: String = "labels.preferences_pb"): DataStore<Preferences> =
+        storeIn(newScope(), name)
+
+    private fun storeIn(
+        scope: CoroutineScope,
+        name: String = "labels.preferences_pb"
+    ): DataStore<Preferences> = PreferenceDataStoreFactory.create(scope = scope) {
+        File(tmpDir.root, name)
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/token/RoomTokenStoreTest.kt
+++ b/app/src/test/java/com/rousecontext/app/token/RoomTokenStoreTest.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import com.rousecontext.app.TestApplication
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -120,5 +121,59 @@ class RoomTokenStoreTest {
 
         // Original access token still valid — wrong-integration attempts are not reuse.
         assertTrue(store.validateToken("health", pair.accessToken))
+    }
+
+    // --- issue #345 ---
+
+    @Test
+    fun `upgradeClientLabel rewrites label for every row with matching clientId`() {
+        // Two token pairs for the same legacy "unknown" client, to verify
+        // the upgrade rewrites both rows atomically rather than only the
+        // first one the store happens to return.
+        val first = store.createTokenPair("health", "legacy-client", clientName = "unknown")
+        val second = store.createTokenPair("health", "legacy-client", clientName = "unknown")
+
+        // Sanity: both start with the legacy literal.
+        assertEquals("unknown", store.resolveClientLabel("health", first.accessToken))
+        assertEquals("unknown", store.resolveClientLabel("health", second.accessToken))
+
+        store.upgradeClientLabel("health", "legacy-client", "Unknown (#7)")
+
+        assertEquals("Unknown (#7)", store.resolveClientLabel("health", first.accessToken))
+        assertEquals("Unknown (#7)", store.resolveClientLabel("health", second.accessToken))
+
+        val listed = store.listTokens("health")
+        assertEquals(2, listed.size)
+        assertTrue(
+            "Upgrade must not leave any row with the legacy literal",
+            listed.none { it.label == "unknown" }
+        )
+        assertTrue(
+            "All rows for the upgraded client share the new label",
+            listed.all { it.label == "Unknown (#7)" }
+        )
+    }
+
+    @Test
+    fun `upgradeClientLabel is scoped to the integration`() {
+        val inHealth = store.createTokenPair("health", "shared-id", clientName = "unknown")
+        val inNotes = store.createTokenPair("notifications", "shared-id", clientName = "unknown")
+
+        store.upgradeClientLabel("health", "shared-id", "Unknown (#3)")
+
+        assertEquals("Unknown (#3)", store.resolveClientLabel("health", inHealth.accessToken))
+        // Other integration for the same clientId is untouched.
+        assertEquals("unknown", store.resolveClientLabel("notifications", inNotes.accessToken))
+    }
+
+    @Test
+    fun `upgradeClientLabel is a no-op when no rows match`() {
+        // A clean call for an unknown clientId must not throw or affect
+        // unrelated rows.
+        val pair = store.createTokenPair("health", "present", clientName = "Real Name")
+
+        store.upgradeClientLabel("health", "does-not-exist", "Unknown (#99)")
+
+        assertEquals("Real Name", store.resolveClientLabel("health", pair.accessToken))
     }
 }

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/AuditListener.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/AuditListener.kt
@@ -69,6 +69,13 @@ data class ToolCallEvent(
 const val UNKNOWN_CLIENT_LABEL: String = "Unknown"
 
 /**
+ * Pre-#345 DCR rows without a `client_name` persisted this literal as the
+ * client label. Issue #345 swaps future writes to `Unknown (#N)`; any row
+ * still carrying this literal is lazily upgraded on first resolve.
+ */
+internal const val LEGACY_UNKNOWN_LABEL: String = "unknown"
+
+/**
  * Audit event emitted when an OAuth token is granted to a client.
  */
 data class TokenGrantEvent(

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/InMemoryTokenStore.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/InMemoryTokenStore.kt
@@ -17,7 +17,9 @@ class InMemoryTokenStore(private val clock: Clock = SystemClock) : TokenStore {
     private data class StoredToken(
         val integrationId: String,
         val clientId: String,
-        val clientName: String?,
+        // Mutable so issue #345 migration can upgrade legacy "unknown" labels
+        // to `Unknown (#N)` in place via [upgradeClientLabel].
+        var clientName: String?,
         val familyId: String,
         val token: String,
         val createdAt: Long,
@@ -29,7 +31,8 @@ class InMemoryTokenStore(private val clock: Clock = SystemClock) : TokenStore {
     private data class StoredRefreshToken(
         val integrationId: String,
         val clientId: String,
-        val clientName: String?,
+        // Mutable: see note on [StoredToken.clientName].
+        var clientName: String?,
         val familyId: String,
         val refreshToken: String,
         val createdAt: Long,
@@ -86,6 +89,18 @@ class InMemoryTokenStore(private val clock: Clock = SystemClock) : TokenStore {
             if (stored.integrationId != integrationId) return null
             return stored.clientName ?: stored.clientId
         }
+    }
+
+    override fun upgradeClientLabel(integrationId: String, clientId: String, newLabel: String) {
+        synchronized(this) {
+            tokens.filter {
+                it.integrationId == integrationId && it.clientId == clientId
+            }.forEach { it.clientName = newLabel }
+            refreshTokens.filter {
+                it.integrationId == integrationId && it.clientId == clientId
+            }.forEach { it.clientName = newLabel }
+        }
+        notifyChanged()
     }
 
     override fun createTokenPair(

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/McpRouting.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/McpRouting.kt
@@ -97,6 +97,7 @@ fun Application.configureMcpRouting(
     serverName: String = "rouse-context",
     serverVersion: String = "0.1.0",
     internalToken: String? = null,
+    unknownClientLabeler: UnknownClientLabeler? = null,
     log: (LogLevel, String) -> Unit = { _, _ -> }
 ) {
     // Installed BEFORE ContentNegotiation so it intercepts well-known and
@@ -125,6 +126,7 @@ fun Application.configureMcpRouting(
         securityAlertCheck = securityAlertCheck,
         serverName = serverName,
         serverVersion = serverVersion,
+        unknownClientLabeler = unknownClientLabeler,
         log = log
     )
 
@@ -168,6 +170,7 @@ internal class McpRoutes(
     private val securityAlertCheck: (() -> Boolean)?,
     private val serverName: String,
     private val serverVersion: String,
+    private val unknownClientLabeler: UnknownClientLabeler? = null,
     private val log: (LogLevel, String) -> Unit
 ) {
     // Per-session MCP servers, keyed by "$integration:$sessionId"
@@ -311,8 +314,6 @@ internal class McpRoutes(
             return
         }
 
-        val clientName = body["client_name"]?.jsonPrimitive?.content ?: "unknown"
-
         // Validate redirect_uris: only http/https schemes allowed
         val rawUris = (body["redirect_uris"] as? JsonArray)
             ?.mapNotNull { it.jsonPrimitive.content }
@@ -338,6 +339,14 @@ internal class McpRoutes(
         val redirectUris = validUris
 
         val clientId = UUID.randomUUID().toString()
+        // Per issue #345: when DCR omits `client_name`, assign a monotonic
+        // `Unknown (#N)` label keyed on the freshly-minted `client_id` so
+        // the client is still attributable in audit rows and the authorized
+        // clients list. Falls back to the literal "unknown" only when no
+        // labeler is configured (older tests / embed paths).
+        val clientName = body["client_name"]?.jsonPrimitive?.content
+            ?: unknownClientLabeler?.labelFor(clientId)
+            ?: "unknown"
         try {
             authorizationCodeManager.registerClient(clientId, clientName, redirectUris)
         } catch (e: IllegalArgumentException) {
@@ -704,12 +713,23 @@ internal class McpRoutes(
         // Capture the client label once at session creation so every
         // subsequent tool-call audit event in this session carries the same
         // stable, human-readable identifier (issue #344). Falls back to the
-        // literal "Unknown" if the token store has no label for this token,
-        // which in practice shouldn't happen for authenticated tool calls
-        // but is handled defensively here. Issue #345 replaces the literal
-        // with monotonic `Unknown (#N)` numbering.
-        val resolvedClientLabel = tokenStore.resolveClientLabel(ri, token)
-            ?: UNKNOWN_CLIENT_LABEL
+        // literal "Unknown" only when the bearer is anonymous / unresolvable —
+        // authenticated clients always get a concrete label, either the DCR
+        // `client_name` or an `Unknown (#N)` labeler assignment (issue #345).
+        val storedLabel = tokenStore.resolveClientLabel(ri, token)
+        val resolvedClientLabel = when {
+            storedLabel == null -> UNKNOWN_CLIENT_LABEL
+            // Lazy migration (#345): pre-#345 DCR rows persisted the literal
+            // "unknown" when `client_name` was missing. Upgrade in place on
+            // first resolve so both this session's audit rows and the
+            // authorized-clients list see the new `Unknown (#N)` label.
+            storedLabel == LEGACY_UNKNOWN_LABEL && unknownClientLabeler != null -> {
+                val upgraded = unknownClientLabeler.labelFor(callerClientId)
+                tokenStore.upgradeClientLabel(ri, callerClientId, upgraded)
+                upgraded
+            }
+            else -> storedLabel
+        }
 
         if (method == "initialize" && incomingSessionId == null) {
             // Create a new session

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/McpSession.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/McpSession.kt
@@ -43,6 +43,7 @@ class McpSession(
     private val securityAlertCheck: (() -> Boolean)? = null,
     private val serverName: String = "rouse-context",
     private val serverVersion: String = "0.1.0",
+    private val unknownClientLabeler: UnknownClientLabeler? = null,
     private val log: (LogLevel, String) -> Unit = { _, _ -> }
 ) {
 
@@ -104,6 +105,7 @@ class McpSession(
                 serverName = serverName,
                 serverVersion = serverVersion,
                 internalToken = token,
+                unknownClientLabeler = unknownClientLabeler,
                 log = log
             )
         }

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/TokenStore.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/TokenStore.kt
@@ -50,6 +50,15 @@ interface TokenStore {
     fun resolveClientLabel(integrationId: String, token: String): String?
 
     /**
+     * Rewrites the stored client label for every row whose `clientId` equals
+     * [clientId] within [integrationId]. Used by the one-shot migration that
+     * upgrades pre-#345 rows with the literal `"unknown"` label to the new
+     * `Unknown (#N)` labeler output. Implementations MUST be idempotent: a
+     * no-op write of the same value is safe.
+     */
+    fun upgradeClientLabel(integrationId: String, clientId: String, newLabel: String)
+
+    /**
      * Creates a new access token + refresh token pair for [integrationId], associated
      * with the given [clientId]. The optional [clientName] is a human-readable label
      * for display in the authorized clients UI.

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/UnknownClientLabeler.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/UnknownClientLabeler.kt
@@ -1,0 +1,25 @@
+package com.rousecontext.mcp.core
+
+/**
+ * Assigns monotonic `Unknown (#N)` labels to OAuth clients that did not
+ * supply a human-readable `client_name` during Dynamic Client Registration.
+ *
+ * The same `clientId` always resolves to the same `N` — the mapping is
+ * persistent across process restarts and never reset, so a client that
+ * appears as `Unknown (#3)` in one audit row stays `Unknown (#3)` forever,
+ * even after its tokens are revoked and a new client takes `#4`.
+ *
+ * Implementations are expected to be safe to call from multiple
+ * coroutines concurrently. See issue #345.
+ */
+interface UnknownClientLabeler {
+
+    /**
+     * Returns a stable `Unknown (#N)` label for [clientId]. If [clientId]
+     * has never been labeled before, atomically allocates the next number
+     * (starting at 1), persists the mapping, and returns the new label.
+     * Subsequent calls with the same [clientId] return the identical
+     * string.
+     */
+    suspend fun labelFor(clientId: String): String
+}

--- a/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/core/UnknownClientLabelerRoutingTest.kt
+++ b/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/core/UnknownClientLabelerRoutingTest.kt
@@ -1,0 +1,338 @@
+package com.rousecontext.mcp.core
+
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.testApplication
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Routing-level tests for the [UnknownClientLabeler] hookup (issue #345).
+ *
+ * Covers two code paths that replaced the literal `"unknown"` / `"Unknown"`
+ * fallbacks:
+ *
+ * 1. Dynamic Client Registration without a `client_name` now persists a
+ *    monotonic `Unknown (#N)` label on the [TokenEntity] equivalent, instead
+ *    of the literal string `"unknown"`.
+ * 2. Pre-#345 rows whose stored label is the literal `"unknown"` are
+ *    lazily upgraded to `Unknown (#N)` the first time the token is resolved
+ *    for an MCP session, so audit rows and the authorized-clients list
+ *    pick up the new label without a schema migration.
+ */
+class UnknownClientLabelerRoutingTest {
+
+    /**
+     * In-memory labeler used by these tests so we don't need DataStore:
+     * the interface contract is the only thing [McpRouting] depends on.
+     */
+    private class InMemoryLabeler : UnknownClientLabeler {
+        private val map = mutableMapOf<String, String>()
+        private var next = 1
+        override suspend fun labelFor(clientId: String): String = synchronized(this) {
+            map.getOrPut(clientId) { "Unknown (#${next++})" }
+        }
+    }
+
+    private class EchoProvider : McpServerProvider {
+        override val id = "health"
+        override val displayName = "Health Connect"
+
+        override fun register(server: Server) {
+            server.addTool(
+                name = "echo",
+                description = "Echoes the provided message",
+                inputSchema = ToolSchema(
+                    properties = buildJsonObject {
+                        put(
+                            "message",
+                            buildJsonObject {
+                                put("type", JsonPrimitive("string"))
+                            }
+                        )
+                    },
+                    required = listOf("message")
+                )
+            ) { _ ->
+                CallToolResult(content = listOf(TextContent("ok")))
+            }
+        }
+    }
+
+    private class RecordingAuditListener : AuditListener {
+        val toolCalls: MutableList<ToolCallEvent> = CopyOnWriteArrayList()
+
+        override suspend fun onToolCall(event: ToolCallEvent) {
+            toolCalls += event
+        }
+    }
+
+    private fun mcpJsonRpc(method: String, params: String? = null, id: Int = 1): String {
+        val paramsStr = if (params != null) ""","params":$params""" else ""
+        return """{"jsonrpc":"2.0","method":"$method"$paramsStr,"id":$id}"""
+    }
+
+    private fun initJson(): String = mcpJsonRpc(
+        "initialize",
+        """{"protocolVersion":"2025-03-26","capabilities":{}""" +
+            ""","clientInfo":{"name":"test","version":"1.0"}}"""
+    )
+
+    private fun toolCallJson(id: Int, message: String): String = mcpJsonRpc(
+        "tools/call",
+        """{"name":"echo","arguments":{"message":"$message"}}""",
+        id = id
+    )
+
+    @Test
+    fun `DCR without client_name persists monotonic Unknown label`() = testApplication {
+        val registry = InMemoryProviderRegistry().apply {
+            register("health", EchoProvider())
+            setEnabled("health", true)
+        }
+        val tokenStore = InMemoryTokenStore()
+        val labeler = InMemoryLabeler()
+
+        application {
+            configureMcpRouting(
+                registry = registry,
+                tokenStore = tokenStore,
+                deviceCodeManager = DeviceCodeManager(tokenStore = tokenStore),
+                hostname = "test.rousecontext.com",
+                integration = "health",
+                unknownClientLabeler = labeler
+            )
+        }
+
+        // /register without client_name -> response carries Unknown (#1).
+        val resp = client.post("/register") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"redirect_uris":["https://claude.ai/cb"]}""")
+        }
+        assertEquals(HttpStatusCode.Created, resp.status)
+        val body = Json.parseToJsonElement(resp.bodyAsText()).jsonObject
+        val clientId = body["client_id"]?.jsonPrimitive?.content
+        assertNotNull("DCR must return a client_id", clientId)
+        assertEquals("Unknown (#1)", body["client_name"]?.jsonPrimitive?.content)
+
+        // Second anonymous DCR -> Unknown (#2), keyed on the fresh client_id.
+        val resp2 = client.post("/register") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"redirect_uris":["https://claude.ai/cb"]}""")
+        }
+        val body2 = Json.parseToJsonElement(resp2.bodyAsText()).jsonObject
+        assertEquals("Unknown (#2)", body2["client_name"]?.jsonPrimitive?.content)
+        assertNotEquals(
+            clientId,
+            body2["client_id"]?.jsonPrimitive?.content
+        )
+    }
+
+    @Test
+    fun `DCR with client_name leaves user-supplied label untouched`() = testApplication {
+        val registry = InMemoryProviderRegistry().apply {
+            register("health", EchoProvider())
+            setEnabled("health", true)
+        }
+        val tokenStore = InMemoryTokenStore()
+        val labeler = InMemoryLabeler()
+
+        application {
+            configureMcpRouting(
+                registry = registry,
+                tokenStore = tokenStore,
+                deviceCodeManager = DeviceCodeManager(tokenStore = tokenStore),
+                hostname = "test.rousecontext.com",
+                integration = "health",
+                unknownClientLabeler = labeler
+            )
+        }
+
+        val resp = client.post("/register") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                """{"client_name":"Claude Desktop",""" +
+                    """"redirect_uris":["https://claude.ai/cb"]}"""
+            )
+        }
+        assertEquals(HttpStatusCode.Created, resp.status)
+        val body = Json.parseToJsonElement(resp.bodyAsText()).jsonObject
+        assertEquals("Claude Desktop", body["client_name"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `legacy unknown label is lazily upgraded on tool call`() = testApplication {
+        val registry = InMemoryProviderRegistry().apply {
+            register("health", EchoProvider())
+            setEnabled("health", true)
+        }
+        val tokenStore = InMemoryTokenStore()
+        val labeler = InMemoryLabeler()
+
+        // Simulate a pre-#345 row: DCR wrote the literal "unknown" as the
+        // client_name when none was supplied.
+        val token = tokenStore.createTokenPair(
+            integrationId = "health",
+            clientId = "legacy-client",
+            clientName = "unknown"
+        ).accessToken
+
+        val audit = RecordingAuditListener()
+
+        application {
+            configureMcpRouting(
+                registry = registry,
+                tokenStore = tokenStore,
+                deviceCodeManager = DeviceCodeManager(tokenStore = tokenStore),
+                hostname = "test.rousecontext.com",
+                integration = "health",
+                auditListener = audit,
+                unknownClientLabeler = labeler
+            )
+        }
+
+        val initResp = client.post("/mcp") {
+            header("Authorization", "Bearer $token")
+            contentType(ContentType.Application.Json)
+            setBody(initJson())
+        }
+        assertEquals(HttpStatusCode.OK, initResp.status)
+        val sessionId = initResp.headers["Mcp-Session-Id"]!!
+
+        val callResp = client.post("/mcp") {
+            header("Authorization", "Bearer $token")
+            header("Mcp-Session-Id", sessionId)
+            contentType(ContentType.Application.Json)
+            setBody(toolCallJson(id = 2, message = "hi"))
+        }
+        assertEquals(HttpStatusCode.OK, callResp.status)
+        Json.parseToJsonElement(callResp.bodyAsText()).jsonObject
+
+        assertEquals(1, audit.toolCalls.size)
+        // The audit row's clientLabel is the upgraded label, not "unknown".
+        val upgraded = audit.toolCalls.single().clientLabel
+        assertEquals("Unknown (#1)", upgraded)
+
+        // And the upgrade was written back to the token store: subsequent
+        // listTokens exposes the new label.
+        val listed = tokenStore.listTokens("health")
+        assertEquals(1, listed.size)
+        assertEquals("Unknown (#1)", listed.single().label)
+        assertTrue(
+            "Upgraded label must not still be the legacy literal",
+            listed.none { it.label == "unknown" }
+        )
+    }
+
+    @Test
+    fun `legacy upgrade is stable across sessions for the same client`() = testApplication {
+        val registry = InMemoryProviderRegistry().apply {
+            register("health", EchoProvider())
+            setEnabled("health", true)
+        }
+        val tokenStore = InMemoryTokenStore()
+        val labeler = InMemoryLabeler()
+
+        val tokenA = tokenStore.createTokenPair(
+            integrationId = "health",
+            clientId = "legacy-A",
+            clientName = "unknown"
+        ).accessToken
+        val tokenB = tokenStore.createTokenPair(
+            integrationId = "health",
+            clientId = "legacy-B",
+            clientName = "unknown"
+        ).accessToken
+
+        val audit = RecordingAuditListener()
+
+        application {
+            configureMcpRouting(
+                registry = registry,
+                tokenStore = tokenStore,
+                deviceCodeManager = DeviceCodeManager(tokenStore = tokenStore),
+                hostname = "test.rousecontext.com",
+                integration = "health",
+                auditListener = audit,
+                unknownClientLabeler = labeler
+            )
+        }
+
+        // Exercise both clients in order A, B, A again. A must keep #1, B gets #2,
+        // A still resolves to #1 on the second session (idempotent).
+        suspend fun runToolCall(accessToken: String): String {
+            val init = client.post("/mcp") {
+                header("Authorization", "Bearer $accessToken")
+                contentType(ContentType.Application.Json)
+                setBody(initJson())
+            }
+            val sid = init.headers["Mcp-Session-Id"]!!
+            val resp = client.post("/mcp") {
+                header("Authorization", "Bearer $accessToken")
+                header("Mcp-Session-Id", sid)
+                contentType(ContentType.Application.Json)
+                setBody(toolCallJson(id = 99, message = "x"))
+            }
+            Json.parseToJsonElement(resp.bodyAsText()).jsonObject
+            return sid
+        }
+
+        runToolCall(tokenA)
+        runToolCall(tokenB)
+        runToolCall(tokenA)
+
+        assertEquals(3, audit.toolCalls.size)
+        assertEquals("Unknown (#1)", audit.toolCalls[0].clientLabel)
+        assertEquals("Unknown (#2)", audit.toolCalls[1].clientLabel)
+        assertEquals("Unknown (#1)", audit.toolCalls[2].clientLabel)
+    }
+
+    @Test
+    fun `null labeler keeps legacy fallback to literal unknown`() = testApplication {
+        // Regression guard: older tests/embed paths that don't wire a labeler
+        // should continue to see the current `"unknown"` literal in DCR
+        // without NPEing.
+        val registry = InMemoryProviderRegistry().apply {
+            register("health", EchoProvider())
+            setEnabled("health", true)
+        }
+        val tokenStore = InMemoryTokenStore()
+
+        application {
+            configureMcpRouting(
+                registry = registry,
+                tokenStore = tokenStore,
+                deviceCodeManager = DeviceCodeManager(tokenStore = tokenStore),
+                hostname = "test.rousecontext.com",
+                integration = "health"
+                // no unknownClientLabeler supplied
+            )
+        }
+
+        val resp = client.post("/register") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"redirect_uris":["https://claude.ai/cb"]}""")
+        }
+        assertEquals(HttpStatusCode.Created, resp.status)
+        val body = Json.parseToJsonElement(resp.bodyAsText()).jsonObject
+        assertEquals("unknown", body["client_name"]?.jsonPrimitive?.content)
+    }
+}


### PR DESCRIPTION
Closes #345.

## Summary

- Dynamic Client Registration without `client_name` now persists `Unknown (#1)`, `Unknown (#2)`, ... as the audit label, keyed on the DCR-assigned `client_id`. Previously every anonymous registration collapsed to the literal `"unknown"`.
- Counter is DataStore-backed, monotonic, never reset — even on token revocation. Same `client_id` always resolves to the same `N`.
- Pre-#345 rows with the literal `"unknown"` label are lazily upgraded on first MCP tool call via a new `TokenStore.upgradeClientLabel()` method. No schema migration needed.

## Files

- **New**: `UnknownClientLabeler` (interface in `:core:mcp`), `DataStoreUnknownClientLabeler` (impl in `:app`), tests for both.
- **Modified**: `McpRouting.handleRegister` (use labeler in DCR fallback), `McpRouting.handleMcp` (lazy upgrade path), `TokenStore` + `InMemoryTokenStore` + `RoomTokenStore` + `TokenDao` (add `upgradeClientLabel`), Koin wiring in `AppModule`.

## Test plan

- [x] `DataStoreUnknownClientLabelerTest` — idempotency, monotonicity, persistence across process restarts, concurrent assignment, label format.
- [x] `UnknownClientLabelerRoutingTest` — DCR with/without `client_name`, legacy `"unknown"` upgrade on tool call, stability across sessions, null-labeler back-compat.
- [x] `RoomTokenStoreTest` additions for `upgradeClientLabel` (multi-row, integration-scoped, no-op).
- [x] `./gradlew :core:mcp:jvmTest :app:testDebugUnitTest` all green.
- [x] `./gradlew ktlintCheck` clean.
- [ ] CI.

Null-labeler fallback keeps the literal `"unknown"` for embed paths / older tests that don't configure one, so the change is strictly additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)