### PR TITLE
Fix #381: Privacy page + debug-only Renew Cert button in Settings

### DIFF
--- a/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/SettingsDestination.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/SettingsDestination.kt
@@ -1,11 +1,14 @@
 package com.rousecontext.app.ui.navigation.destinations
 
 import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
@@ -20,8 +23,12 @@ import com.rousecontext.app.ui.navigation.Routes
 import com.rousecontext.app.ui.navigation.tabSlideDirection
 import com.rousecontext.app.ui.screens.SettingsContent
 import com.rousecontext.app.ui.viewmodels.SettingsViewModel
+import com.rousecontext.work.CertRenewalScheduler
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
+
+/** User-facing privacy page on the Jekyll docs site (see `docs/user/privacy.md`). */
+internal const val PRIVACY_URL = "https://rousecontext.com/privacy"
 
 @Suppress("UNUSED_PARAMETER")
 fun NavGraphBuilder.settingsDestination(navController: NavController) {
@@ -50,35 +57,53 @@ fun NavGraphBuilder.settingsDestination(navController: NavController) {
             title = stringResource(R.string.destination_title_settings),
             showBottomBar = true
         )
-        val viewModel: SettingsViewModel = koinViewModel()
-        val state by viewModel.state.collectAsState()
-        val showAll by viewModel.showAllMcpMessages.collectAsState()
-        val bugReportUriBuilder: BugReportUriBuilder = koinInject()
-        val settingsContext = LocalContext.current
-        SettingsContent(
-            state = state.copy(showAllMcpMessages = showAll),
-            onIdleTimeoutChanged = viewModel::setIdleTimeout,
-            onPostSessionModeChanged =
-            viewModel::setPostSessionMode,
-            onShowAllMcpMessagesChanged =
-            viewModel::setShowAllMcpMessages,
-            onThemeModeChanged = viewModel::setThemeMode,
-            onSecurityCheckIntervalChanged =
-            viewModel::setSecurityCheckInterval,
-            onGenerateNewAddress = viewModel::rotateSecret,
-            onAcknowledgeAlert = viewModel::acknowledgeAlert,
-            onReportBug = {
-                val uri = bugReportUriBuilder.build()
-                val intent = Intent(Intent.ACTION_VIEW, uri).apply {
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                }
-                try {
-                    settingsContext.startActivity(intent)
-                } catch (_: ActivityNotFoundException) {
-                    // No browser available; silently ignore.
-                }
-            },
-            onRetry = viewModel::refresh
-        )
+        SettingsDestinationContent()
+    }
+}
+
+/**
+ * Composable body of [settingsDestination]. Extracted so the top-level
+ * function stays inside detekt's `LongMethod` limit while still wiring the
+ * view-model, bug-report URI builder, privacy page link, and debug-only
+ * "Renew cert now" callback into [SettingsContent].
+ */
+@Composable
+private fun SettingsDestinationContent() {
+    val viewModel: SettingsViewModel = koinViewModel()
+    val state by viewModel.state.collectAsState()
+    val showAll by viewModel.showAllMcpMessages.collectAsState()
+    val bugReportUriBuilder: BugReportUriBuilder = koinInject()
+    val settingsContext = LocalContext.current
+    SettingsContent(
+        state = state.copy(showAllMcpMessages = showAll),
+        onIdleTimeoutChanged = viewModel::setIdleTimeout,
+        onPostSessionModeChanged = viewModel::setPostSessionMode,
+        onShowAllMcpMessagesChanged = viewModel::setShowAllMcpMessages,
+        onThemeModeChanged = viewModel::setThemeMode,
+        onSecurityCheckIntervalChanged = viewModel::setSecurityCheckInterval,
+        onGenerateNewAddress = viewModel::rotateSecret,
+        onAcknowledgeAlert = viewModel::acknowledgeAlert,
+        onReportBug = { openUriSafely(settingsContext, bugReportUriBuilder.build()) },
+        onOpenPrivacy = { openUriSafely(settingsContext, Uri.parse(PRIVACY_URL)) },
+        // Debug-only button (gated in SettingsContent via BuildConfig.DEBUG).
+        // Route through the scheduler so WorkManager wiring stays in :work.
+        onRenewCertNow = { CertRenewalScheduler.enqueueOneShot(settingsContext) },
+        onRetry = viewModel::refresh
+    )
+}
+
+/**
+ * Fire an `ACTION_VIEW` intent, swallowing [ActivityNotFoundException] when
+ * the device has no browser installed. Shared by the Report Bug and Privacy
+ * rows so their wiring stays declarative.
+ */
+private fun openUriSafely(context: Context, uri: Uri) {
+    val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    try {
+        context.startActivity(intent)
+    } catch (_: ActivityNotFoundException) {
+        // No browser available; silently ignore.
     }
 }

