### PR TITLE
Fix #392: Share OnboardingViewModel across onboarding flow

### DIFF
--- a/app/src/main/java/com/rousecontext/app/MainActivity.kt
+++ b/app/src/main/java/com/rousecontext/app/MainActivity.kt
@@ -53,7 +53,10 @@ class MainActivity : ComponentActivity() {
             val hasSubdomain = certStore.getSubdomain() != null
             val notificationDestination = destinationForNotificationIntent(intent)
             startDestination = when {
-                !hasSubdomain -> Routes.ONBOARDING
+                // ONBOARDING_BASE (not the full arg pattern) is the concrete
+                // route; NavHost resolves it to the composable registered
+                // with the optional ?autostart={autostart} arg (#392).
+                !hasSubdomain -> Routes.ONBOARDING_BASE
                 notificationDestination != null -> notificationDestination
                 else -> Routes.HOME
             }

--- a/app/src/main/java/com/rousecontext/app/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/navigation/AppNavigation.kt
@@ -38,7 +38,21 @@ import com.rousecontext.app.ui.navigation.destinations.usageSetupDestination
 import com.rousecontext.app.ui.screens.SetupMode
 
 object Routes {
-    const val ONBOARDING = "onboarding"
+    // Full route pattern used to register the onboarding composable. The
+    // optional [AUTOSTART_ARG] lets NotificationPreferences re-route here and
+    // trigger registration on the *same* VM that hosts the destination. Prior
+    // to #392 NotificationPreferences fetched its own OnboardingViewModel,
+    // kicked off registration, and navigated here, which created a second
+    // VM that never observed the flow completing (stuck on Welcome).
+    const val ONBOARDING = "onboarding?autostart={autostart}"
+
+    /**
+     * Base route (no args) used as the nav start destination and as the
+     * [popUpTo] target. NavHost resolves `"onboarding"` to the composable
+     * registered at [ONBOARDING] because [AUTOSTART_ARG] is nullable.
+     */
+    const val ONBOARDING_BASE = "onboarding"
+    const val AUTOSTART_ARG = "autostart"
     const val NOTIFICATION_PREFERENCES = "onboarding/notification_preferences"
     const val HOME = "home"
     const val AUDIT = "audit?provider={provider}&scrollToCallId={scrollToCallId}"
@@ -55,6 +69,13 @@ object Routes {
     const val AUTH_APPROVAL = "auth_approval"
     const val ALL_CLIENTS = "all_clients/{integrationId}"
     const val AUDIT_DETAIL = "audit_detail/{entryId}"
+
+    /**
+     * Concrete onboarding route that drives the destination to start
+     * registration immediately on enter. Used by NotificationPreferences
+     * Continue (#392) so the VM owning the destination observes the flow.
+     */
+    const val ONBOARDING_AUTOSTART = "onboarding?autostart=true"
 
     fun allClients(integrationId: String): String = "all_clients/$integrationId"
     fun audit(provider: String? = null, scrollToCallId: Long? = null): String {
@@ -76,6 +97,7 @@ object Routes {
 
 private val ONBOARDING_ROUTES = setOf(
     Routes.ONBOARDING,
+    Routes.ONBOARDING_BASE,
     Routes.NOTIFICATION_PREFERENCES
 )
 

--- a/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/NotificationPreferencesDestination.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/NotificationPreferencesDestination.kt
@@ -14,7 +14,6 @@ import com.rousecontext.app.ui.navigation.ConfigureNavBar
 import com.rousecontext.app.ui.navigation.Routes
 import com.rousecontext.app.ui.screens.NotificationPreferencesScreen
 import com.rousecontext.app.ui.viewmodels.NotificationPreferencesViewModel
-import com.rousecontext.app.ui.viewmodels.OnboardingViewModel
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
@@ -27,20 +26,19 @@ fun NavGraphBuilder.notificationPreferencesDestination(navController: NavControl
         )
         val prefsViewModel: NotificationPreferencesViewModel =
             koinViewModel()
-        val onboardingViewModel: OnboardingViewModel =
-            koinViewModel()
         val state by prefsViewModel.state.collectAsState()
         val refresher: NotificationPermissionRefresher =
             koinInject()
+        // #392: Do NOT call startOnboarding() from this destination — it
+        // would run on a NotificationPreferences-scoped OnboardingViewModel
+        // that gets discarded when we navigate away, leaving the
+        // freshly-created destination VM to read a still-empty subdomain
+        // and show Welcome forever. Instead, route to the onboarding
+        // destination with autostart=true so the VM that owns that
+        // destination kicks off AND observes the flow.
         val continueToHome = {
             prefsViewModel.persistSelection()
-            // Kick off relay/FCM registration + ACME cert provisioning now
-            // that the user has completed the one-time onboarding
-            // preferences. Route back to the onboarding destination, which
-            // shows a progress UI during the several-second ACME hop and
-            // only navigates to Home once the full flow succeeds (#389).
-            onboardingViewModel.startOnboarding()
-            navController.navigate(Routes.ONBOARDING) {
+            navController.navigate(Routes.ONBOARDING_AUTOSTART) {
                 popUpTo(Routes.ONBOARDING) {
                     inclusive = true
                 }

--- a/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/OnboardingDestination.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/OnboardingDestination.kt
@@ -6,7 +6,9 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.rousecontext.app.ui.navigation.ConfigureNavBar
 import com.rousecontext.app.ui.navigation.Routes
 import com.rousecontext.app.ui.screens.SettingUpContent
@@ -16,10 +18,20 @@ import com.rousecontext.app.ui.screens.WelcomeScreen
 import com.rousecontext.app.ui.viewmodels.OnboardingState
 import com.rousecontext.app.ui.viewmodels.OnboardingStep
 import com.rousecontext.app.ui.viewmodels.OnboardingViewModel
+import kotlinx.coroutines.flow.StateFlow
 import org.koin.androidx.compose.koinViewModel
 
 fun NavGraphBuilder.onboardingDestination(navController: NavController) {
-    composable(Routes.ONBOARDING) {
+    composable(
+        route = Routes.ONBOARDING,
+        arguments = listOf(
+            navArgument(Routes.AUTOSTART_ARG) {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = null
+            }
+        )
+    ) { backStackEntry ->
         ConfigureNavBar(
             title = "",
             showTopBar = false,
@@ -27,14 +39,27 @@ fun NavGraphBuilder.onboardingDestination(navController: NavController) {
         )
         val onboardingViewModel: OnboardingViewModel =
             koinViewModel()
-        val state by onboardingViewModel.state.collectAsState()
+        // #392: Fresh-install onboarding used to fail because
+        // NotificationPreferences called startOnboarding() on its own
+        // VM (scoped to its own NavBackStackEntry), then navigated here
+        // which created a brand-new VM that never observed the in-flight
+        // flow. With [Routes.onboardingAutostart] the Continue button
+        // instead navigates us back with autostart=true and THIS
+        // destination's VM drives the flow — so the same VM that kicks
+        // off registration is also the one observing it finish and
+        // navigating to Home.
+        val autostart = backStackEntry.arguments
+            ?.getString(Routes.AUTOSTART_ARG) == "true"
 
-        LaunchedEffect(state) {
-            // Only navigate to Home once the device is fully onboarded
-            // (subdomain AND certs persisted, #389). In-progress and error
-            // states stay on this screen so the user sees either progress
-            // or a retryable failure.
-            if (state is OnboardingState.Onboarded) {
+        OnboardingDestinationContent(
+            autostart = autostart,
+            stateFlow = onboardingViewModel.state,
+            onStartOnboarding = { onboardingViewModel.startOnboarding() },
+            onRetry = { onboardingViewModel.retry() },
+            onGetStarted = {
+                navController.navigate(Routes.NOTIFICATION_PREFERENCES)
+            },
+            onOnboarded = {
                 navController.navigate(Routes.HOME) {
                     popUpTo(Routes.ONBOARDING) {
                         inclusive = true
@@ -42,18 +67,50 @@ fun NavGraphBuilder.onboardingDestination(navController: NavController) {
                     launchSingleTop = true
                 }
             }
-        }
-
-        OnboardingBody(
-            state = state,
-            onGetStarted = {
-                navController.navigate(
-                    Routes.NOTIFICATION_PREFERENCES
-                )
-            },
-            onRetry = { onboardingViewModel.retry() }
         )
     }
+}
+
+/**
+ * Pure composable body of the onboarding destination, separated from the
+ * NavGraph/ViewModel plumbing so it can be driven directly from Robolectric
+ * Compose tests. The [onStartOnboarding] callback is fired exactly once per
+ * destination entry when [autostart] is true — this is the invariant broken
+ * by #392's two-VM split and restored by scoping the autostart trigger to
+ * this destination instead of NotificationPreferences.
+ */
+@Composable
+internal fun OnboardingDestinationContent(
+    autostart: Boolean,
+    stateFlow: StateFlow<OnboardingState>,
+    onStartOnboarding: () -> Unit,
+    onRetry: () -> Unit,
+    onGetStarted: () -> Unit,
+    onOnboarded: () -> Unit
+) {
+    val state by stateFlow.collectAsState()
+
+    LaunchedEffect(autostart) {
+        if (autostart) {
+            onStartOnboarding()
+        }
+    }
+
+    LaunchedEffect(state) {
+        // Only navigate to Home once the device is fully onboarded
+        // (subdomain AND certs persisted, #389). In-progress and error
+        // states stay on this screen so the user sees either progress
+        // or a retryable failure.
+        if (state is OnboardingState.Onboarded) {
+            onOnboarded()
+        }
+    }
+
+    OnboardingBody(
+        state = state,
+        onGetStarted = onGetStarted,
+        onRetry = onRetry
+    )
 }
 
 @Composable

--- a/app/src/test/java/com/rousecontext/app/ui/navigation/BackStackFlowTest.kt
+++ b/app/src/test/java/com/rousecontext/app/ui/navigation/BackStackFlowTest.kt
@@ -105,12 +105,22 @@ class BackStackFlowTest {
 
     /**
      * First-time onboarding flow with #69 global notification preferences:
-     * Welcome -> NotificationPreferences -> Home. The preferences step
-     * must pop the entire onboarding stack (inclusive of ONBOARDING) so
-     * back from HOME exits rather than re-entering onboarding.
+     * Welcome -> NotificationPreferences -> Onboarding(autostart) -> Home.
+     *
+     * #392: NotificationPreferences "Continue" no longer navigates to HOME
+     * directly. It navigates back to ONBOARDING with `autostart=true` and
+     * pops the prior onboarding entry inclusive so the destination's VM
+     * (the one that shows progress + eventually flips to Home) is the same
+     * VM that kicks off registration. After the flow succeeds the
+     * onboarding destination LaunchedEffect navigates to HOME, again
+     * popping ONBOARDING inclusive.
      */
     @Test
     fun `onboarding visits notification preferences before home`() {
+        // NavHost stores each entry by its registered route pattern. The
+        // concrete autostart arg lives in the entry's Bundle, not in the
+        // pattern, so both the Welcome entry and the autostart entry live
+        // under the [Routes.ONBOARDING] pattern.
         val stack = FakeBackStack(Routes.ONBOARDING)
 
         // Welcome "Get Started" -> NotificationPreferences (plain navigate)
@@ -120,7 +130,19 @@ class BackStackFlowTest {
             stack.asList
         )
 
-        // NotificationPreferences "Continue" -> HOME, popping ONBOARDING inclusive
+        // #392: NotificationPreferences "Continue" -> autostart route,
+        // popping the prior ONBOARDING entry inclusive. The new entry
+        // shares the same pattern but carries autostart=true in its args.
+        stack.navigate(
+            route = Routes.ONBOARDING,
+            popTarget = Routes.ONBOARDING,
+            inclusive = true,
+            launchSingleTop = true
+        )
+        assertEquals(listOf(Routes.ONBOARDING), stack.asList)
+
+        // The onboarding destination's LaunchedEffect on Onboarded -> HOME,
+        // popping the onboarding entry inclusive.
         stack.navigate(
             route = Routes.HOME,
             popTarget = Routes.ONBOARDING,
@@ -130,6 +152,15 @@ class BackStackFlowTest {
         assertEquals(listOf(Routes.HOME), stack.asList)
         // Back from HOME should exit the app (stack is empty beneath HOME)
         assertEquals(false, stack.popBackStack())
+    }
+
+    /**
+     * #392 regression: The resolved autostart URL is distinct from the
+     * registered pattern, but the constant carries the right query.
+     */
+    @Test
+    fun `onboardingAutostart constant has autostart true query`() {
+        assertEquals("onboarding?autostart=true", Routes.ONBOARDING_AUTOSTART)
     }
 
     /**

--- a/app/src/test/java/com/rousecontext/app/ui/navigation/destinations/OnboardingDestinationContentTest.kt
+++ b/app/src/test/java/com/rousecontext/app/ui/navigation/destinations/OnboardingDestinationContentTest.kt
@@ -1,0 +1,190 @@
+package com.rousecontext.app.ui.navigation.destinations
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.rousecontext.app.ui.theme.RouseContextTheme
+import com.rousecontext.app.ui.viewmodels.OnboardingState
+import com.rousecontext.app.ui.viewmodels.OnboardingStep
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Regression tests for #392.
+ *
+ * Prior to this fix NotificationPreferences called `startOnboarding()` on
+ * its own NavBackStackEntry-scoped [OnboardingViewModel] instance and then
+ * navigated to the onboarding destination, which created a *different*
+ * ViewModel that re-read the CertificateStore's subdomain (still null at
+ * that instant) and was stuck on Welcome forever. The in-flight
+ * registration did complete on the discarded VM, but nothing observed it.
+ *
+ * The fix scopes the `startOnboarding()` trigger to the onboarding
+ * destination itself via an `autostart=true` nav arg. These tests drive
+ * the extracted [OnboardingDestinationContent] composable to prove that:
+ *
+ *  1. When `autostart=true`, the destination's own `onStartOnboarding`
+ *     callback fires exactly once on entry.
+ *  2. When `autostart=false`, it does NOT fire (returning-Welcome path).
+ *  3. When the VM transitions to [OnboardingState.Onboarded],
+ *     `onOnboarded` fires so the destination can navigate to Home.
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(
+    sdk = [33],
+    qualifiers = "w400dp-h800dp-xxhdpi",
+    application = com.rousecontext.app.TestApplication::class
+)
+class OnboardingDestinationContentTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun autostartTrue_firesStartOnboardingOnce() {
+        val stateFlow = MutableStateFlow<OnboardingState>(OnboardingState.NotOnboarded)
+        var startCount = 0
+
+        composeRule.setContent {
+            RouseContextTheme(darkTheme = true) {
+                OnboardingDestinationContent(
+                    autostart = true,
+                    stateFlow = stateFlow,
+                    onStartOnboarding = { startCount += 1 },
+                    onRetry = {},
+                    onGetStarted = {},
+                    onOnboarded = {}
+                )
+            }
+        }
+
+        composeRule.waitForIdle()
+        assertEquals(
+            "autostart should invoke onStartOnboarding exactly once",
+            1,
+            startCount
+        )
+    }
+
+    @Test
+    fun autostartFalse_doesNotFireStartOnboarding() {
+        val stateFlow = MutableStateFlow<OnboardingState>(OnboardingState.NotOnboarded)
+        var started = false
+
+        composeRule.setContent {
+            RouseContextTheme(darkTheme = true) {
+                OnboardingDestinationContent(
+                    autostart = false,
+                    stateFlow = stateFlow,
+                    onStartOnboarding = { started = true },
+                    onRetry = {},
+                    onGetStarted = {},
+                    onOnboarded = {}
+                )
+            }
+        }
+
+        composeRule.waitForIdle()
+        assertFalse(
+            "onStartOnboarding must not fire on plain Welcome entry",
+            started
+        )
+    }
+
+    @Test
+    fun stateOnboarded_firesOnOnboardedCallback() {
+        val stateFlow = MutableStateFlow<OnboardingState>(OnboardingState.NotOnboarded)
+        var onboardedFired = false
+
+        composeRule.setContent {
+            RouseContextTheme(darkTheme = true) {
+                OnboardingDestinationContent(
+                    autostart = false,
+                    stateFlow = stateFlow,
+                    onStartOnboarding = {},
+                    onRetry = {},
+                    onGetStarted = {},
+                    onOnboarded = { onboardedFired = true }
+                )
+            }
+        }
+
+        composeRule.waitForIdle()
+        assertFalse(
+            "onOnboarded must not fire while state is NotOnboarded",
+            onboardedFired
+        )
+
+        // The #392 regression scenario: the same VM transitions to
+        // Onboarded after background registration completes. The
+        // destination must observe that transition and navigate.
+        stateFlow.value = OnboardingState.Onboarded
+        composeRule.waitForIdle()
+
+        assertTrue(
+            "onOnboarded must fire once state becomes Onboarded",
+            onboardedFired
+        )
+    }
+
+    @Test
+    fun autostart_fullFlowTransitionsToOnboarded() {
+        // End-to-end: autostart triggers start, state progresses through
+        // InProgress variants, and Onboarded fires the navigation.
+        val stateFlow = MutableStateFlow<OnboardingState>(OnboardingState.NotOnboarded)
+        var startCount = 0
+        var onboardedFired = false
+
+        composeRule.setContent {
+            RouseContextTheme(darkTheme = true) {
+                OnboardingDestinationContent(
+                    autostart = true,
+                    stateFlow = stateFlow,
+                    onStartOnboarding = {
+                        startCount += 1
+                        // Mirror the real VM: startOnboarding flips to
+                        // InProgress, then eventually to Onboarded. We
+                        // drive that via the StateFlow here so the test
+                        // composition actually re-renders.
+                        stateFlow.value = OnboardingState.InProgress(
+                            OnboardingStep.Registering
+                        )
+                    },
+                    onRetry = {},
+                    onGetStarted = {},
+                    onOnboarded = { onboardedFired = true }
+                )
+            }
+        }
+
+        composeRule.waitForIdle()
+        assertEquals(1, startCount)
+
+        // Simulate the appScope-launched registration completing.
+        stateFlow.value = OnboardingState.InProgress(
+            OnboardingStep.ProvisioningCerts
+        )
+        composeRule.waitForIdle()
+        assertFalse("not yet Onboarded", onboardedFired)
+
+        stateFlow.value = OnboardingState.Onboarded
+        composeRule.waitForIdle()
+        assertTrue(
+            "destination must navigate to Home once Onboarded fires",
+            onboardedFired
+        )
+        // Recomposing under Onboarded must NOT re-trigger startOnboarding.
+        assertEquals(
+            "autostart must not re-fire on state changes",
+            1,
+            startCount
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Fresh-install onboarding succeeded on disk (subdomain + certs persisted) but the UI stayed on WelcomeScreen because `koinViewModel<OnboardingViewModel>()` is scoped per NavBackStackEntry. NotificationPreferences called `startOnboarding()` on its own VM, navigated to Onboarding, and the newly-created destination VM never observed the in-flight flow completing.
- Scope the startOnboarding trigger to the onboarding destination itself via an optional `autostart=true` nav arg. The `Continue` handler on NotificationPreferences now just navigates to `Routes.ONBOARDING_AUTOSTART` (popping ONBOARDING inclusive); the destination's VM reads the arg, fires `startOnboarding()`, and drives the full lifecycle including the flip to Home.
- Extracted an internal `OnboardingDestinationContent` composable so the autostart + state->Home navigation invariants can be asserted directly from a Robolectric Compose test without standing up a full NavHost + Koin.

## Test plan

- [x] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew :app:testDebugUnitTest`
- [x] `JAVA_HOME=/usr/lib/jvm/java-21-openjdk ./gradlew ktlintCheck detekt`
- [x] `:app:assembleDebug` succeeds (APK at `app/build/outputs/apk/debug/app-debug.apk`)
- [ ] Manual fresh-install repro: `pm clear com.rousecontext.debug`, launch, Get Started -> Continue -> Allow. UI should progress through the SettingUp screen and land on Home without bouncing back to Welcome.

Closes #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)