### PR TITLE
Fix #374: Stabilize DataStoreUnknownClientLabelerTest against DataStore instance-lock race

### DIFF
--- a/app/src/test/java/com/rousecontext/app/token/DataStoreUnknownClientLabelerTest.kt
+++ b/app/src/test/java/com/rousecontext/app/token/DataStoreUnknownClientLabelerTest.kt
@@ -6,10 +6,12 @@ import androidx.datastore.preferences.core.Preferences
 import java.io.File
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.job
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -41,9 +43,15 @@ class DataStoreUnknownClientLabelerTest {
     private val scopes = mutableListOf<CoroutineScope>()
 
     @After
-    fun tearDown() {
-        scopes.forEach { it.cancel() }
+    fun tearDown() = runBlocking {
+        scopes.forEach { cancelAndJoin(it) }
         scopes.clear()
+    }
+
+    private suspend fun cancelAndJoin(scope: CoroutineScope) {
+        val job: Job = scope.coroutineContext.job
+        scope.cancel()
+        job.join()
     }
 
     @Test
@@ -102,9 +110,12 @@ class DataStoreUnknownClientLabelerTest {
             assertEquals("Unknown (#1)", first.labelFor("client-A"))
             assertEquals("Unknown (#2)", first.labelFor("client-B"))
             // Simulate process death: DataStore requires only one active instance
-            // per file, so release the first before opening a second pointed at
-            // the same path.
-            firstScope.cancel()
+            // per file (enforced by a static `activeFiles` set in FileStorage),
+            // so release the first before opening a second pointed at the same
+            // path. Cancellation is asynchronous — the connection's
+            // invokeOnCompletion handler removes the file from `activeFiles`,
+            // so we must join the scope's job before opening a new DataStore.
+            cancelAndJoin(firstScope)
 
             val secondScope = newScope()
             val second = DataStoreUnknownClientLabeler(storeIn(secondScope))


### PR DESCRIPTION
## Summary

- Closes #374
- Same pattern as #359/#360: cancellation is asynchronous, so opening a second DataStore on the same file right after `scope.cancel()` races with the connection's `invokeOnCompletion` handler that removes the file from `FileStorage.activeFiles`, resulting in `IllegalStateException` at `FileStorage.kt:52`.
- Added a `cancelAndJoin(scope)` helper in the test, used in `@After` teardown and at the "second labeler" seam that simulates process restart. Test-only; labeler production code untouched.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "*DataStoreUnknownClientLabelerTest*" --rerun-tasks` — 20/20 consecutive passes locally
- [x] `./gradlew ktlintCheck detekt` — clean
- [ ] CI green

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>