### PR TITLE
Fix #368: Audit stale empty-state + encode notification extras in nav route

### DIFF
--- a/app/src/main/java/com/rousecontext/app/MainActivity.kt
+++ b/app/src/main/java/com/rousecontext/app/MainActivity.kt
@@ -97,28 +97,33 @@ class MainActivity : ComponentActivity() {
          * Resolve a notification-tap [Intent] to a nav route, or null if the
          * intent does not carry a notification deep-link. Notifications from
          * the per-tool-call and session-summary notifiers carry actions like
-         * [PerToolCallNotifier.ACTION_OPEN_AUDIT_HISTORY] and extras we can
-         * convert into one of the [Routes] entries.
+         * [PerToolCallNotifier.ACTION_OPEN_AUDIT_HISTORY] and extras that are
+         * encoded into the returned [Routes.audit] route so the destination's
+         * nav args carry the scroll target / session time window through to
+         * the ViewModel.
          *
          * The mapping:
-         *  - Per-call tap / summary tap → [Routes.AUDIT_BASE] (intent extras
-         *    like scrollToCallId / start+end millis are carried through for
-         *    the destination composable to pick up).
+         *  - Per-call tap → [Routes.audit] with `scrollToCallId` populated
+         *    from [PerToolCallNotifier.EXTRA_SCROLL_TO_CALL_ID].
+         *  - Summary tap → [Routes.audit] with `startMillis`/`endMillis`
+         *    populated from
+         *    [SessionSummaryNotifier.EXTRA_START_MILLIS]/[SessionSummaryNotifier.EXTRA_END_MILLIS].
+         *  - Tap with no known extras → plain [Routes.AUDIT_BASE].
          *  - `Manage` action button with a single integration id → the
          *    integration manage route.
          *  - `Manage` action button for a mixed-integration summary → home.
          *
-         * We return a plain route string so the [RouseContextApp] start
-         * destination can be chosen without a live NavController. Intent
-         * extras are left on the Activity intent so destinations can read
-         * them via `LocalActivityIntent` / `LocalContext.findActivity()`
-         * helpers already in the codebase.
+         * Fix #368 (Bug B): previously this returned bare [Routes.AUDIT_BASE]
+         * for both notifier actions, dropping all deep-link extras. That
+         * meant per-tool-call taps never scrolled to the called row and
+         * summary taps never applied the session time window — both landed
+         * on the default TODAY filter with no scroll.
          */
         internal fun destinationForNotificationIntent(intent: Intent?): String? {
             if (intent == null) return null
             return when (intent.action) {
                 PerToolCallNotifier.ACTION_OPEN_AUDIT_HISTORY,
-                SessionSummaryNotifier.ACTION_OPEN_AUDIT_HISTORY -> Routes.AUDIT_BASE
+                SessionSummaryNotifier.ACTION_OPEN_AUDIT_HISTORY -> auditRouteFor(intent)
                 PerToolCallNotifier.ACTION_OPEN_INTEGRATION_MANAGE,
                 SessionSummaryNotifier.ACTION_OPEN_INTEGRATION_MANAGE -> {
                     val id = intent.getStringExtra(PerToolCallNotifier.EXTRA_INTEGRATION_ID)
@@ -129,5 +134,34 @@ class MainActivity : ComponentActivity() {
                 else -> null
             }
         }
+
+        /**
+         * Build an audit-history route that carries the deep-link extras
+         * (per-tool-call scroll target, summary time window) through to
+         * the destination's nav args. See [destinationForNotificationIntent].
+         */
+        private fun auditRouteFor(intent: Intent): String {
+            val scrollToCallId = intent
+                .getLongExtra(PerToolCallNotifier.EXTRA_SCROLL_TO_CALL_ID, UNSET_LONG_EXTRA)
+                .takeIf { it != UNSET_LONG_EXTRA }
+            val startMillis = intent
+                .getLongExtra(SessionSummaryNotifier.EXTRA_START_MILLIS, UNSET_LONG_EXTRA)
+                .takeIf { it != UNSET_LONG_EXTRA }
+            val endMillis = intent
+                .getLongExtra(SessionSummaryNotifier.EXTRA_END_MILLIS, UNSET_LONG_EXTRA)
+                .takeIf { it != UNSET_LONG_EXTRA }
+            return Routes.audit(
+                scrollToCallId = scrollToCallId,
+                startMillis = startMillis,
+                endMillis = endMillis
+            )
+        }
+
+        /**
+         * Sentinel for absent long extras. `-1` is legitimate for a
+         * not-yet-populated audit entry id and for pre-epoch millis, so pick
+         * a value neither will ever take on in practice.
+         */
+        private const val UNSET_LONG_EXTRA = Long.MIN_VALUE
     }
 }

--- a/app/src/main/java/com/rousecontext/app/ui/viewmodels/AuditHistoryViewModel.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/viewmodels/AuditHistoryViewModel.kt
@@ -115,6 +115,14 @@ class AuditHistoryViewModel(
         )
     }.stateIn(
         scope = viewModelScope,
+        // Fix #368: STOP_TIMEOUT_MS = 0 — tear down the upstream the moment
+        // the last subscriber leaves. A non-zero grace used to serve the
+        // stale cached `groups = []` snapshot back to a re-subscribing
+        // consumer (notification tap) even if rows had been inserted during
+        // the grace window, because Room's invalidation tracker had not yet
+        // delivered the new emission through the still-alive upstream. With
+        // a zero grace every re-subscribe runs a fresh query and the newly
+        // inserted row is returned immediately.
         started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS),
         initialValue = AuditHistoryState(isLoading = true)
     )
