### PR TITLE
Lower integration-manage Recent Activity cap 20 -> 5

### DIFF
--- a/app/src/main/java/com/rousecontext/app/ui/viewmodels/IntegrationManageViewModel.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/viewmodels/IntegrationManageViewModel.kt
@@ -152,7 +152,7 @@ class IntegrationManageViewModel(
     }
 
     companion object {
-        private const val RECENT_LIMIT = 20
+        private const val RECENT_LIMIT = 5
         private const val STOP_TIMEOUT_MS = 5_000L
         private val DATE_FORMAT = SimpleDateFormat("MMM d, yyyy", Locale.getDefault())
     }


### PR DESCRIPTION
Follow-up to #370. The unified \`ToolCallRow\` widget is now shared across dashboard / integration-manage / audit history (#371). Integration-manage was still capping at 20 rows while the dashboard caps at 5; that mismatch made the card read as a full list rather than a teaser.

Drops \`RECENT_LIMIT\` from 20 to 5 so both teaser surfaces behave the same. "View all" still leads to the full audit screen (which now defaults to the last 7 days per #370).

No test or UI change beyond the constant.