### PR TITLE
Add UX changes rule + decision log + onboarding flow page

### DIFF
--- a/.claude/rules/ux-changes.md
+++ b/.claude/rules/ux-changes.md
@@ -1,0 +1,39 @@
+# UX Changes Require Explicit Approval
+
+Some changes affect the product's user-facing flow in ways that code review alone cannot catch. For those changes, explicit user approval is required BEFORE implementation starts, AND a new entry must be added to [`docs/ux-decisions.md`](../../docs/ux-decisions.md) as part of the same PR.
+
+Filing an issue with options and a ranked recommendation is NOT approval. A GitHub issue is context; the user's in-session reply is the approval.
+
+## Requires approval (in-session + decision-log entry)
+
+- Onboarding step added, removed, or reordered
+- Timing of cert / credential / subdomain provisioning (when it fires in the flow)
+- First-run UX (the Welcome → NotificationPreferences → Home path, including anything on that path)
+- Permission prompt timing (when system permission dialogs appear relative to user actions)
+- Error surface changes — where an error lands (new destination, different screen), how the user recovers (new button, different navigation), whether an error is shown at all
+
+## Does NOT require approval
+
+- Visual tweaks — spacing, colors, typography, layout within a screen
+- Bug fixes that restore previously-intended behavior (the prior behavior was the approved one)
+- Copy wording at the same step, same flow position, same intent
+- New screens that are pure additions behind existing entry points (e.g. new Settings sub-pages, new Help content)
+
+## Gray zone — ask
+
+- Adding a new integration (new screens, but follows an established pattern)
+- Moving features between Home and Settings
+- Notification copy or routing changes
+
+If you are unsure whether a change falls into "requires approval", ask. A 30-second check-in costs nothing; an agent-implemented UX shift costs a rollback.
+
+## How to ask
+
+1. Surface the decision early: "this bug has 2+ defensible fixes with different UX trade-offs — which direction?"
+2. Present options with trade-offs (not just a recommendation).
+3. Wait for explicit approval ("sure", "go ahead", "looks good", etc.). A pending question is not approval.
+4. Only AFTER approval: write tests, implement, open PR. Include the new `docs/ux-decisions.md` entry in the same PR.
+
+## Why this rule exists
+
+On #389, fresh-install cert provisioning was broken. The fix had three defensible shapes (onboarding-time provision, background provision, first-integration-time provision). An agent was launched to implement the first without explicit approval, based on a ranked recommendation in the issue. The user later observed the UX shift — "Registering" appears before any integration is picked — and noted that filing an issue with options is not the same as getting approval. See the `#389` entry in [`docs/ux-decisions.md`](../../docs/ux-decisions.md).

