### PR TITLE
Fix #359: Stabilize NotificationIdCounterTest against DataStore instance-lock race

### DIFF
--- a/notifications/src/test/java/com/rousecontext/notifications/NotificationIdCounterTest.kt
+++ b/notifications/src/test/java/com/rousecontext/notifications/NotificationIdCounterTest.kt
@@ -6,8 +6,10 @@ import androidx.datastore.preferences.core.Preferences
 import java.io.File
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -31,9 +33,15 @@ class NotificationIdCounterTest {
     private val scopes = mutableListOf<CoroutineScope>()
 
     @After
-    fun tearDown() {
-        scopes.forEach { it.cancel() }
+    fun tearDown() = runBlocking {
+        scopes.forEach { cancelAndJoin(it) }
         scopes.clear()
+    }
+
+    private suspend fun cancelAndJoin(scope: CoroutineScope) {
+        val job: Job = scope.coroutineContext.job
+        scope.cancel()
+        job.join()
     }
 
     @Test
@@ -59,9 +67,12 @@ class NotificationIdCounterTest {
         assertEquals(1, first.next())
         assertEquals(2, first.next())
         // Simulate process death: DataStore requires only one active instance
-        // per file, so we must release the first before opening a second
-        // pointed at the same path.
-        firstScope.cancel()
+        // per file (enforced by a static `activeFiles` set in FileStorage),
+        // so we must release the first before opening a second pointed at the
+        // same path. Cancellation is asynchronous — the connection's
+        // invokeOnCompletion handler removes the file from `activeFiles`, so
+        // we must join the scope's job before opening a new DataStore.
+        cancelAndJoin(firstScope)
 
         val secondScope = newScope()
         val second = NotificationIdCounter(storeIn(secondScope))

--- a/notifications/src/test/java/com/rousecontext/notifications/PerToolCallNotifierTest.kt
+++ b/notifications/src/test/java/com/rousecontext/notifications/PerToolCallNotifierTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -181,9 +182,16 @@ class PerToolCallNotifierTest {
         }
 
         // Simulate cold start: release the first DataStore (only one active
-        // instance per file is permitted), then open a fresh one from the
-        // same backing file as a new process would.
-        scope.cancel()
+        // instance per file is permitted, enforced by a static `activeFiles`
+        // set in FileStorage), then open a fresh one from the same backing
+        // file as a new process would. Cancellation is asynchronous — the
+        // connection's invokeOnCompletion handler removes the file from
+        // `activeFiles`, so we must join the scope's job before opening a
+        // new DataStore pointed at the same path.
+        runBlocking {
+            scope.cancel()
+            scopeJob.join()
+        }
         val coldStartScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
         try {
             val reopenedStore = PreferenceDataStoreFactory.create(scope = coldStartScope) {
@@ -225,7 +233,10 @@ class PerToolCallNotifierTest {
                 titles.any { it.contains("get_sleep") }
             )
         } finally {
-            coldStartScope.cancel()
+            runBlocking {
+                coldStartScope.cancel()
+                coldStartScope.coroutineContext.job.join()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- DataStore's `FileStorage` tracks active file paths in a static `activeFiles` set and throws `IllegalStateException` at `FileStorage.kt:52` when a second instance is created for a still-active path.
- The "cold start" tests cancelled a scope and then immediately opened a new DataStore on the same file; because scope cancellation is asynchronous, the connection's `invokeOnCompletion` cleanup (which removes the path from `activeFiles`) was racing with the next `create(...)`.
- Join the scope's `Job` after cancellation in `NotificationIdCounterTest` and `PerToolCallNotifierTest` so the cleanup has observably completed before the new DataStore is opened. No production changes.

Closes #359

## Test plan
- [x] `./gradlew :notifications:testDebugUnitTest --tests NotificationIdCounterTest --rerun-tasks` 10x green
- [x] `./gradlew :notifications:testDebugUnitTest --tests PerToolCallNotifierTest --rerun-tasks` 20x green
- [x] `./gradlew :notifications:ktlintCheck` green
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)