### PR TITLE
Fix #377: Replace 500ms session-registration sleep with deterministic Notify signal

### DIFF
--- a/core/testfixtures/src/main/kotlin/com/rousecontext/tunnel/integration/TestRelayFixture.kt
+++ b/core/testfixtures/src/main/kotlin/com/rousecontext/tunnel/integration/TestRelayFixture.kt
@@ -470,6 +470,18 @@ class TestRelayManager(
         requireAdmin().sendFcmWake(subdomain)
     }
 
+    /**
+     * Block until a device mux session is registered for [subdomain], or
+     * [timeoutMs] elapses. Returns `true` if the session is (or becomes)
+     * registered. See [TestRelayAdmin.waitForSessionRegistered] for
+     * background — replaces the 500ms sleep the integration tests used to
+     * paper over the post-WS-handshake registration race (issue #377).
+     *
+     * Requires [enableTestMode] = true.
+     */
+    fun waitForSessionRegistered(subdomain: String, timeoutMs: Long = 5_000L): Boolean =
+        requireAdmin().waitForSessionRegistered(subdomain, timeoutMs)
+
     /** Count of `/register/certs` calls observed by the relay. */
     fun registerCertsCalls(): Int = requireAdmin().registerCertsCalls()
 
@@ -752,6 +764,30 @@ class TestRelayAdmin(private val port: Int) {
                 "test-mode admin returned HTTP $code on emit-stream-error: $body"
             )
         }
+    }
+
+    /**
+     * Block until a mux session for [subdomain] is registered in the relay's
+     * [SessionRegistry], or [timeoutMs] elapses. Returns `true` if the
+     * session is (or becomes) registered.
+     *
+     * Replaces the hardcoded 500ms sleep the integration tests used to bridge
+     * the gap between client-side `TunnelState.CONNECTED` (WS handshake done)
+     * and relay-side `SessionRegistry.insert` (device is routable). See
+     * issue #377 for the flake this deterministic signal fixes.
+     */
+    fun waitForSessionRegistered(subdomain: String, timeoutMs: Long = 5_000L): Boolean {
+        // Give the HTTP client enough headroom beyond the server-side timeout
+        // to read the response, plus a safety margin for slow CI.
+        val readTimeout = (timeoutMs + 2_000L).toInt().coerceAtLeast(HTTP_TIMEOUT_MS)
+        val path = "/test/wait-session-registered?subdomain=${subdomain.urlEncoded()}" +
+            "&timeout_ms=$timeoutMs"
+        val conn = openConnection(path).apply {
+            requestMethod = "GET"
+            this.readTimeout = readTimeout
+        }
+        val body = readBody(conn)
+        return parseBoolField(body, "registered")
     }
 
     /** Number of `/register` calls observed since the relay started. */

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/OAuthEndToEndTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/OAuthEndToEndTest.kt
@@ -82,7 +82,7 @@ class OAuthEndToEndTest {
          * receives a consistent integration hostname. See sibling
          * EndToEndSessionTest for the SNI router semantics.
          */
-        private const val SESSION_REGISTRATION_DELAY_MS = 500L
+        private const val SESSION_REGISTRATION_TIMEOUT_MS = 10_000L
     }
 
     private lateinit var tempDir: File
@@ -115,7 +115,10 @@ class OAuthEndToEndTest {
         ca = TestCertificateAuthority(tempDir, RELAY_HOSTNAME, DEVICE_SUBDOMAIN)
         ca.generate()
 
-        relayManager = TestRelayManager(tempDir, RELAY_HOSTNAME)
+        // test-mode enables the `/test/wait-session-registered` admin
+        // endpoint used below to deterministically wait for the relay-side
+        // `SessionRegistry.insert` instead of a blind 500ms sleep (#377).
+        relayManager = TestRelayManager(tempDir, RELAY_HOSTNAME, enableTestMode = true)
         relayPort = findFreePort()
         relayManager.start(relayPort)
     }
@@ -518,10 +521,21 @@ class OAuthEndToEndTest {
             client.state.value,
             "TunnelClient should be CONNECTED"
         )
-        // Wait for the relay to finish auto-creating the Firestore record and
-        // inserting the mux session into its registry (both happen in the
-        // server-side `handle_mux_session` body after WS upgrade completes).
-        kotlinx.coroutines.delay(SESSION_REGISTRATION_DELAY_MS)
+        // Deterministic wait for the relay to finish auto-creating the
+        // Firestore record and inserting the mux session into its registry
+        // (both happen in the server-side `handle_mux_session` body after WS
+        // upgrade completes). Replaces the former 500ms sleep that was racing
+        // with the relay-side task scheduling under CI load -- see issue #377
+        // and the `CompletableDeferred`-based pattern from #341 this mirrors.
+        val registered = relayManager.waitForSessionRegistered(
+            DEVICE_SUBDOMAIN,
+            SESSION_REGISTRATION_TIMEOUT_MS
+        )
+        assertTrue(
+            registered,
+            "Relay did not register mux session for $DEVICE_SUBDOMAIN within " +
+                "${SESSION_REGISTRATION_TIMEOUT_MS}ms"
+        )
         return client
     }
 