--- a/app/src/main/java/com/rousecontext/app/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/screens/SettingsScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.rousecontext.app.BuildConfig
 import com.rousecontext.app.R
 import com.rousecontext.app.ui.components.ErrorState
 import com.rousecontext.app.ui.components.LoadingIndicator
@@ -180,6 +181,9 @@ fun SettingsContent(
     onFixBatteryOptimization: () -> Unit = {},
     onAcknowledgeAlert: () -> Unit = {},
     onReportBug: () -> Unit = {},
+    onOpenPrivacy: () -> Unit = {},
+    onRenewCertNow: () -> Unit = {},
+    showDeveloperSection: Boolean = BuildConfig.DEBUG,
     onRetry: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
@@ -432,6 +436,33 @@ fun SettingsContent(
                     stringResource(R.string.screen_settings_license),
                     style = MaterialTheme.typography.bodyMedium
                 )
+                HorizontalDivider(
+                    modifier = Modifier.padding(vertical = dimensionResource(R.dimen.spacing_sm)),
+                    color = MaterialTheme.colorScheme.outlineVariant
+                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = onOpenPrivacy),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.screen_settings_privacy),
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                        Text(
+                            text = stringResource(R.string.screen_settings_privacy_subtitle),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
 
@@ -473,7 +504,67 @@ fun SettingsContent(
             }
         }
 
+        if (showDeveloperSection) {
+            Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_lg)))
+            DeveloperSection(onRenewCertNow = onRenewCertNow)
+        }
+
         Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_xl)))
+    }
+}
+
+/**
+ * Developer-only tools. Compiled into the UI only when [SettingsContent] is
+ * rendered with `showDeveloperSection = true`, which in production wiring is
+ * gated on [BuildConfig.DEBUG]. Intentionally minimal — this is not meant to
+ * ship to release users, so it does not get the full polish of the rest of
+ * Settings.
+ *
+ * The one-shot renewal goes through [com.rousecontext.work.CertRenewalScheduler]
+ * so the scheduler owns the `WorkManager` coupling instead of the UI layer.
+ */
+@Composable
+private fun DeveloperSection(onRenewCertNow: () -> Unit) {
+    SectionHeader(stringResource(R.string.screen_settings_section_developer))
+    SettingsSectionCard {
+        Column(modifier = Modifier.padding(dimensionResource(R.dimen.spacing_lg))) {
+            var enqueuedLabelVisible by remember { mutableStateOf(false) }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.screen_settings_renew_cert_now),
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                    Text(
+                        text = stringResource(R.string.screen_settings_renew_cert_subtitle),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                TextButton(
+                    onClick = {
+                        onRenewCertNow()
+                        enqueuedLabelVisible = true
+                    },
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.primary
+                    )
+                ) {
+                    Text(stringResource(R.string.screen_settings_renew_cert_now))
+                }
+            }
+            if (enqueuedLabelVisible) {
+                Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_sm)))
+                Text(
+                    text = stringResource(R.string.screen_settings_renew_cert_enqueued),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
     }
 }
 
