### PR TITLE
Fix #391: Update design docs to reflect GTS as primary CA

### DIFF
--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -138,7 +138,7 @@ This defeats targeted interception attacks where an adversary filters the self-c
 - Results stored in the local audit log alongside tool call history
 
 **CAA records**
-The production `rousecontext.com` DNS zone should have a CAA record restricting issuance to a single CA (e.g. `0 issue "letsencrypt.org"`). This prevents other CAs from issuing for the domain even if credentials are compromised. Document in deployment runbook.
+The production `rousecontext.com` DNS zone should have a CAA record restricting issuance to a single CA. The upstream `rousecontext.com` zone uses Google Trust Services, so it publishes `0 issue "pki.goog"`; self-hosters using Let's Encrypt would use `0 issue "letsencrypt.org"` instead. This prevents other CAs from issuing for the domain even if credentials are compromised. Document in deployment runbook.
 
 ### Subdomain rotation
 
@@ -326,7 +326,11 @@ User controls exposure by:
 
 ## ACME Rate Limit Handling
 
-### Primary CA: Let's Encrypt (50 certs per registered domain per week)
+### Primary CA: Google Trust Services (GTS)
+
+`rousecontext.com` production runs against GTS's `dv.acme-v02.api.pki.goog` directory. GTS quotas (roughly 100 new orders/hour/account, tens of thousands of certs/day overall) are far above what the relay generates even under mass-onboarding load — quota was the main reason to move off Let's Encrypt, whose 50-cert-per-registered-domain-per-week ceiling was the binding constraint for fresh-install churn. GTS requires External Account Binding on the first `newAccount` call; see `docs/design/relay.md` for the config knobs.
+
+Let's Encrypt remains a supported option for self-hosters (see `docs/self-hosting.md`). The rate-limit handling below is generic and applies to any ACME CA the relay is pointed at.
 
 ### When limit is hit:
 1. Relay returns `{"error": "rate_limited", "retry_after_secs": 604800}` to device
@@ -338,8 +342,6 @@ User controls exposure by:
 ### When quota resets:
 1. Relay processes pending queue
 2. Relay sends FCM to each blocked device to trigger cert pickup
-
-### Future: add Google Trust Services or ZeroSSL as fallback CA
 
 ## Module Structure
 
@@ -408,7 +410,7 @@ User can request new subdomain once per 30 days. Old subdomain invalidated immed
 27. Device validates renewed cert CN/SAN matches stored subdomain before storing
 
 ### ACME rate limits
-28. Registration hits Let's Encrypt rate limit → device gets `rate_limited` error + retry_after
+28. Registration hits the ACME CA rate limit → device gets `rate_limited` error + retry_after
 29. Device shows "delayed" notification, schedules retry
 30. Admin receives automated alert
 31. Quota resets → relay processes pending queue, sends FCM to blocked devices

--- a/docs/design/relay-api.md
+++ b/docs/design/relay-api.md
@@ -14,7 +14,7 @@ Three authentication methods are used across endpoints:
 
 | Method | Mechanism | When Used |
 |---|---|---|
-| **mTLS** | TLS client certificate presented during handshake, verified against Let's Encrypt root certs (ISRG Root X1, X2). Subdomain extracted from certificate CN or first SAN dNSName matching `*.rousecontext.com`. | `/ws`, `/renew` (valid cert path) |
+| **mTLS** | TLS client certificate presented during handshake, verified against the relay's private device CA (loaded from `tls.ca_cert_path` in `relay.toml`; this is the same CA that issues the `client_cert` returned from `/register/certs` and `/renew`). Subdomain extracted from certificate CN or first SAN dNSName matching `*.rousecontext.com`. | `/ws`, `/renew` (valid cert path) |
 | **Firebase ID Token** | `firebase_token` field in request body. Verified via Google's public keys (RS256 JWT). Must match project ID. Extracts `sub` claim as Firebase UID. | `/register`, `/renew` (expired cert path) |
 | **Unauthenticated** | No credentials required. | `/wake/:subdomain`, `/status` |
 
@@ -67,7 +67,7 @@ Establishes a multiplexed WebSocket connection from a device to the relay. All M
 
 #### Authentication
 