@@ -180,7 +188,7 @@ class AuditHistoryViewModel(
     }
 
     companion object {
-        private const val STOP_TIMEOUT_MS = 5_000L
+        private const val STOP_TIMEOUT_MS = 0L
         private val TIME_FORMAT = SimpleDateFormat("HH:mm", Locale.getDefault())
 
         internal fun dateRangeFor(filter: DateFilterOption): Pair<Long, Long> {

--- a/app/src/test/java/com/rousecontext/app/MainActivityNotificationRoutingTest.kt
+++ b/app/src/test/java/com/rousecontext/app/MainActivityNotificationRoutingTest.kt
@@ -1,0 +1,120 @@
+package com.rousecontext.app
+
+import android.content.Intent
+import com.rousecontext.app.ui.navigation.Routes
+import com.rousecontext.notifications.PerToolCallNotifier
+import com.rousecontext.notifications.SessionSummaryNotifier
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression tests for [MainActivity.destinationForNotificationIntent] — the
+ * notification-tap deep-link router. These tests pin the contract between the
+ * notification intents emitted by [PerToolCallNotifier] /
+ * [SessionSummaryNotifier] and the nav route used to pick the audit-history
+ * destination's start entry.
+ *
+ * Fix #368 (Bug B): the previous implementation dropped every intent extra,
+ * returning bare [Routes.AUDIT_BASE]. These tests encode the per-call
+ * scroll-to target and the summary session window into the route so the
+ * destination's nav args can deliver them to the ViewModel.
+ */
+@RunWith(RobolectricTestRunner::class)
+class MainActivityNotificationRoutingTest {
+
+    @Test
+    fun `per-tool-call tap with scroll-to-call extra encodes it in the audit route`() {
+        val intent = Intent().apply {
+            action = PerToolCallNotifier.ACTION_OPEN_AUDIT_HISTORY
+            putExtra(PerToolCallNotifier.EXTRA_SCROLL_TO_CALL_ID, 7042L)
+        }
+        val route = MainActivity.destinationForNotificationIntent(intent)
+        requireNotNull(route) { "expected non-null route" }
+        assertTrue(
+            "expected scrollToCallId in route, got '$route'",
+            route.contains("scrollToCallId=7042")
+        )
+    }
+
+    @Test
+    fun `session summary tap with time window encodes start and end in the audit route`() {
+        val startMillis = 1_700_000_000_000L
+        val endMillis = 1_700_000_123_000L
+        val intent = Intent().apply {
+            action = SessionSummaryNotifier.ACTION_OPEN_AUDIT_HISTORY
+            putExtra(SessionSummaryNotifier.EXTRA_START_MILLIS, startMillis)
+            putExtra(SessionSummaryNotifier.EXTRA_END_MILLIS, endMillis)
+        }
+        val route = MainActivity.destinationForNotificationIntent(intent)
+        requireNotNull(route) { "expected non-null route" }
+        assertTrue(
+            "expected startMillis in route, got '$route'",
+            route.contains("startMillis=$startMillis")
+        )
+        assertTrue(
+            "expected endMillis in route, got '$route'",
+            route.contains("endMillis=$endMillis")
+        )
+    }
+
+    @Test
+    fun `audit tap with no extras returns the bare audit route`() {
+        val intent = Intent().apply {
+            action = PerToolCallNotifier.ACTION_OPEN_AUDIT_HISTORY
+        }
+        val route = MainActivity.destinationForNotificationIntent(intent)
+        assertEquals(Routes.AUDIT_BASE, route)
+    }
+
+    @Test
+    fun `summary tap with no extras returns the bare audit route`() {
+        val intent = Intent().apply {
+            action = SessionSummaryNotifier.ACTION_OPEN_AUDIT_HISTORY
+        }
+        val route = MainActivity.destinationForNotificationIntent(intent)
+        assertEquals(Routes.AUDIT_BASE, route)
+    }
+
+    @Test
+    fun `manage action with an integration id routes to integration manage`() {
+        val intent = Intent().apply {
+            action = PerToolCallNotifier.ACTION_OPEN_INTEGRATION_MANAGE
+            putExtra(PerToolCallNotifier.EXTRA_INTEGRATION_ID, "health")
+        }
+        val route = MainActivity.destinationForNotificationIntent(intent)
+        assertEquals(Routes.integrationManage("health"), route)
+    }
+
+    @Test
+    fun `manage action with no integration id falls back to home`() {
+        val intent = Intent().apply {
+            action = PerToolCallNotifier.ACTION_OPEN_INTEGRATION_MANAGE
+        }
+        val route = MainActivity.destinationForNotificationIntent(intent)
+        assertEquals(Routes.HOME, route)
+    }
+
+    @Test
+    fun `open-home action returns the home route`() {
+        val intent = Intent().apply {
+            action = SessionSummaryNotifier.ACTION_OPEN_HOME
+        }
+        val route = MainActivity.destinationForNotificationIntent(intent)
+        assertEquals(Routes.HOME, route)
+    }
+
+    @Test
+    fun `unrelated intent returns null so launcher taps are unaffected`() {
+        val intent = Intent().apply { action = Intent.ACTION_MAIN }
+        assertNull(MainActivity.destinationForNotificationIntent(intent))
+    }
+
+    @Test
+    fun `null intent returns null`() {
+        assertNull(MainActivity.destinationForNotificationIntent(null))
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/ui/viewmodels/AuditHistoryViewModelRoomTest.kt
+++ b/app/src/test/java/com/rousecontext/app/ui/viewmodels/AuditHistoryViewModelRoomTest.kt
@@ -1,0 +1,145 @@
+package com.rousecontext.app.ui.viewmodels
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.rousecontext.notifications.audit.AuditDatabase
+import com.rousecontext.notifications.audit.AuditEntry
+import java.util.concurrent.Executors
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Regression test for GitHub issue #368.
+ *
+ * The [AuditHistoryViewModel] composes a Room [kotlinx.coroutines.flow.Flow]
+ * through `stateIn(...)`. When the user visits the audit screen (empty),
+ * navigates away, makes a tool call (which persists a new row via
+ * `RoomAuditListener`), and then taps a per-tool-call notification that
+ * deep-links back to the audit screen, the UI must not serve the stale
+ * cached `groups = []` snapshot.
+ *
+ * With the previous `SharingStarted.WhileSubscribed(5_000L)` policy, the
+ * upstream was kept alive for 5 seconds after the last subscriber left.
+ * A re-subscribe that landed inside that grace window would receive the
+ * stale empty-state value from `stateIn`'s replay cache even though the
+ * DAO had been written to in the meantime (Room's invalidation-tracker
+ * re-emission to a subscriberless shared flow is not guaranteed). The
+ * fix is to tear down the upstream the moment the last subscriber leaves,
+ * forcing a fresh DAO query on every re-subscribe.
+ *
+ * Exercises a real in-memory Room database so the test pins the actual
+ * `stateIn` lifecycle semantics rather than mocking `observeByDateRange`.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class AuditHistoryViewModelRoomTest {
+
+    private lateinit var database: AuditDatabase
+    private lateinit var testScope: CoroutineScope
+
+    @Before
+    fun setUp() {
+        // ViewModel's viewModelScope uses Dispatchers.Main.immediate. Routing
+        // Main to the IO dispatcher lets Room's reactive Flow and the VM share
+        // a real scheduler; Unconfined would trampoline emissions on the
+        // calling thread and miss cross-thread invalidation-tracker wakeups.
+        Dispatchers.setMain(Dispatchers.IO)
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        // Build the database directly so the query/transaction executor is a
+        // real thread pool. Robolectric's default scheduling can leave Room's
+        // Flow emissions unpumped, which would turn this test into a false
+        // positive. We want Room to behave like it does on a real device.
+        database = Room.inMemoryDatabaseBuilder(context, AuditDatabase::class.java)
+            .setQueryExecutor(Executors.newSingleThreadExecutor())
+            .setTransactionExecutor(Executors.newSingleThreadExecutor())
+            .build()
+        testScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    }
+
+    @After
+    fun tearDown() {
+        testScope.coroutineContext[Job]?.cancel()
+        database.close()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `re-subscribing after a row insert reflects the new row without stale empty`() {
+        runBlocking {
+            val dao = database.auditDao()
+            val vm = AuditHistoryViewModel(auditDao = dao)
+
+            // Phase 1: first subscriber lands on an empty DB and sees groups = [].
+            val firstLoaded = withTimeout(TIMEOUT_MS) {
+                vm.state
+                    .filter { !it.isLoading }
+                    .first()
+            }
+            assertTrue(
+                "Expected first emission to reflect empty DB, got ${firstLoaded.groups}",
+                firstLoaded.groups.isEmpty()
+            )
+
+            // A no-op collector warms the shared flow so stateIn has seen at
+            // least one live subscriber. Cancelling it simulates the user
+            // leaving the audit screen.
+            val warmupJob: Job = vm.state.onEach { /* observe */ }.launchIn(testScope)
+            warmupJob.cancelAndJoin()
+
+            // Phase 2: insert a row while the user is "away". This mirrors
+            // RoomAuditListener.onToolCall firing during a live MCP session
+            // that the user has since backgrounded.
+            dao.insert(
+                AuditEntry(
+                    sessionId = "session-1",
+                    toolName = "get_steps",
+                    provider = "health",
+                    timestampMillis = System.currentTimeMillis(),
+                    durationMillis = 42L,
+                    success = true,
+                    clientLabel = "Claude Desktop"
+                )
+            )
+
+            // Phase 3: re-subscribe. With a zero grace window the upstream
+            // is rebuilt and the fresh DAO query returns the new row. With
+            // the pre-fix five-second grace the stateIn served its cached
+            // empty snapshot and this waits forever (bug #368).
+            val reSubscribed = withTimeout(TIMEOUT_MS) {
+                vm.state
+                    .filter { !it.isLoading && it.groups.isNotEmpty() }
+                    .first()
+            }
+
+            assertEquals(1, reSubscribed.groups.size)
+            assertEquals(1, reSubscribed.groups[0].items.size)
+        }
+    }
+
+    private companion object {
+        // Deliberately longer than the previous STOP_TIMEOUT_MS (5s) so a
+        // stuck grace window turns into a clear failure rather than a
+        // flaky hang.
+        const val TIMEOUT_MS = 10_000L
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/ui/viewmodels/AuditHistoryViewModelTest.kt
+++ b/app/src/test/java/com/rousecontext/app/ui/viewmodels/AuditHistoryViewModelTest.kt
@@ -251,6 +251,42 @@ class AuditHistoryViewModelTest {
         }
 
     @Test
+    fun `requestScrollTo updates scrollTarget and consume clears it`() = runTest(testDispatcher) {
+        val auditDao = mockk<AuditDao> {
+            every { observeByDateRange(any(), any(), any()) } returns flowOf(emptyList())
+        }
+        val vm = AuditHistoryViewModel(auditDao)
+        assertEquals(null, vm.scrollTarget.value)
+        vm.requestScrollTo(42L)
+        assertEquals(42L, vm.scrollTarget.value)
+        vm.consumeScrollTarget()
+        assertEquals(null, vm.scrollTarget.value)
+    }
+
+    @Test
+    fun `applySessionWindow queries that window in preference to the date filter`() =
+        runTest(testDispatcher) {
+            val auditDao = mockk<AuditDao> {
+                every { observeByDateRange(any(), any(), any()) } returns flowOf(emptyList())
+            }
+            val vm = AuditHistoryViewModel(auditDao)
+            vm.state.test {
+                awaitItem() // loading
+                awaitItem() // initial empty with default date filter
+                vm.applySessionWindow(startMillis = 1_000L, endMillis = 2_000L)
+                // Let the combine/flatMapLatest pick up the new
+                // sessionWindow and actually run a DAO query against the
+                // new bounds. The state value itself doesn't change
+                // (still empty groups) so StateFlow deduplicates and no
+                // new turbine item appears — instead we check that the
+                // DAO saw the windowed query.
+                testDispatcher.scheduler.advanceUntilIdle()
+                cancelAndIgnoreRemainingEvents()
+            }
+            verify { auditDao.observeByDateRange(1_000L, 2_000L, null) }
+        }
+
+    @Test
     fun `groupByDate groups entries by calendar date`() {
         val dayOneMs = 1750032000000L // 2025-06-16 00:00 UTC
         val dayTwoMs = dayOneMs + 24 * 60 * 60 * 1000L


### PR DESCRIPTION
Closes #368.

## Bug A — stale empty state (root cause)

`AuditHistoryViewModel.state` used `SharingStarted.WhileSubscribed(5_000L)`. When the user left the audit screen and a tool call persisted a row during the 5s grace window, a re-subscribing consumer (notification tap) saw the still-cached `groups = []` snapshot because Room's invalidation-tracker re-emission through a still-alive-but-subscriberless upstream is not guaranteed.

Root cause confirmed by `AuditHistoryViewModelRoomTest` — a Robolectric + in-memory Room repro that subscribes, unsubscribes, inserts a row within the grace window, re-subscribes, and asserts the new row surfaces. That test hangs with the previous 5s grace (bug reproduced) and passes with a 0s grace (tear down + rebuild on every subscribe).

Fix: drop the grace to 0s. The audit screen isn't a hot re-entry surface, so the cost is negligible, and every re-subscribe now runs a fresh DAO query and surfaces the latest row.

## Bug B — notification extras dropped

`MainActivity.destinationForNotificationIntent` returned bare `Routes.AUDIT_BASE` for both notifier actions, discarding `EXTRA_SCROLL_TO_CALL_ID` / `EXTRA_START_MILLIS` / `EXTRA_END_MILLIS`. The destination reads nav args, not intent extras, so per-tool-call taps never scrolled and summary taps never applied the session window.

Fix: build the route via `Routes.audit(...)` populated from the intent extras, falling back to the bare `Routes.AUDIT_BASE` when no extras are present. Uses `Long.MIN_VALUE` as the "extra absent" sentinel since `-1L` is legitimate for a call id / millis.

## Test plan

- [x] `AuditHistoryViewModelRoomTest` — fails on 5s grace, passes on 0s grace (bug A repro + regression)
- [x] `MainActivityNotificationRoutingTest` — covers scroll-to-call, session window, bare route, manage-with/without-id, open-home, unrelated-intent, null-intent (bug B regression)
- [x] `AuditHistoryViewModelTest` — new coverage for `requestScrollTo` / `consumeScrollTarget` lifecycle and `applySessionWindow` overriding the date filter in the DAO query
- [x] `./gradlew :app:testDebugUnitTest :notifications:testDebugUnitTest` — all green
- [x] `./gradlew ktlintCheck detekt` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)