--- a/relay/src/passthrough.rs
+++ b/relay/src/passthrough.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, Notify};
 use tracing::{debug, info, warn};
 
 /// Errors that can occur during passthrough.
@@ -99,12 +99,20 @@ pub struct SessionEntry {
 /// await points.
 pub struct SessionRegistry {
     sessions: DashMap<String, SessionEntry>,
+    /// Per-subdomain notifier fired when `insert` registers a new session.
+    /// Enables deterministic "wait for session registered" semantics in
+    /// tests without sleeping: `wait_until_registered` grabs (or creates)
+    /// the `Notify` for a subdomain and awaits `notified()`. See issue #377
+    /// for the flake this replaced (a hardcoded 500ms sleep in the tunnel
+    /// integration tests was racing with `insert` under CI load).
+    registration_signals: DashMap<String, Arc<Notify>>,
 }
 
 impl SessionRegistry {
     pub fn new() -> Self {
         Self {
             sessions: DashMap::new(),
+            registration_signals: DashMap::new(),
         }
     }
 
@@ -124,6 +132,46 @@ impl SessionRegistry {
                 frame_tx,
             },
         );
+        // Wake any `wait_until_registered` awaiters for this subdomain.
+        if let Some(notify) = self.registration_signals.get(subdomain) {
+            notify.notify_waiters();
+        }
+    }
+
+    /// Return whether a mux session is currently registered for `subdomain`.
+    pub fn contains(&self, subdomain: &str) -> bool {
+        self.sessions.contains_key(subdomain)
+    }
+
+    /// Wait until a mux session is registered for `subdomain`, or `timeout`
+    /// elapses. Returns `true` if a session is (or becomes) registered,
+    /// `false` on timeout.
+    ///
+    /// Used by the test-mode admin `/test/wait-session-registered` endpoint to
+    /// replace the 500ms sleep that used to guard the relay-side insertion
+    /// race in integration tests. The approach mirrors the `CompletableDeferred`
+    /// pattern from issue #341: a `Notify` primed once per subdomain lets
+    /// `insert` wake awaiters directly instead of forcing them to poll.
+    pub async fn wait_until_registered(&self, subdomain: &str, timeout: Duration) -> bool {
+        // Grab (or create) the `Notify` for this subdomain BEFORE the fast
+        // path check so that a concurrent `insert` racing between our check
+        // and the `notified()` subscription is caught by `enable()` below.
+        let notify = self
+            .registration_signals
+            .entry(subdomain.to_string())
+            .or_insert_with(|| Arc::new(Notify::new()))
+            .clone();
+        // Per tokio docs, `notified()` only starts listening when polled.
+        // `enable()` arms the future eagerly so any `notify_waiters` that
+        // fires after this line will wake it, closing the classic
+        // "notify between check and await" gap.
+        let notified = notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        if self.sessions.contains_key(subdomain) {
+            return true;
+        }
+        tokio::time::timeout(timeout, notified).await.is_ok()
     }
 
     /// Send a frame directly to the device's mux WebSocket. Test-only hook

--- a/relay/src/test_mode.rs
+++ b/relay/src/test_mode.rs
@@ -22,6 +22,10 @@
 //!   push a mux ERROR frame onto an already-open stream so tests can assert
 //!   that stream-level failures do not tear down the tunnel. `code` is a
 //!   `MuxErrorCode` value (1..=4); `message` is an optional UTF-8 diagnostic.
+//! - `GET  /test/wait-session-registered?subdomain=<sub>&timeout_ms=<ms>` —
+//!   deterministic wait for a device's mux `SessionRegistry` insertion. Used
+//!   to replace the 500ms sleep that guarded the relay-insertion race in the
+//!   integration tests (issue #377). Returns immediately if already registered.
 //! - `GET  /test/stats` — per-endpoint request counters + synthetic-wake log.
 //!
 //! See issue #249 for the motivating scenarios (#247 integration tier).