--- a/docs/internal/flows/index.html
+++ b/docs/internal/flows/index.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Rouse Context &mdash; UX Flows</title>
+<style>
+  :root {
+    --bg: #1a1a2e;
+    --surface: #16213e;
+    --surface-hover: #1e2a4e;
+    --border: #0f3460;
+    --text: #e0e0e0;
+    --text-muted: #a0a0b0;
+    --accent: #e94560;
+    --accent-dim: #b33349;
+    --branch: #8a8aa0;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { min-height: 100%; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.45;
+    padding: 1.5rem 1.5rem 4rem;
+  }
+  header {
+    max-width: 1200px;
+    margin: 0 auto 1.5rem;
+  }
+  h1 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: #fff;
+  }
+  header p {
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    margin-top: 0.35rem;
+  }
+  .flow {
+    max-width: 1200px;
+    margin: 0 auto;
+  }
+  h2 {
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: #fff;
+    margin-top: 2.5rem;
+    margin-bottom: 0.5rem;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid var(--border);
+  }
+  h2 + p {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    margin-bottom: 1.5rem;
+  }
+  .steps {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+  }
+  .step {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+  }
+  .step img {
+    width: 100%;
+    max-width: 220px;
+    margin: 0 auto 0.5rem;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+    background: #000;
+  }
+  .step .label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #fff;
+    margin-bottom: 0.15rem;
+  }
+  .step .sub {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+  }
+  .step.branch {
+    border-color: var(--branch);
+    opacity: 0.85;
+  }
+  .step.branch .label {
+    color: var(--branch);
+  }
+  .actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    justify-content: center;
+    margin: 0.4rem 0;
+    color: var(--accent);
+    font-size: 0.85rem;
+  }
+  .actions span {
+    padding: 0.2rem 0.6rem;
+    border: 1px dashed var(--accent-dim);
+    border-radius: 999px;
+    background: rgba(233, 69, 96, 0.08);
+  }
+  .branches {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+    margin: 0.8rem 0 0;
+    padding-left: 1rem;
+    border-left: 3px dashed var(--branch);
+  }
+  .branch-header {
+    grid-column: 1 / -1;
+    font-size: 0.85rem;
+    color: var(--branch);
+    margin-bottom: -0.2rem;
+  }
+  .note {
+    background: rgba(233, 69, 96, 0.08);
+    border-left: 3px solid var(--accent);
+    padding: 0.75rem 1rem;
+    border-radius: 4px;
+    color: var(--text);
+    font-size: 0.9rem;
+    margin: 0.8rem 0;
+  }
+  .note a {
+    color: var(--accent);
+  }
+  footer {
+    max-width: 1200px;
+    margin: 3rem auto 0;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border);
+    color: var(--text-muted);
+    font-size: 0.85rem;
+  }
+</style>
+</head>
+<body>
+<header>
+  <h1>UX Flows</h1>
+  <p>Screenshots laid out as a flow. Used to spot unintended timing or ordering changes at review time. Source images are from the roborazzi suite in <code>app/screenshots/</code>.</p>
+</header>
+
+<section class="flow">
+  <h2>Onboarding &amp; first integration</h2>
+  <p>Fresh install &rarr; Home with at least one integration enabled.</p>
+
+  <div class="steps">
+    <div class="step">
+      <img src="../../../app/screenshots/01_welcome_light.png" alt="Welcome">
+      <div class="label">Welcome</div>
+      <div class="sub">First screen on fresh install. No state exists yet.</div>
+    </div>
+  </div>
+
+  <div class="actions"><span>tap "Get Started"</span></div>
+
+  <div class="steps">
+    <div class="step">
+      <img src="../../../app/screenshots/29_notification_preferences_light.png" alt="Notification Preferences">
+      <div class="label">Notification Preferences</div>
+      <div class="sub">User picks how tool-call notifications appear.</div>
+    </div>
+  </div>
+
+  <div class="actions"><span>tap "Continue" &rarr; system POST_NOTIFICATIONS dialog (Android 13+) &rarr; grant</span></div>
+
+  <div class="note">
+    <strong>Design decision (#389):</strong> Relay registration + cert provisioning fire here, before Home loads. The user has not yet picked an integration. See
+    <a href="../../ux-decisions.md">docs/ux-decisions.md</a> for the trade-offs and why this was chosen over deferring to first integration add.
+  </div>
+
+  <div class="steps">
+    <div class="step">
+      <img src="../../../app/screenshots/02_setting_up_first_time_light.png" alt="Setting up: Registering">
+      <div class="label">Setting up &mdash; Registering</div>
+      <div class="sub">Relay registration in flight. Subdomain + integration secrets persisted here.</div>
+    </div>
+  </div>
+
+  <div class="actions"><span>registration succeeds</span></div>
+
+  <div class="steps">
+    <div class="step">
+      <img src="../../../app/screenshots/03_setting_up_refreshing_light.png" alt="Setting up: Provisioning certs">
+      <div class="label">Setting up &mdash; Provisioning certs</div>
+      <div class="sub">ACME hop. Server cert, client (mTLS) cert, relay CA all persisted.</div>
+    </div>
+  </div>
+
+  <div class="branches">
+    <div class="branch-header">Error branches (stay on Setting up screen):</div>
+    <div class="step branch">
+      <img src="../../../app/screenshots/04_setting_up_rate_limited_light.png" alt="Rate limited">
+      <div class="label">Rate limited</div>
+      <div class="sub">ACME or relay quota exhausted. User sees retry date.</div>
+    </div>
+    <div class="step branch">
+      <img src="../../../app/screenshots/05_setting_up_failed_light.png" alt="Failed">
+      <div class="label">Failed</div>
+      <div class="sub">Network or server error. "Try again" button re-runs the failed hop.</div>
+    </div>
+  </div>
+
+  <div class="actions"><span>cert provisioning succeeds &rarr; <code>Onboarded</code> state</span></div>
+
+  <div class="steps">
+    <div class="step">
+      <img src="../../../app/screenshots/07_dashboard_empty_light.png" alt="Home (empty)">
+      <div class="label">Home &mdash; empty state</div>
+      <div class="sub">Device is fully provisioned but no integrations enabled yet.</div>
+    </div>
+  </div>
+
+  <div class="actions"><span>tap "Add your first" integrations row</span></div>
+
+  <div class="steps">
+    <div class="step">
+      <img src="../../../app/screenshots/14_add_integration_picker_light.png" alt="Add Integration picker">
+      <div class="label">Add Integration</div>
+      <div class="sub">List of available integrations (Health Connect, Notifications, Outreach, Test Tools, Usage Stats).</div>
+    </div>
+  </div>
+
+  <div class="actions"><span>tap one</span></div>
+
+  <div class="steps">
+    <div class="step">
+      <img src="../../../app/screenshots/16_integration_enabled_light.png" alt="Integration enabled">
+      <div class="label">Integration detail &mdash; ready</div>
+      <div class="sub">Integration URL shown. "Waiting for AI client&hellip;" until one connects.</div>
+    </div>
+  </div>
+
+  <div class="actions"><span>tap "Finish Later" (or add AI client now)</span></div>
+
+  <div class="steps">
+    <div class="step">
+      <img src="../../../app/screenshots/08_dashboard_integrations_light.png" alt="Home with integrations">
+      <div class="label">Home &mdash; integrations enabled</div>
+      <div class="sub">Fully configured. Integration card shows active state.</div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  Adding or reordering any step above requires explicit approval and an entry in
+  <a href="../../ux-decisions.md" style="color: var(--accent);">docs/ux-decisions.md</a>.
+  See <a href="../../../.claude/rules/ux-changes.md" style="color: var(--accent);">.claude/rules/ux-changes.md</a>.
+</footer>
+</body>
+</html>

--- a/docs/internal/index.html
+++ b/docs/internal/index.html
@@ -125,6 +125,7 @@
       <button class="tab" role="tab" id="tab-notifications" data-tab="notifications" aria-controls="pane-notifications">Notifications</button>
       <button class="tab" role="tab" id="tab-app-ui" data-tab="app-ui" aria-controls="pane-app-ui">App UI</button>
       <button class="tab" role="tab" id="tab-oauth" data-tab="oauth" aria-controls="pane-oauth">OAuth pages</button>
+      <button class="tab" role="tab" id="tab-flows" data-tab="flows" aria-controls="pane-flows">Flows</button>
     </div>
     <a class="deep-link" id="deep-link" href="notifications/" target="_blank" rel="noopener">Open in new tab &#8599;</a>
   </div>
@@ -140,16 +141,20 @@
   <section class="pane" id="pane-oauth" role="tabpanel" aria-labelledby="tab-oauth">
     <iframe data-src="auth/" title="OAuth authorization pages" loading="lazy"></iframe>
   </section>
+  <section class="pane" id="pane-flows" role="tabpanel" aria-labelledby="tab-flows">
+    <iframe data-src="flows/" title="UX flow diagrams" loading="lazy"></iframe>
+  </section>
 </main>
 
 <script>
   (function () {
-    var TABS = ['notifications', 'app-ui', 'oauth'];
+    var TABS = ['notifications', 'app-ui', 'oauth', 'flows'];
     var DEFAULT_TAB = 'notifications';
     var TAB_URLS = {
       'notifications': 'notifications/',
       'app-ui': 'app/',
-      'oauth': 'auth/'
+      'oauth': 'auth/',
+      'flows': 'flows/'
     };
 
     var loaded = {};

--- a/docs/ux-decisions.md
+++ b/docs/ux-decisions.md
@@ -1,0 +1,34 @@
+# UX Decisions
+
+Append-only log of user-facing flow decisions. Governed by [`.claude/rules/ux-changes.md`](../.claude/rules/ux-changes.md).
+
+Every PR that changes UX flow, timing, permission prompts, or error surfaces adds an entry here. Include:
+- **Decision** — the one-line outcome
+- **Approved by** — the person + how (in-session, PR review, etc.)
+- **Context** — what problem prompted the change
+- **Alternatives considered** — the roads not taken and why
+- **Trade-off accepted** — what we gave up to get the chosen behavior
+- **Relevant** — linked issues, PRs, memories
+
+Newest entries on top.
+
+---
+
+## 2026-04-24 — Cert provisioning runs at Continue, not at first integration add
+
+**Decision:** Keep the post-#389 flow where relay subdomain registration and ACME cert provisioning fire immediately after the user taps Continue on NotificationPreferences, before Home loads.
+
+**Approved by:** Jason, in-session 2026-04-24 ("we can keep the current, particularly since we don't have cert limit issues anymore"). Retroactive approval; the original #389 landing predated this rule.
+
+**Context:** Fresh installs were landing on a half-configured Home without the PEMs required to serve AI clients (#386 / #387). The root cause was that `OnboardingFlow.execute()` never called `CertProvisioningFlow.execute()` — that call only happened inside `IntegrationSetupViewModel`, so a user who onboarded and didn't add an integration was stuck.
+
+**Alternatives considered:**
+- **Defer to first integration add** — cert provisioning fires only when the user enables their first integration. Pros: no quota burn if the user bails; registration happens when there's actually something to register. Cons: first-integration setup is now several seconds slower (ACME hop); Home is reachable without certs.
+- **Partial** — register subdomain at Continue (needed to display the device's address), defer certs to first integration. Adds a split state to reason about.
+- **Block tunnel startup without certs** — foreground service refuses to start until certs exist. Makes the failure loud but doesn't fix the underlying gap.
+
+**Trade-off accepted:** Every fresh install commits a subdomain + a cert even if the user bails before enabling an integration. Acceptable because the project is on Google Trust Services (no LE 50/week/domain ceiling), so quota pressure is not a real constraint. See `project_acme_provider` memory.
+
+**Relevant:**
+- Fixed by: `#389` → PR `#390` (cert provisioning in onboarding), `#392` → PR `#393` (VM-scope regression that broke the post-#389 flow), `#394` → PR `#396` (e2e cold-start test hardening)
+- This was the motivating incident for [`.claude/rules/ux-changes.md`](../.claude/rules/ux-changes.md) itself — the decision was made unilaterally the first time; this rule exists so it cannot be made unilaterally again.


### PR DESCRIPTION
## Summary

Three pieces, one PR:

1. **`.claude/rules/ux-changes.md`** — auto-loaded rule listing the change categories that require explicit user approval (and a decision-log entry) before implementation. Filing an issue with a ranked recommendation is explicitly **not** approval.

2. **`docs/ux-decisions.md`** — append-only log of UX flow decisions. Seeded with the `#389` cert-provisioning-at-Continue decision, retroactively approved.

3. **`docs/internal/flows/index.html`** — onboarding flow page composed of the existing roborazzi screenshots, wired together with action labels and error-branch screens (Rate limited, Failed). Linked into the existing internal dashboard as a new Flows tab.

## Motivation

`#389` moved cert provisioning from "on first integration add" to "right after Continue, before Home loads". That's a real UX timing change. An agent picked it unilaterally based on a ranked recommendation in the issue body. The user spotted the shift after the fact ("immediately after the notifications screen its showing registering, before any integrations are set up") and asked for a structural check that survives across Claude sessions, not just a per-session memory entry.

The decision itself is fine — kept as-is, no LE quota pressure under GTS — but this PR is the structural fix to prevent the next instance.

## Test plan

- [x] Render preview via local share — flows page loads, all screenshot paths resolve, dashboard shows the new Flows tab.
- [x] No app code touched; build/test side: nothing to run beyond the markdown link audit.
- [ ] After merge: GH Pages picks up the new files; `rousecontext.com/internal/flows/` reachable.

## Closes / related

- Codifies the lesson from `#389` / `#392` / `#394` (none of those auto-close)
- Companion to memory: \`feedback_bugfix_vs_design_choice\` (per-session); this PR is the in-repo equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)