-**mTLS required.** The device must present a valid TLS client certificate issued by a trusted CA (Let's Encrypt). The relay extracts the subdomain from the certificate's CN or SAN `dNSName` field (first entry matching `*.rousecontext.com`, stripping the domain suffix).
+**mTLS required.** The device must present a valid TLS client certificate issued by the relay's private device CA (returned as `client_cert` from `/register/certs`). The relay extracts the subdomain from the certificate's CN or SAN `dNSName` field (first entry matching `*.rousecontext.com`, stripping the domain suffix).
 
 #### Request
 
@@ -161,7 +161,7 @@ Content-Type: application/json
 | 403 | Firebase UID already registered but `signature` missing | `forbidden` | `"Signature required for re-registration"` |
 | 403 | `signature` does not verify against stored public key | `forbidden` | `"Signature verification failed"` |
 | 429 | `force_new: true` but last rotation was less than 30 days ago | `cooldown` | `"Subdomain rotation available after 2026-05-01"` |
-| 429 | ACME CA rate limit reached (50 certs/week for `rousecontext.com`) | `acme_rate_limited` | `"Certificate issuance rate limited"` |
+| 429 | ACME CA rate limit reached (CA-specific; GTS in production has tens-of-thousands/day headroom, Let's Encrypt is 50/registered-domain/week) | `acme_rate_limited` | `"Certificate issuance rate limited"` |
 | 502 | ACME challenge failed (DNS propagation timeout, CA rejection, Cloudflare API failure after 3 retries) | `acme_failure` | `"ACME DNS-01 challenge failed"` |
 | 500 | Firestore write failure, unexpected internal error | `internal` | `"Internal server error"` |
 
@@ -180,7 +180,7 @@ Content-Type: application/json
    - `signature` is required. Verify against stored `public_key`.
    - Check `last_rotation` timestamp. If less than 30 days ago, return 429 `cooldown`.
    - Generate new random subdomain. Delete old `devices/` document. All client tokens for the old subdomain are implicitly revoked (device-side responsibility).
-6. Check ACME weekly issuance count. If at or above 50, store in `pending_certs/{subdomain}` and return 429 `acme_rate_limited`.
+6. Check configured ACME issuance quota. If exceeded (CA-specific: GTS production is effectively unbounded at this scale, Let's Encrypt enforces 50 certs per registered domain per week), store in `pending_certs/{subdomain}` and return 429 `acme_rate_limited`.
 7. Perform ACME DNS-01 challenge for `{subdomain}.rousecontext.com` (see ACME Orchestration in `relay.md`).
 8. Write/update `devices/{subdomain}` document in Firestore.
 9. Return certificate chain, subdomain, and relay host.
@@ -255,7 +255,7 @@ Content-Type: application/json
 
 | Field | Type | Description |
 |---|---|---|
-| `server_cert` | string | PEM-encoded ACME server certificate (Let's Encrypt, serverAuth) |
+| `server_cert` | string | PEM-encoded ACME-issued server certificate (serverAuth EKU). Issued by the ACME provider the relay is configured against — Google Trust Services in production, Let's Encrypt or another public CA for self-hosted deployments. |
 | `client_cert` | string | PEM-encoded relay CA client certificate (clientAuth) |
 | `relay_ca_cert` | string | PEM-encoded relay CA root certificate |
 
@@ -748,8 +748,8 @@ The signature is always over the **raw DER bytes of the CSR** -- the bytes that 
 | Endpoint | Scope | Limit | Mechanism | State |
 |---|---|---|---|---|
 | `POST /wake/:subdomain` | Per subdomain | 6 requests per minute | Token bucket (1 token per 10 seconds, max burst 6) | In-memory (resets on relay restart) |
-| `POST /register` | Global (ACME) | 50 certs per week for `rousecontext.com` | Counter (resets weekly) | In-memory + Firestore `pending_certs/` for overflow |
+| `POST /register` | Global (ACME) | CA-specific — GTS (production) has tens-of-thousands/day headroom; Let's Encrypt (self-hosting) is 50/registered-domain/week | Counter (resets on the CA's quota window) | In-memory + Firestore `pending_certs/` for overflow |
 | `POST /register` (`force_new`) | Per Firebase UID | Once per 30 days | `last_rotation` timestamp in Firestore | Firestore |
-| `POST /renew` | Global (ACME) | 50 certs per week (shared with `/register`) | Same counter as `/register` | Same as `/register` |
+| `POST /renew` | Global (ACME) | Same as `/register` (shared ACME account/quota) | Same counter as `/register` | Same as `/register` |
 
-The ACME rate limit counter is best-effort. On relay restart, the counter resets. The relay can query Firestore `devices/` records with `cert_expires` in the current week to reconstruct an approximate count, but the exact count is not critical -- Let's Encrypt will reject requests that exceed the real limit, and the relay handles that gracefully.
+The ACME rate limit counter is best-effort. On relay restart, the counter resets. The relay can query Firestore `devices/` records with `cert_expires` in the current window to reconstruct an approximate count, but the exact count is not critical -- the CA will reject requests that exceed the real limit, and the relay handles that gracefully. In practice the counter mostly exists to spare Let's Encrypt-backed self-hosts from burning quota on retry storms; the production GTS-backed relay rarely gets close to its ceiling.

--- a/docs/design/relay.md
+++ b/docs/design/relay.md
@@ -46,7 +46,7 @@ No separate API port. One port, two behaviors.
 
 - Relay's own cert for `relay.rousecontext.com`: manually provisioned via certbot, deployed from GitHub Secrets alongside the binary. Referenced in `relay.toml` (`tls.cert_path`, `tls.key_path`). Renewed via GitHub Actions scheduled workflow (weekly certbot run).
 - Client cert: **optional** at TLS level (`rustls` `WebPkiClientVerifier` with `allow_unauthenticated()`). Individual endpoints enforce client cert requirements.
-- Client cert trust anchors: Let's Encrypt root certs (ISRG Root X1, X2), embedded in binary. Future: add additional CA roots as fallback CAs are added.
+- Client cert trust anchors: the **relay's private device CA** (the same CA that issues the `client_cert` returned from `/register/certs` and `/renew`). Loaded from `tls.ca_cert_path` in `relay.toml` at startup, not embedded in the binary. Public CAs (GTS, Let's Encrypt, ...) are not involved in mTLS — they only issue the device-facing `server_cert`.
 
 ### Client Passthrough (SNI = device subdomain)
 
@@ -167,7 +167,7 @@ Relay:
 ## ACME Orchestration
 
 ### CA Selection
-Primary: **Let's Encrypt** (50 certs per registered domain per week, no EAB needed). Future: add Google Trust Services or ZeroSSL as fallback CA.
+Primary: **Google Trust Services** (GTS) production directory `https://dv.acme-v02.api.pki.goog/directory`. GTS requires External Account Binding (RFC 8555 §7.3.4) on the first `newAccount` registration; EAB credentials are provisioned once via `gcloud publicca external-account-keys create` and supplied via the env vars named in `acme.external_account_binding_*_env`. GTS was chosen over Let's Encrypt because its issuance quota (tens of thousands of certs per day per account) is not a practical constraint for fresh-install churn or mass-install scenarios, whereas LE's 50 certs-per-registered-domain-per-week ceiling was. Let's Encrypt is still a supported fallback for self-hosters and can be selected by setting `acme.directory_url` (see `docs/self-hosting.md`).
 
 ### DNS-01 Challenge Flow
 1. Relay generates ACME order for `{subdomain}.rousecontext.com`
@@ -180,9 +180,9 @@ Primary: **Let's Encrypt** (50 certs per registered domain per week, no EAB need
 8. Relay returns cert to device
 
 ### Rate Limit Handling
-- Let's Encrypt: 50 certs per registered domain (`rousecontext.com`) per week
-- Relay tracks issued cert count per week
-- When limit hit:
+- GTS (current production): ~100 new orders per hour per account; overall daily issuance quota is in the tens of thousands. In practice this is not a ceiling we hit during normal operation or mass onboarding.
+- Let's Encrypt (fallback option for self-hosters): 50 certs per registered domain per week. This was the motivating reason to switch the default to GTS.
+- The relay still tracks issued-cert count and handles CA-side rate-limit errors generically:
   1. Store blocked device in Firestore `pending_certs/{subdomain}`
   2. Return `rate_limited` error with `retry_after_secs`
   3. Send admin alert (email/webhook, configured in relay.toml)
@@ -196,10 +196,10 @@ Primary: **Let's Encrypt** (50 certs per registered domain per week, no EAB need
 The production `rousecontext.com` DNS zone MUST have a CAA record restricting certificate issuance to the primary CA:
 
 ```
-rousecontext.com. CAA 0 issue "letsencrypt.org"
+rousecontext.com. CAA 0 issue "pki.goog"
 ```
 
-This prevents other CAs from issuing certs for `*.rousecontext.com` even if credentials are compromised or an attacker controls a different CA's validation. If a fallback CA is added (e.g. Google Trust Services), add a second `issue` record for it.
+This prevents other CAs from issuing certs for `*.rousecontext.com` even if credentials are compromised or an attacker controls a different CA's validation. Self-hosted deployments using Let's Encrypt should publish `0 issue "letsencrypt.org"` instead (or in addition, if both CAs are configured). The startup CAA check (see `relay/src/caa_check.rs`, #322) verifies the configured ACME provider's identifier appears in the CAA record set at boot and logs ERROR on mismatch — a silent CAA misconfiguration would otherwise only surface at the next renewal, 60-90 days later.
 
 Set via Cloudflare DNS alongside the zone configuration. Verify with `dig CAA rousecontext.com` after deployment.
 
@@ -285,7 +285,10 @@ max_streams_per_device = 8
 subdomain_rotation_cooldown_days = 30
 
 [acme]
-ca_url = "https://acme.letsencrypt.org/directory"
+# Defaults to Google Trust Services production when omitted.
+# directory_url = "https://dv.acme-v02.api.pki.goog/directory"
+external_account_binding_kid_env = "GTS_EAB_KID"
+external_account_binding_hmac_env = "GTS_EAB_HMAC"
 ```
 
 Secrets via env vars: `CLOUDFLARE_API_TOKEN`, `FIREBASE_SERVICE_ACCOUNT_JSON`, `ADMIN_ALERT_WEBHOOK`.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -267,7 +267,7 @@ If any step fails, tail the relay logs (`journalctl -u rouse-relay -f`) and the 
 
 **`strip_prefix("relay.")` doesn't match my hostname** — set `[server].base_domain` explicitly in `relay.toml`.
 
-**ACME rate limit (50 certs/week)** — use the staging directory (`https://acme-staging-v02.api.letsencrypt.org/directory`) for development, and persist `acme.account_key_path` so you don't register new accounts on every restart.
+**ACME rate limit** — quotas are CA-specific. Let's Encrypt enforces 50 certs per registered domain per week; for development against LE, use the staging directory (`https://acme-staging-v02.api.letsencrypt.org/directory`) to avoid burning production quota. Google Trust Services has tens-of-thousands/day headroom and is not a practical ceiling at this scale. In either case, persist `acme.account_key_path` so you don't register new accounts on every restart.
 
 ## Appendix: Runtime secrets for the upstream deploy (maintainers)
 


### PR DESCRIPTION
## Summary

Closes #391.

Production `rousecontext.com` has been on Google Trust Services since #213 (relay defaults to GTS when no `[acme]` section is configured — confirmed via `effective_directory_url` in `relay/src/caa_check.rs`), but three design docs still described Let's Encrypt as primary and quoted LE-specific numbers. This PR corrects them.

- `docs/design/relay.md` — CA Selection now names GTS with the `dv.acme-v02.api.pki.goog` directory and the EAB requirement; rate-limit section covers both CAs (noting GTS's tens-of-thousands/day headroom vs LE's 50/registered-domain/week that motivated the switch); CAA example flipped to `pki.goog`; mTLS trust-anchor description rewritten (client certs are verified against the relay's private device CA loaded from `tls.ca_cert_path`, not "Let's Encrypt root certs embedded in binary" — the old text was wrong on both the CA and the source).
- `docs/design/overall.md` — Primary-CA heading flipped to GTS; LE framed as a supported option for self-hosters; CAA example updated; stray "Let's Encrypt rate limit" wording in an edge-case list made CA-agnostic.
- `docs/design/relay-api.md` — mTLS auth description, `server_cert` response-field description, `/register` and `/renew` error rows, and the Rate Limiting Summary table no longer hard-code Let's Encrypt.
- `docs/self-hosting.md` — Troubleshooting quota note broadened to cover both CAs. The LE example `[acme]` block and CAA row kept intact (per the issue's non-goal: LE is a legitimate option for self-hosters).

## Intentionally left as-is

- `docs/self-hosting.md` still shows an LE `directory_url` example and an LE CAA row — this is the guide's offered example for self-hosters, not a claim about production.
- `docs/ux-decisions.md` already names GTS correctly.
- `docs/device-test-report.md` — historical artifact, no LE mentions to update.
- No code under `app/`, `core/`, `relay/` touched.

## Test plan

- [x] `git grep -iE "(let.{0,2}encrypt|letsencrypt|ISRG|\bLE\b)" docs/` — remaining hits are all self-hosting examples or explicit fallback mentions.
- [x] Visual review of each edited section for coherence.
- No build/tests — docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)