### PR TITLE
Fix #400: Migrate 4 integration tests to waitForSessionRegistered helper

### DIFF
--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/AbruptDisconnectTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/AbruptDisconnectTest.kt
@@ -11,7 +11,6 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancelChildren
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -53,8 +52,13 @@ class AbruptDisconnectTest {
         /** Same miss count as production. */
         private const val KEEPALIVE_MAX_MISSES = 3
 
-        /** Session registration delay — relay needs time after WS upgrade. */
-        private const val SESSION_REGISTRATION_DELAY_MS = 500L
+        /**
+         * Upper bound for [TestRelayManager.waitForSessionRegistered]. The
+         * relay-side `Notify` typically fires within a millisecond of the
+         * mux WebSocket upgrade completing; 10s is generous for CI under
+         * stress (#400).
+         */
+        private const val SESSION_REGISTRATION_TIMEOUT_MS = 10_000L
     }
 
     private lateinit var tempDir: File
@@ -70,7 +74,7 @@ class AbruptDisconnectTest {
         val relayBinary = findRelayBinary()
         assumeTrue(
             relayBinary.exists() && relayBinary.canExecute(),
-            "Relay binary not found. Build with: cd relay && cargo build"
+            "Relay binary not found. Build with: cd relay && cargo build --features test-mode"
         )
 
         tempDir = File.createTempFile("e2e-abrupt-", "")
@@ -80,7 +84,11 @@ class AbruptDisconnectTest {
         ca = TestCertificateAuthority(tempDir, RELAY_HOSTNAME, DEVICE_SUBDOMAIN)
         ca.generate()
 
-        relayManager = TestRelayManager(tempDir, RELAY_HOSTNAME)
+        // test-mode enables the `/test/wait-session-registered` admin
+        // endpoint used by `connectTunnelClient` to deterministically wait
+        // for the relay-side `SessionRegistry.insert` instead of a blind
+        // 500ms sleep (#400).
+        relayManager = TestRelayManager(tempDir, RELAY_HOSTNAME, enableTestMode = true)
         relayPort = findFreePort()
         relayManager.start(relayPort)
     }
@@ -148,11 +156,10 @@ class AbruptDisconnectTest {
 
             // Phase 4: restart the relay on the same port
             relayManager.stop() // clean up the dead process reference
-            relayManager = TestRelayManager(tempDir, RELAY_HOSTNAME)
+            // test-mode again so the post-reconnect waitForSessionRegistered
+            // call below can reach the admin endpoint (#400).
+            relayManager = TestRelayManager(tempDir, RELAY_HOSTNAME, enableTestMode = true)
             relayManager.start(relayPort)
-
-            // Small delay to let the new relay fully initialize
-            delay(SESSION_REGISTRATION_DELAY_MS)
 
             // Phase 5: reconnect and verify CONNECTED
             val reconnectStartMs = System.currentTimeMillis()
@@ -162,6 +169,19 @@ class AbruptDisconnectTest {
                 TunnelState.CONNECTED,
                 tunnelClient.state.value,
                 "Tunnel should be CONNECTED after reconnecting to new relay"
+            )
+
+            // Deterministic wait that the new relay completed its
+            // SessionRegistry.insert for our subdomain. Replaces the former
+            // blind 500ms post-restart sleep (#400).
+            val registered = relayManager.waitForSessionRegistered(
+                DEVICE_SUBDOMAIN,
+                SESSION_REGISTRATION_TIMEOUT_MS
+            )
+            assertTrue(
+                registered,
+                "Relay did not register mux session for $DEVICE_SUBDOMAIN after " +
+                    "restart within ${SESSION_REGISTRATION_TIMEOUT_MS}ms"
             )
 
             val reconnectTimeMs = System.currentTimeMillis() - reconnectStartMs
@@ -192,7 +212,19 @@ class AbruptDisconnectTest {
             client.state.value,
             "TunnelClient should be CONNECTED after connect()"
         )
-        delay(SESSION_REGISTRATION_DELAY_MS)
+        // Deterministic wait for the relay's `SessionRegistry.insert` after
+        // the WS upgrade completes. Replaces the former 500ms blind sleep
+        // (#400). Backed by per-subdomain `Notify` on the relay, exposed via
+        // the test-mode admin endpoint.
+        val registered = relayManager.waitForSessionRegistered(
+            DEVICE_SUBDOMAIN,
+            SESSION_REGISTRATION_TIMEOUT_MS
+        )
+        assertTrue(
+            registered,
+            "Relay did not register mux session for $DEVICE_SUBDOMAIN within " +
+                "${SESSION_REGISTRATION_TIMEOUT_MS}ms"
+        )
         return client
     }
 }

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/CertRotationIntegrationTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/CertRotationIntegrationTest.kt
@@ -31,7 +31,6 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import okhttp3.Dns
@@ -59,7 +58,7 @@ import org.junit.jupiter.api.Timeout
  * trick through [Ipv4OnlyMtlsWebSocketFactory].
  *
  * Skipped when the relay binary has not been built. Build with:
- *   cd relay && cargo build
+ *   cd relay && cargo build --features test-mode
  */
 @Tag("integration")
 @Timeout(value = 180, unit = TimeUnit.SECONDS)
@@ -70,7 +69,14 @@ class CertRotationIntegrationTest {
         private const val BASE_DOMAIN = "relay.test.internal"
         private const val DUMMY_FIREBASE_TOKEN = "test-firebase-token-rotation"
         private const val DUMMY_FCM_TOKEN = "test-fcm-token-rotation"
-        private const val SESSION_REGISTRATION_DELAY_MS = 500L
+
+        /**
+         * Upper bound for [TestRelayManager.waitForSessionRegistered]. The
+         * relay-side `Notify` typically fires within a millisecond of the
+         * mux WebSocket upgrade completing; 10s is generous for CI under
+         * stress (#400).
+         */
+        private const val SESSION_REGISTRATION_TIMEOUT_MS = 10_000L
     }
 
     private lateinit var tempDir: File
@@ -85,7 +91,7 @@ class CertRotationIntegrationTest {
         val relayBinary = findRelayBinary()
         assumeTrue(
             relayBinary.exists() && relayBinary.canExecute(),
-            "Relay binary not found. Build with: cd relay && cargo build"
+            "Relay binary not found. Build with: cd relay && cargo build --features test-mode"
         )
 
         tempDir = File.createTempFile("cert-rotation-integration-", "")
@@ -101,12 +107,17 @@ class CertRotationIntegrationTest {
         val deviceCaCertFile = ca.caCertPemFile()
 
         relayPort = findFreePort()
+        // test-mode enables the `/test/wait-session-registered` admin
+        // endpoint used after `tunnelClient.connect()` to deterministically
+        // wait for the relay-side `SessionRegistry.insert` instead of a
+        // blind 500ms sleep (#400).
         relayManager = TestRelayManager(
             tempDir,
             RELAY_HOSTNAME,
             deviceCaPaths = deviceCaKeyFile to deviceCaCertFile,
             disableFirebaseVerification = true,
-            baseDomainOverride = BASE_DOMAIN
+            baseDomainOverride = BASE_DOMAIN,
+            enableTestMode = true
         )
         relayManager.start(relayPort)
 
@@ -155,6 +166,7 @@ class CertRotationIntegrationTest {
      * Full cert rotation end-to-end: register, get certs, renew, assert new certs,
      * reconnect with renewed client cert and prove the mux session is accepted.
      */
+    @Suppress("LongMethod")
     @Test
     fun `renew returns new cert triple and reconnect with renewed cert succeeds`(): Unit =
         runBlocking {
@@ -229,8 +241,19 @@ class CertRotationIntegrationTest {
                 "TunnelClient must reach CONNECTED state after reconnect with renewed cert"
             )
 
-            // Allow session registration on the relay side
-            delay(SESSION_REGISTRATION_DELAY_MS)
+            // Deterministic wait for the relay's `SessionRegistry.insert`
+            // after the WS upgrade completes. Replaces the former 500ms
+            // blind sleep (#400). Backed by per-subdomain `Notify` on the
+            // relay, exposed via the test-mode admin endpoint.
+            val registered = relayManager.waitForSessionRegistered(
+                subdomain,
+                SESSION_REGISTRATION_TIMEOUT_MS
+            )
+            assertTrue(
+                registered,
+                "Relay did not register mux session for $subdomain within " +
+                    "${SESSION_REGISTRATION_TIMEOUT_MS}ms"
+            )
 
             // Clean disconnect
             tunnelClient.disconnect()
@@ -312,7 +335,19 @@ class CertRotationIntegrationTest {
             tunnelClient.state.value,
             "TunnelClient must connect with second-renewal certs"
         )
-        delay(SESSION_REGISTRATION_DELAY_MS)
+        // Deterministic wait for the relay's `SessionRegistry.insert` after
+        // the WS upgrade completes. Replaces the former 500ms blind sleep
+        // (#400). Backed by per-subdomain `Notify` on the relay, exposed via
+        // the test-mode admin endpoint.
+        val registered = relayManager.waitForSessionRegistered(
+            reg.subdomain,
+            SESSION_REGISTRATION_TIMEOUT_MS
+        )
+        assertTrue(
+            registered,
+            "Relay did not register mux session for ${reg.subdomain} within " +
+                "${SESSION_REGISTRATION_TIMEOUT_MS}ms"
+        )
         tunnelClient.disconnect()
     }
 

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/HalfOpenDetectionTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/HalfOpenDetectionTest.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelChildren
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -56,8 +55,13 @@ class HalfOpenDetectionTest {
         /** Same miss count as production. */
         private const val KEEPALIVE_MAX_MISSES = 3
 
-        /** Session registration delay — relay needs time after WS upgrade. */
-        private const val SESSION_REGISTRATION_DELAY_MS = 500L
+        /**
+         * Upper bound for [TestRelayManager.waitForSessionRegistered]. The
+         * relay-side `Notify` typically fires within a millisecond of the
+         * mux WebSocket upgrade completing; 10s is generous for CI under
+         * stress (#400).
+         */
+        private const val SESSION_REGISTRATION_TIMEOUT_MS = 10_000L
     }
 
     private lateinit var tempDir: File
@@ -74,7 +78,7 @@ class HalfOpenDetectionTest {
         val relayBinary = findRelayBinary()
         assumeTrue(
             relayBinary.exists() && relayBinary.canExecute(),
-            "Relay binary not found. Build with: cd relay && cargo build"
+            "Relay binary not found. Build with: cd relay && cargo build --features test-mode"
         )
 
         tempDir = File.createTempFile("e2e-halfopen-", "")
@@ -84,7 +88,11 @@ class HalfOpenDetectionTest {
         ca = TestCertificateAuthority(tempDir, RELAY_HOSTNAME, DEVICE_SUBDOMAIN)
         ca.generate()
 
-        relayManager = TestRelayManager(tempDir, RELAY_HOSTNAME)
+        // test-mode enables the `/test/wait-session-registered` admin
+        // endpoint used by `connectTunnelClient` to deterministically wait
+        // for the relay-side `SessionRegistry.insert` instead of a blind
+        // 500ms sleep (#400).
+        relayManager = TestRelayManager(tempDir, RELAY_HOSTNAME, enableTestMode = true)
         relayPort = findFreePort()
         relayManager.start(relayPort)
 
@@ -184,7 +192,19 @@ class HalfOpenDetectionTest {
             client.state.value,
             "TunnelClient should be CONNECTED after connect()"
         )
-        delay(SESSION_REGISTRATION_DELAY_MS)
+        // Deterministic wait for the relay's `SessionRegistry.insert` after
+        // the WS upgrade completes. Replaces the former 500ms blind sleep
+        // (#400). Backed by per-subdomain `Notify` on the relay, exposed via
+        // the test-mode admin endpoint.
+        val registered = relayManager.waitForSessionRegistered(
+            DEVICE_SUBDOMAIN,
+            SESSION_REGISTRATION_TIMEOUT_MS
+        )
+        assertTrue(
+            registered,
+            "Relay did not register mux session for $DEVICE_SUBDOMAIN within " +
+                "${SESSION_REGISTRATION_TIMEOUT_MS}ms"
+        )
         return client
     }
 }

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/TestRelayAdminSmokeTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/TestRelayAdminSmokeTest.kt
@@ -51,7 +51,13 @@ class TestRelayAdminSmokeTest {
         private const val KEEPALIVE_TIMEOUT_MS = 1_000L
         private const val KEEPALIVE_MAX_MISSES = 3
 
-        private const val SESSION_REGISTRATION_DELAY_MS = 500L
+        /**
+         * Upper bound for [TestRelayManager.waitForSessionRegistered]. The
+         * relay-side `Notify` typically fires within a millisecond of the
+         * mux WebSocket upgrade completing; 10s is generous for CI under
+         * stress (#400).
+         */
+        private const val SESSION_REGISTRATION_TIMEOUT_MS = 10_000L
     }
 
     private lateinit var tempDir: File
@@ -181,7 +187,19 @@ class TestRelayAdminSmokeTest {
             keepaliveMaxMisses = KEEPALIVE_MAX_MISSES
         )
         client.connect("wss://$RELAY_HOSTNAME:$relayPort/ws")
-        delay(SESSION_REGISTRATION_DELAY_MS)
+        // Deterministic wait for the relay's `SessionRegistry.insert` after
+        // the WS upgrade completes. Replaces the former 500ms blind sleep
+        // (#400). Backed by per-subdomain `Notify` on the relay, exposed via
+        // the test-mode admin endpoint.
+        val registered = relayManager.waitForSessionRegistered(
+            DEVICE_SUBDOMAIN,
+            SESSION_REGISTRATION_TIMEOUT_MS
+        )
+        assertTrue(
+            registered,
+            "Relay did not register mux session for $DEVICE_SUBDOMAIN within " +
+                "${SESSION_REGISTRATION_TIMEOUT_MS}ms"
+        )
         return client
     }
 }


### PR DESCRIPTION
## Summary
- Migrates 4 of the 6 integration tests called out in #400 from the blind `delay(SESSION_REGISTRATION_DELAY_MS = 500L)` sleep to the deterministic `relayManager.waitForSessionRegistered(subdomain, 10_000)` helper that landed in #399.
- Migrated: `AbruptDisconnectTest`, `CertRotationIntegrationTest`, `HalfOpenDetectionTest`, `TestRelayAdminSmokeTest`.
- Each migrated test now opts into `enableTestMode = true` so the `/test/wait-session-registered` admin endpoint is live.

## Migration recipe (per #399)
1. `TestRelayManager(... , enableTestMode = true)`.
2. Replace `delay(SESSION_REGISTRATION_DELAY_MS)` after `tunnelClient.connect(...)` with a `waitForSessionRegistered(subdomain, 10_000L)` call.
3. `assertTrue(registered, "<subdomain> not registered within ...ms")` so a stuck relay surfaces immediately instead of looking like the next assertion's flake.
4. Where appropriate (`AbruptDisconnectTest` post-restart), drop the second 500ms blind sleep -- it predated the helper and was redundant with `TestRelayManager.start(...)`'s admin readiness wait.

## Deferred (deviations)
Two of the six listed in #400 are intentionally **not** migrated here:

- `ClaudeFullFlowEndToEndTest` and `MultiClientConcurrencyTest`. Both wire an AI-client TLS handshake immediately after `connectTunnelClient()` while also launching `tunnelClient.incomingSessions.collect { ... }` on a separate `backgroundScope(Dispatchers.IO)`. The old 500ms blind sleep gave that collector time to subscribe before the AI bytes arrived. `waitForSessionRegistered` returns in microseconds and exposes the device-side collector-launch race as `SocketTimeoutException` on `socket.startHandshake()` (~1-in-7 even without external CPU stress). The helper itself is fine; the collector race is a separate issue requiring its own deterministic ready signal. Per #400 ("don't force the helper in -- note the deviation"), leaving these two on `delay(SESSION_REGISTRATION_DELAY_MS)` for now.
- `EndToEndSessionTest` -- tracked separately under #263.

## SESSION_REGISTRATION_DELAY_MS
Three callers still reference the constant locally (`ClaudeFullFlowEndToEndTest`, `MultiClientConcurrencyTest`, `EndToEndSessionTest`). Since each test file holds its own private `const val`, no global cleanup applies; the symbol is gone from the four migrated files.

## Verification
Locally, against b61b2f50 + this PR. CPU stress used `yes > /dev/null` x 6 instead of `stress-ng --cpu 6` (stress-ng not available on this host); same effect -- saturates 6 of 16 cores hot.

- `./gradlew :core:tunnel:ktlintCheck detekt` clean.
- `./gradlew :core:tunnel:integrationTest --tests '*<the four classes>*' --rerun-tasks`:
  - **50 / 50** consecutive passes normal load.
  - **20 / 20** consecutive passes under `yes`-storm CPU stress (6 workers).
  - 0 failures across the 70-run combined verification.

## Closes
Closes #400. Cross-references #263 (EndToEndSessionTest sibling flake) and #377 (helper origin).

## Test plan
- [x] `./gradlew :core:tunnel:ktlintCheck detekt` clean.
- [x] 50 normal + 20 stress consecutive passes for the four migrated tests, 0 failures.
- [ ] CI green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>