### PR TITLE
Fix #402: Subscribe to incomingSessions before connect (matches production)

### DIFF
--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/ClaudeFullFlowEndToEndTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/ClaudeFullFlowEndToEndTest.kt
@@ -89,7 +89,14 @@ class ClaudeFullFlowEndToEndTest {
         private const val INTEGRATION = "test"
         private const val INTEGRATION_HOST =
             "exact-$INTEGRATION.$DEVICE_SUBDOMAIN.$RELAY_HOSTNAME"
-        private const val SESSION_REGISTRATION_DELAY_MS = 500L
+
+        /**
+         * Upper bound for [TestRelayManager.waitForSessionRegistered]. The
+         * relay-side `Notify` typically fires within a millisecond of the
+         * mux WebSocket upgrade completing; 10s is generous for CI under
+         * stress (#400).
+         */
+        private const val SESSION_REGISTRATION_TIMEOUT_MS = 10_000L
     }
 
     // --- Infrastructure (shared across all test methods) ---
@@ -136,7 +143,11 @@ class ClaudeFullFlowEndToEndTest {
         ca = TestCertificateAuthority(tempDir, RELAY_HOSTNAME, DEVICE_SUBDOMAIN)
         ca.generate()
 
-        relayManager = TestRelayManager(tempDir, RELAY_HOSTNAME)
+        // test-mode enables the `/test/wait-session-registered` admin
+        // endpoint used by `connectTunnelClient` to deterministically wait
+        // for the relay-side `SessionRegistry.insert` instead of a blind
+        // 500ms sleep (#400, #402).
+        relayManager = TestRelayManager(tempDir, RELAY_HOSTNAME, enableTestMode = true)
         relayPort = findFreePort()
         relayManager.start(relayPort)
 
@@ -146,9 +157,15 @@ class ClaudeFullFlowEndToEndTest {
         tokenStore = InMemoryTokenStore()
         authorizationCodeManager = AuthorizationCodeManager(tokenStore = tokenStore)
 
-        tunnelClient = connectTunnelClient()
-
-        // Collect incoming sessions on the background scope (not runBlocking's scope)
+        // Subscribe to incoming sessions BEFORE connect so the collector is
+        // active when the relay starts splicing AI-client sockets to mux
+        // streams. Matches production wiring in TunnelForegroundService
+        // (#402): `_incomingSessions` is a `Channel(Channel.BUFFERED)`, so a
+        // late subscriber wouldn't lose frames, but the previous
+        // connect-then-collect ordering masked subtler races where the
+        // collector hadn't started before the AI-client TLS handshake hit
+        // the relay (~1-in-7 flake on iter 7/50 of the stress loop).
+        tunnelClient = createTunnelClient()
         backgroundScope.launch {
             tunnelClient.incomingSessions.collect { stream ->
                 launch(Dispatchers.IO) {
@@ -156,6 +173,7 @@ class ClaudeFullFlowEndToEndTest {
                 }
             }
         }
+        connectTunnelClient(tunnelClient)
 
         // AI client connects via TLS through the relay
         aiSocket = withTimeout(15_000) {
@@ -632,21 +650,40 @@ class ClaudeFullFlowEndToEndTest {
     // TunnelClient connection
     // =====================================================================
 
-    private suspend fun connectTunnelClient(): TunnelClientImpl {
+    /**
+     * Build the [TunnelClientImpl] without connecting it. The caller is
+     * expected to subscribe to [TunnelClientImpl.incomingSessions] before
+     * invoking [connectTunnelClient] so the collector is live when the
+     * relay starts splicing client sockets onto mux streams.
+     */
+    private fun createTunnelClient(): TunnelClientImpl {
         val sslContext = TestSslContexts.buildMtls(deviceKeyStore, caCert)
         val wsFactory = MtlsWebSocketFactory(sslContext)
-        val client = TunnelClientImpl(
+        return TunnelClientImpl(
             scope = kotlinx.coroutines.CoroutineScope(Dispatchers.IO),
             webSocketFactory = wsFactory
         )
+    }
+
+    private suspend fun connectTunnelClient(client: TunnelClientImpl) {
         client.connect("wss://$RELAY_HOSTNAME:$relayPort/ws")
         assertEquals(
             com.rousecontext.tunnel.TunnelState.CONNECTED,
             client.state.value,
             "TunnelClient should be CONNECTED"
         )
-        kotlinx.coroutines.delay(SESSION_REGISTRATION_DELAY_MS)
-        return client
+        // Deterministic wait for the relay's `SessionRegistry.insert` after
+        // the WS upgrade completes (#400). Backed by per-subdomain `Notify`
+        // on the relay, exposed via the test-mode admin endpoint.
+        val registered = relayManager.waitForSessionRegistered(
+            DEVICE_SUBDOMAIN,
+            SESSION_REGISTRATION_TIMEOUT_MS
+        )
+        assertTrue(
+            registered,
+            "Relay did not register mux session for $DEVICE_SUBDOMAIN within " +
+                "${SESSION_REGISTRATION_TIMEOUT_MS}ms"
+        )
     }
 
     // =====================================================================

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/MultiClientConcurrencyTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/integration/MultiClientConcurrencyTest.kt
@@ -80,7 +80,14 @@ class MultiClientConcurrencyTest {
         private const val INTEGRATION = "test"
         private const val INTEGRATION_HOST =
             "exact-$INTEGRATION.$DEVICE_SUBDOMAIN.$RELAY_HOSTNAME"
-        private const val SESSION_REGISTRATION_DELAY_MS = 500L
+
+        /**
+         * Upper bound for [TestRelayManager.waitForSessionRegistered]. The
+         * relay-side `Notify` typically fires within a millisecond of the
+         * mux WebSocket upgrade completing; 10s is generous for CI under
+         * stress (#400).
+         */
+        private const val SESSION_REGISTRATION_TIMEOUT_MS = 10_000L
     }
 
     private lateinit var tempDir: File
@@ -115,7 +122,11 @@ class MultiClientConcurrencyTest {
         ca = TestCertificateAuthority(tempDir, RELAY_HOSTNAME, DEVICE_SUBDOMAIN)
         ca.generate()
 
-        relayManager = TestRelayManager(tempDir, RELAY_HOSTNAME)
+        // test-mode enables the `/test/wait-session-registered` admin
+        // endpoint used by `connectTunnelClient` to deterministically wait
+        // for the relay-side `SessionRegistry.insert` instead of a blind
+        // 500ms sleep (#400, #402).
+        relayManager = TestRelayManager(tempDir, RELAY_HOSTNAME, enableTestMode = true)
         relayPort = findFreePort()
         relayManager.start(relayPort)
 
@@ -125,8 +136,15 @@ class MultiClientConcurrencyTest {
         tokenStore = InMemoryTokenStore()
         authorizationCodeManager = AuthorizationCodeManager(tokenStore = tokenStore)
 
-        tunnelClient = connectTunnelClient()
-
+        // Subscribe to incoming sessions BEFORE connect so the collector is
+        // active when the relay starts splicing AI-client sockets to mux
+        // streams. Matches production wiring in TunnelForegroundService
+        // (#402): `_incomingSessions` is a `Channel(Channel.BUFFERED)`, so a
+        // late subscriber wouldn't lose frames, but the previous
+        // connect-then-collect ordering masked a subtler races where the
+        // collector hadn't started before the AI-client TLS handshake hit
+        // the relay (~1-in-7 flake).
+        tunnelClient = createTunnelClient()
         backgroundScope.launch {
             tunnelClient.incomingSessions.collect { stream ->
                 launch(Dispatchers.IO) {
@@ -134,6 +152,7 @@ class MultiClientConcurrencyTest {
                 }
             }
         }
+        connectTunnelClient(tunnelClient)
         Unit
     }
 
@@ -523,21 +542,40 @@ class MultiClientConcurrencyTest {
     // TunnelClient connection
     // =====================================================================
 
-    private suspend fun connectTunnelClient(): TunnelClientImpl {
+    /**
+     * Build the [TunnelClientImpl] without connecting it. The caller is
+     * expected to subscribe to [TunnelClientImpl.incomingSessions] before
+     * invoking [connectTunnelClient] so the collector is live when the
+     * relay starts splicing client sockets onto mux streams.
+     */
+    private fun createTunnelClient(): TunnelClientImpl {
         val sslContext = TestSslContexts.buildMtls(deviceKeyStore, caCert)
         val wsFactory = MtlsWebSocketFactory(sslContext)
-        val client = TunnelClientImpl(
+        return TunnelClientImpl(
             scope = CoroutineScope(Dispatchers.IO),
             webSocketFactory = wsFactory
         )
+    }
+
+    private suspend fun connectTunnelClient(client: TunnelClientImpl) {
         client.connect("wss://$RELAY_HOSTNAME:$relayPort/ws")
         assertEquals(
             TunnelState.CONNECTED,
             client.state.value,
             "TunnelClient should be CONNECTED"
         )
-        delay(SESSION_REGISTRATION_DELAY_MS)
-        return client
+        // Deterministic wait for the relay's `SessionRegistry.insert` after
+        // the WS upgrade completes (#400). Backed by per-subdomain `Notify`
+        // on the relay, exposed via the test-mode admin endpoint.
+        val registered = relayManager.waitForSessionRegistered(
+            DEVICE_SUBDOMAIN,
+            SESSION_REGISTRATION_TIMEOUT_MS
+        )
+        assertTrue(
+            registered,
+            "Relay did not register mux session for $DEVICE_SUBDOMAIN within " +
+                "${SESSION_REGISTRATION_TIMEOUT_MS}ms"
+        )
     }
 
     // =====================================================================


### PR DESCRIPTION
## Summary
- Reorders `MultiClientConcurrencyTest` and `ClaudeFullFlowEndToEndTest` to subscribe to `tunnelClient.incomingSessions` *before* calling `connectTunnelClient(...)`, matching production wiring in `TunnelForegroundService` (`launch { collectIncomingSessions() }` fires before `tunnelClient.connect(...)`).
- Replaces the blind `delay(SESSION_REGISTRATION_DELAY_MS = 500L)` in `connectTunnelClient` with the deterministic `relayManager.waitForSessionRegistered(subdomain, 10_000)` helper from #399 (same migration recipe as PR #401's four tests).
- Drops both per-class `SESSION_REGISTRATION_DELAY_MS = 500L` constants. After this, only `EndToEndSessionTest` still carries one (13 scenarios, tracked under #263).

## Why this works without a new ready-signal API
- `_incomingSessions` is a `Channel(Channel.BUFFERED)` (default 64 slots) on `TunnelClientImpl`. A late subscriber would not lose frames anyway.
- Production `TunnelForegroundService` already does subscribe-before-connect (lines 96, 199, 331). The previous test ordering (connect → launch collector on a separate `Dispatchers.IO` scope) didn't match production and was a test-only bug masked by the 500ms sleep.
- No public API change. No new `StateFlow`. Just reorder + drop the constant.

## Verification
Ran on this branch (`fix-402-subscribe-before-connect`) on a 16-core box. CPU stress used `yes > /dev/null` x 6 (saturates 6 cores hot) since `stress-ng` isn't installed -- same recipe PR #401 used.

- `./gradlew :core:tunnel:ktlintCheck detekt` clean.
- `./gradlew :core:tunnel:jvmTest` clean.
- `./gradlew :core:tunnel:integrationTest --tests '*MultiClientConcurrencyTest*' --rerun-tasks`:
  - **50 / 50** consecutive passes normal load.
  - **20 / 20** consecutive passes under `yes`-storm CPU stress (two back-to-back runs to confirm).
- `./gradlew :core:tunnel:integrationTest --tests '*ClaudeFullFlowEndToEndTest*' --rerun-tasks`:
  - **50 / 50** consecutive passes normal load.
  - **20 / 20** consecutive passes under `yes`-storm CPU stress.

Note: one earlier 18/20 MultiClient stress run (failures at iter 10 and 14, both `SocketTimeoutException` on the AI-client TLS handshake) traced to Gradle daemon contention from a parallel `:core:tunnel:jvmTest` invocation I ran during the stress loop; once the daemons quiesced, two back-to-back 20/20 runs reproduced cleanly. Calling that out in case CI ever reproduces the 18/20 -- the symptom looks like a slow-handshake stress flake, not the connect/subscribe race that #402 was about.

## Scope choices
- `EndToEndSessionTest` (the third holdout, suspected sibling of #263 with 13 `connectTunnelClient()` call sites across scenarios) is *not* migrated here. Mechanically the same fix would apply, but it's a much larger reorder and the previous agent's analysis of #263 isn't yet empirically confirmed. Leaving #263 as the tracker rather than expanding scope mid-PR.
- No production code touched. Test-side only, per the issue brief.

## Closes
Closes #402.

Cross-references #263 (`EndToEndSessionTest` sibling flake, scenario 20), #400 / PR #401 (the four previously-migrated tests), #377 / PR #399 (the `waitForSessionRegistered` helper origin).

## Test plan
- [x] `./gradlew :core:tunnel:ktlintCheck detekt` clean.
- [x] `./gradlew :core:tunnel:jvmTest` clean.
- [x] 50/50 normal + 20/20 stress passes per class, 0 failures (at the verified-final state).
- [ ] CI green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>