@@ -177,6 +181,46 @@ pub async fn handle_kill_ws(
 #[derive(Serialize)]
 pub struct WakeResponse {
     captured: usize,
+}
+
+#[derive(Deserialize)]
+pub struct WaitSessionQuery {
+    subdomain: String,
+    /// Upper bound in milliseconds on how long to block waiting for the
+    /// device-side WS upgrade to complete `SessionRegistry::insert`.
+    /// Defaults to 5s.
+    timeout_ms: Option<u64>,
+}
+
+#[derive(Serialize)]
+pub struct WaitSessionResponse {
+    registered: bool,
+    subdomain: String,
+}
+
+/// Block until the mux session for `subdomain` is registered (or `timeout_ms`
+/// elapses). Returns immediately if already registered. Replaces the
+/// hardcoded 500ms sleep integration tests used to insert after WS connect
+/// (issue #377) — the relay's insertion is on an async task and can be
+/// delayed under CI load, racing the AI-client TLS handshake that must
+/// route through the newly-registered session.
+pub async fn handle_wait_session_registered(
+    State(state): State<AdminState>,
+    Query(q): Query<WaitSessionQuery>,
+) -> Response {
+    let timeout = std::time::Duration::from_millis(q.timeout_ms.unwrap_or(5_000));
+    let registered = state
+        .session_registry
+        .wait_until_registered(&q.subdomain, timeout)
+        .await;
+    (
+        StatusCode::OK,
+        Json(WaitSessionResponse {
+            registered,
+            subdomain: q.subdomain,
+        }),
+    )
+        .into_response()
 }
 
 pub async fn handle_fcm_wake(
@@ -402,6 +446,10 @@ pub fn build_admin_router(admin_state: AdminState) -> axum::Router {
             "/test/emit-stream-error",
             axum::routing::post(handle_emit_stream_error),
         )
+        .route(
+            "/test/wait-session-registered",
+            axum::routing::get(handle_wait_session_registered),
+        )
         .route("/test/stats", axum::routing::get(handle_stats))
         .with_state(admin_state)
 }
@@ -565,5 +613,81 @@ mod tests {
         let router = build_admin_router(state);
         let resp = post(router, "/test/open-stream?subdomain=missing&stream_id=1").await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    async fn get(router: axum::Router, uri: &str) -> axum::response::Response {
+        router
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn read_body(resp: axum::response::Response) -> String {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn wait_session_registered_returns_immediately_when_already_registered() {
+        let (state, registry) = admin_state();
+        let _frame_rx = register_fake_session(&registry, "already");
+        let router = build_admin_router(state);
+        let resp = get(
+            router,
+            "/test/wait-session-registered?subdomain=already&timeout_ms=50",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = read_body(resp).await;
+        assert!(body.contains("\"registered\":true"), "body was: {body}");
+    }
+
+    #[tokio::test]
+    async fn wait_session_registered_unblocks_on_insert_before_timeout() {
+        let (state, registry) = admin_state();
+        let router = build_admin_router(state);
+
+        let reg_for_task = registry.clone();
+        let inserter = tokio::spawn(async move {
+            // Delay well under the admin call's timeout so the waiter is
+            // guaranteed to be parked on `notified()` before we fire.
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let (open_tx, _open_rx) = mpsc::channel(4);
+            let (kill_tx, _kill_rx) = mpsc::channel(1);
+            let (frame_tx, _frame_rx) = mpsc::channel(16);
+            reg_for_task.insert("later", open_tx, kill_tx, frame_tx);
+        });
+
+        let resp = get(
+            router,
+            "/test/wait-session-registered?subdomain=later&timeout_ms=2000",
+        )
+        .await;
+        inserter.await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = read_body(resp).await;
+        assert!(body.contains("\"registered\":true"), "body was: {body}");
+    }
+
+    #[tokio::test]
+    async fn wait_session_registered_reports_false_on_timeout() {
+        let (state, _registry) = admin_state();
+        let router = build_admin_router(state);
+        let resp = get(
+            router,
+            "/test/wait-session-registered?subdomain=never&timeout_ms=25",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = read_body(resp).await;
+        assert!(body.contains("\"registered\":false"), "body was: {body}");
     }
 }


### PR DESCRIPTION
## Summary
- Replaces `OAuthEndToEndTest`'s hardcoded `delay(500)` with a deterministic wait backed by a new per-subdomain `Notify` on the relay's `SessionRegistry`.
- `insert` fires `notify_waiters` for the subdomain, and a new `/test/wait-session-registered` admin endpoint exposes `wait_until_registered` (uses `enable()` to close the notify-between-check-and-await gap).
- OAuthEndToEndTest now opts into test-mode and calls `TestRelayManager.waitForSessionRegistered(...)` instead of sleeping.

## Root cause
When the AI client's TLS handshake landed before `SessionRegistry.insert` completed under CI load, the relay fell through to the FCM-wake path; that fails with a network error in the test harness (no valid FCM auth), producing the `SocketTimeoutException at OAuthEndToEndTest.kt:596` observed on main (run 24814276053).

Mirrors the `CompletableDeferred`-based signal pattern from #341.

## Test plan
- [x] Relay `cargo test --features test-mode` passes (including 3 new handler tests)
- [x] `cargo clippy --features test-mode -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `./gradlew ktlintCheck detekt` clean
- [x] `./gradlew :core:tunnel:integrationTest` full pass
- [x] OAuthEndToEndTest loop: 50 consecutive passes normal + 45 under `stress-ng --cpu 6..8` = 95 consecutive passes (required 50+)

Scope kept to OAuth-specific paths; other tests using the same 500ms sleep pattern are out of scope here (see #263 for EndToEndSessionTest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>