@@ -494,6 +585,9 @@ fun SettingsScreen(
     onFixBatteryOptimization: () -> Unit = {},
     onAcknowledgeAlert: () -> Unit = {},
     onReportBug: () -> Unit = {},
+    onOpenPrivacy: () -> Unit = {},
+    onRenewCertNow: () -> Unit = {},
+    showDeveloperSection: Boolean = BuildConfig.DEBUG,
     onRetry: () -> Unit = {},
     onTabSelected: (Int) -> Unit = {}
 ) {
@@ -564,6 +658,9 @@ fun SettingsScreen(
             onFixBatteryOptimization = onFixBatteryOptimization,
             onAcknowledgeAlert = onAcknowledgeAlert,
             onReportBug = onReportBug,
+            onOpenPrivacy = onOpenPrivacy,
+            onRenewCertNow = onRenewCertNow,
+            showDeveloperSection = showDeveloperSection,
             onRetry = onRetry,
             modifier = Modifier.padding(padding)
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,6 +214,12 @@
     <string name="screen_settings_section_about">About</string>
     <string name="screen_settings_version">Version %1$s</string>
     <string name="screen_settings_license">Apache 2.0 License</string>
+    <string name="screen_settings_privacy">Privacy</string>
+    <string name="screen_settings_privacy_subtitle">What data leaves your phone and what the relay sees</string>
+    <string name="screen_settings_section_developer">Developer</string>
+    <string name="screen_settings_renew_cert_now">Renew cert now</string>
+    <string name="screen_settings_renew_cert_subtitle">Enqueue a one-shot cert renewal via WorkManager</string>
+    <string name="screen_settings_renew_cert_enqueued">Renewal enqueued</string>
     <string name="screen_settings_section_support">Support</string>
     <string name="screen_settings_support_privacy_note">Your device model and app state are included. Personal integration data is not.</string>
     <string name="screen_settings_report_bug">Report a bug</string>

--- a/app/src/test/java/com/rousecontext/app/ui/screens/SettingsPrivacyRowTest.kt
+++ b/app/src/test/java/com/rousecontext/app/ui/screens/SettingsPrivacyRowTest.kt
@@ -1,0 +1,109 @@
+package com.rousecontext.app.ui.screens
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import com.rousecontext.app.ui.theme.RouseContextTheme
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Compose test for the Privacy row and the debug-only "Renew cert now" button
+ * added in issue #381. Covers:
+ *
+ * 1. The Privacy row renders in the About section and fires its callback when tapped.
+ * 2. The developer section only renders when `showDeveloperSection = true`.
+ * 3. Tapping "Renew cert now" fires the `onRenewCertNow` callback and surfaces
+ *    the "Renewal enqueued" confirmation text.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(
+    sdk = [33],
+    qualifiers = "w400dp-h800dp-xxhdpi",
+    application = com.rousecontext.app.TestApplication::class
+)
+class SettingsPrivacyRowTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun privacyRow_tapFiresCallback() {
+        var privacyTaps = 0
+        composeRule.setContent {
+            RouseContextTheme(darkTheme = true) {
+                SettingsContent(
+                    showDeveloperSection = false,
+                    onOpenPrivacy = { privacyTaps++ }
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Privacy")
+            .performScrollTo()
+            .assertIsDisplayed()
+            .performClick()
+
+        assertEquals(
+            "Tapping the Privacy row must fire onOpenPrivacy exactly once",
+            1,
+            privacyTaps
+        )
+    }
+
+    @Test
+    fun developerSection_hiddenWhenFlagOff() {
+        composeRule.setContent {
+            RouseContextTheme(darkTheme = true) {
+                SettingsContent(showDeveloperSection = false)
+            }
+        }
+
+        // Scroll to the bottom so a section rendered after Support would be
+        // visible if it existed.
+        composeRule.onNodeWithText("Privacy").performScrollTo()
+
+        val hasDeveloperHeader = runCatching {
+            composeRule.onNodeWithText("Developer").assertIsDisplayed()
+        }.isSuccess
+        assertFalse(
+            "Developer section must not render when showDeveloperSection = false",
+            hasDeveloperHeader
+        )
+    }
+
+    @Test
+    fun renewCertButton_tapFiresCallbackAndShowsEnqueuedLabel() {
+        var renewTaps = 0
+        composeRule.setContent {
+            RouseContextTheme(darkTheme = true) {
+                SettingsContent(
+                    showDeveloperSection = true,
+                    onRenewCertNow = { renewTaps++ }
+                )
+            }
+        }
+
+        // "Renew cert now" is rendered twice: once as the row title label and
+        // once as the TextButton's own label. Tap the TextButton (the second,
+        // clickable match).
+        val buttonMatches = composeRule.onAllNodesWithText("Renew cert now")
+        buttonMatches[1].performScrollTo().performClick()
+
+        assertTrue("Tapping Renew cert now must fire onRenewCertNow", renewTaps >= 1)
+        composeRule.onNodeWithText("Renewal enqueued")
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/ui/screenshots/ScreenScreenshotTest.kt
+++ b/app/src/test/java/com/rousecontext/app/ui/screenshots/ScreenScreenshotTest.kt
@@ -714,11 +714,19 @@ class ScreenScreenshotTest {
     // Settings
     // =========================================================================
 
+    // Goldens render the release-shape Settings layout: the developer section
+    // (debug-only "Renew cert now" button) is suppressed so a signed release
+    // build and the recorded golden match. Explicit override to keep the
+    // golden-diff surface tight regardless of BuildConfig.DEBUG in tests.
     @Test
-    fun settingsDark() = captureDark("37_settings") { SettingsScreen() }
+    fun settingsDark() = captureDark("37_settings") {
+        SettingsScreen(showDeveloperSection = false)
+    }
 
     @Test
-    fun settingsLight() = captureLight("37_settings") { SettingsScreen() }
+    fun settingsLight() = captureLight("37_settings") {
+        SettingsScreen(showDeveloperSection = false)
+    }
 
     @Test
     fun settingsNoBatteryWarningDark() = captureDark("38_settings_no_battery") {
@@ -726,7 +734,8 @@ class ScreenScreenshotTest {
             state = SettingsState(
                 showBatteryWarning = false,
                 batteryOptimizationExempt = true
-            )
+            ),
+            showDeveloperSection = false
         )
     }
 
@@ -736,38 +745,57 @@ class ScreenScreenshotTest {
             state = SettingsState(
                 showBatteryWarning = false,
                 batteryOptimizationExempt = true
-            )
+            ),
+            showDeveloperSection = false
         )
     }
 
     @Test
     fun settingsTrustVerifiedDark() = captureDark("39_settings_trust_verified") {
-        SettingsScreen(state = settingsTrustState(TrustOverallStatus.VERIFIED, "verified"))
+        SettingsScreen(
+            state = settingsTrustState(TrustOverallStatus.VERIFIED, "verified"),
+            showDeveloperSection = false
+        )
     }
 
     @Test
     fun settingsTrustVerifiedLight() = captureLight("39_settings_trust_verified") {
-        SettingsScreen(state = settingsTrustState(TrustOverallStatus.VERIFIED, "verified"))
+        SettingsScreen(
+            state = settingsTrustState(TrustOverallStatus.VERIFIED, "verified"),
+            showDeveloperSection = false
+        )
     }
 
     @Test
     fun settingsTrustWarningDark() = captureDark("40_settings_trust_warning") {
-        SettingsScreen(state = settingsTrustState(TrustOverallStatus.WARNING, "warning"))
+        SettingsScreen(
+            state = settingsTrustState(TrustOverallStatus.WARNING, "warning"),
+            showDeveloperSection = false
+        )
     }
 
     @Test
     fun settingsTrustWarningLight() = captureLight("40_settings_trust_warning") {
-        SettingsScreen(state = settingsTrustState(TrustOverallStatus.WARNING, "warning"))
+        SettingsScreen(
+            state = settingsTrustState(TrustOverallStatus.WARNING, "warning"),
+            showDeveloperSection = false
+        )
     }
 
     @Test
     fun settingsTrustAlertDark() = captureDark("41_settings_trust_alert") {
-        SettingsScreen(state = settingsTrustState(TrustOverallStatus.ALERT, "alert"))
+        SettingsScreen(
+            state = settingsTrustState(TrustOverallStatus.ALERT, "alert"),
+            showDeveloperSection = false
+        )
     }
 
     @Test
     fun settingsTrustAlertLight() = captureLight("41_settings_trust_alert") {
-        SettingsScreen(state = settingsTrustState(TrustOverallStatus.ALERT, "alert"))
+        SettingsScreen(
+            state = settingsTrustState(TrustOverallStatus.ALERT, "alert"),
+            showDeveloperSection = false
+        )
     }
 
     // Isolated trust-card renderings for the user-facing docs site. Each

--- a/work/src/main/kotlin/com/rousecontext/work/CertRenewalScheduler.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/CertRenewalScheduler.kt
@@ -27,19 +27,25 @@ import java.util.concurrent.TimeUnit
  */
 object CertRenewalScheduler {
 
+    /**
+     * Shared constraints for every renewal request. The cert MUST be renewed even if the
+     * device never charges inside the window, so charging is NOT required; battery-not-low
+     * is required so a dying phone doesn't spin on a doomed renewal.
+     */
+    private fun renewalConstraints(): Constraints = Constraints.Builder()
+        .setRequiredNetworkType(NetworkType.CONNECTED)
+        .setRequiresBatteryNotLow(true)
+        .build()
+
     /** Enqueue the periodic daily renewal check. Safe to call every app startup. */
     fun enqueuePeriodic(context: Context) {
-        val constraints = Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.CONNECTED)
-            .setRequiresBatteryNotLow(true)
-            .build()
         val request = PeriodicWorkRequestBuilder<CertRenewalWorker>(
             PERIODIC_INTERVAL_HOURS,
             TimeUnit.HOURS,
             PERIODIC_FLEX_HOURS,
             TimeUnit.HOURS
         )
-            .setConstraints(constraints)
+            .setConstraints(renewalConstraints())
             .setBackoffCriteria(BackoffPolicy.LINEAR, BACKOFF_MINUTES, TimeUnit.MINUTES)
             .build()
         WorkManager.getInstance(context).enqueueUniquePeriodicWork(
@@ -54,16 +60,34 @@ object CertRenewalScheduler {
      * provides a specific `retry_after`.
      */
     fun enqueueDelayed(context: Context, delaySeconds: Long) {
-        val constraints = Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.CONNECTED)
-            .setRequiresBatteryNotLow(true)
-            .build()
         val request = OneTimeWorkRequestBuilder<CertRenewalWorker>()
             .setInitialDelay(delaySeconds, TimeUnit.SECONDS)
-            .setConstraints(constraints)
+            .setConstraints(renewalConstraints())
             .build()
         WorkManager.getInstance(context).enqueueUniqueWork(
             CertRenewalWorker.WORK_NAME_DELAYED,
+            ExistingWorkPolicy.REPLACE,
+            request
+        )
+    }
+
+    /**
+     * Enqueue a one-time renewal immediately (no delay). Used by the debug-only
+     * "Renew cert now" Settings button (issue #381).
+     *
+     * Distinct unique-work slot from [CertRenewalWorker.WORK_NAME] and
+     * [CertRenewalWorker.WORK_NAME_DELAYED] so it does not clobber the periodic
+     * schedule or the rate-limit reschedule. Uses [ExistingWorkPolicy.REPLACE]
+     * so repeated taps collapse to a single pending request instead of
+     * enqueueing a backlog of identical requests.
+     */
+    fun enqueueOneShot(context: Context) {
+        val request = OneTimeWorkRequestBuilder<CertRenewalWorker>()
+            .setConstraints(renewalConstraints())
+            .setBackoffCriteria(BackoffPolicy.LINEAR, BACKOFF_MINUTES, TimeUnit.MINUTES)
+            .build()
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            WORK_NAME_ONE_SHOT,
             ExistingWorkPolicy.REPLACE,
             request
         )
@@ -102,12 +126,8 @@ object CertRenewalScheduler {
         if (millisUntilExpiry > thresholdMillis) {
             return false
         }
-        val constraints = Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.CONNECTED)
-            .setRequiresBatteryNotLow(true)
-            .build()
         val request = OneTimeWorkRequestBuilder<CertRenewalWorker>()
-            .setConstraints(constraints)
+            .setConstraints(renewalConstraints())
             .setBackoffCriteria(BackoffPolicy.LINEAR, BACKOFF_MINUTES, TimeUnit.MINUTES)
             .build()
         WorkManager.getInstance(context).enqueueUniqueWork(
@@ -131,6 +151,13 @@ object CertRenewalScheduler {
      * regress the scheduling contracts covered by #277.
      */
     const val WORK_NAME_IMMEDIATE = "cert_renewal_immediate"
+
+    /**
+     * Unique-work slot for the debug "Renew cert now" Settings button (issue #381).
+     * Distinct from the periodic, delayed, and immediate (near-expiry) slots so
+     * the manual request has its own lifecycle and REPLACE semantics.
+     */
+    const val WORK_NAME_ONE_SHOT = "cert_renewal_one_shot"
 
     /** Mirrors [CertRenewalWorker.DEFAULT_RENEWAL_WINDOW_DAYS] in millis. */
     const val DEFAULT_IMMEDIATE_THRESHOLD_MS =

--- a/work/src/test/kotlin/com/rousecontext/work/CertRenewalSchedulerTest.kt
+++ b/work/src/test/kotlin/com/rousecontext/work/CertRenewalSchedulerTest.kt
@@ -179,6 +179,68 @@ class CertRenewalSchedulerTest {
             )
         }
 
+    @Test
+    fun `enqueueOneShot adds a one-time request to the one-shot slot`() = runBlocking {
+        CertRenewalScheduler.enqueueOneShot(context)
+
+        val infos = workManager
+            .getWorkInfosForUniqueWork(CertRenewalScheduler.WORK_NAME_ONE_SHOT)
+            .get()
+        assertEquals(1, infos.size)
+        assertEquals(WorkInfo.State.ENQUEUED, infos.single().state)
+    }
+
+    @Test
+    fun `enqueueOneShot REPLACE collapses repeated taps to one pending request`() = runBlocking {
+        CertRenewalScheduler.enqueueOneShot(context)
+        val firstId = workManager
+            .getWorkInfosForUniqueWork(CertRenewalScheduler.WORK_NAME_ONE_SHOT)
+            .get()
+            .single()
+            .id
+
+        // User spams the "Renew cert now" button. REPLACE means the second request
+        // supersedes the first rather than queueing a backlog.
+        CertRenewalScheduler.enqueueOneShot(context)
+        val infos = workManager
+            .getWorkInfosForUniqueWork(CertRenewalScheduler.WORK_NAME_ONE_SHOT)
+            .get()
+
+        assertEquals(
+            "REPLACE must leave exactly one request in the slot after a re-enqueue",
+            1,
+            infos.size
+        )
+        assertTrue(
+            "REPLACE must produce a new work id, not preserve the original",
+            firstId != infos.single().id
+        )
+    }
+
+    @Test
+    fun `enqueueOneShot slot is distinct from periodic and immediate slots`() = runBlocking {
+        val now = 1_000_000L
+        val store = SchedulerFakeCertificateStore(expiry = now - MS_PER_DAY)
+
+        CertRenewalScheduler.enqueuePeriodic(context)
+        CertRenewalScheduler.enqueueImmediateIfExpiring(context, store, now = now)
+        CertRenewalScheduler.enqueueOneShot(context)
+
+        val periodic = workManager
+            .getWorkInfosForUniqueWork(CertRenewalWorker.WORK_NAME)
+            .get()
+        val immediate = workManager
+            .getWorkInfosForUniqueWork(CertRenewalScheduler.WORK_NAME_IMMEDIATE)
+            .get()
+        val oneShot = workManager
+            .getWorkInfosForUniqueWork(CertRenewalScheduler.WORK_NAME_ONE_SHOT)
+            .get()
+
+        assertEquals(1, periodic.size)
+        assertEquals(1, immediate.size)
+        assertEquals(1, oneShot.size)
+    }
+
     private companion object {
         const val MS_PER_DAY = 24L * 60L * 60L * 1000L
     }


### PR DESCRIPTION
Part of #378. Closes #381.

## Summary

- Wires an in-app **Privacy** row in Settings → About that opens `https://rousecontext.com/privacy` via `Intent.ACTION_VIEW`. The docs page already exists at `docs/user/privacy.md`; this PR just adds the link + string resource.
- Adds a debug-only **Developer → Renew cert now** button that enqueues a one-shot cert renewal through a new `CertRenewalScheduler.enqueueOneShot` entry point. Gated on `BuildConfig.DEBUG` so it is not rendered for release users.
- Extracts a shared `renewalConstraints()` helper in `CertRenewalScheduler` so the periodic, delayed, expiring-immediate, and one-shot code paths all share the same `NetworkType.CONNECTED + requiresBatteryNotLow` constraints instead of duplicating the builder three times.
- Uses `ExistingWorkPolicy.REPLACE` on the one-shot slot so spammed button taps collapse to a single pending request rather than queueing a backlog.

## Test plan

- [x] `:work:testDebugUnitTest` — new `CertRenewalSchedulerTest` cases cover enqueue, REPLACE-on-re-enqueue, and slot distinctness from the periodic and immediate slots.
- [x] `:app:testDebugUnitTest` — new `SettingsPrivacyRowTest` asserts Privacy row renders + fires callback, Developer section hidden when flag off, Renew button fires callback + shows "Renewal enqueued" confirmation.
- [x] `:app:verifyRoborazziDebug` — Settings goldens remain pixel-identical (the new rows render below the 800dp test viewport, so visible surface is unchanged). Screenshot tests force `showDeveloperSection = false` explicitly so release-shape and test-shape always match.
- [x] `ktlintCheck` + `detekt` — clean, no new baseline entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)