### PR TITLE
Refine ux-changes rule: doc updates describing shipped behavior are not UX changes

### DIFF
--- a/.claude/rules/ux-changes.md
+++ b/.claude/rules/ux-changes.md
@@ -18,6 +18,7 @@ Filing an issue with options and a ranked recommendation is NOT approval. A GitH
 - Bug fixes that restore previously-intended behavior (the prior behavior was the approved one)
 - Copy wording at the same step, same flow position, same intent
 - New screens that are pure additions behind existing entry points (e.g. new Settings sub-pages, new Help content)
+- **Documentation updates that describe already-shipped behavior** — bringing design docs, READMEs, or audits in line with what the code already does. No code changes, no behavior changes. This is doc maintenance, not UX. (Don't conflate "rewriting design docs to match shipped code" with "changing the design.")
 
 ## Gray zone — ask
 


### PR DESCRIPTION
Per user feedback: "updating docs to reflect the current ux and design is not ux change". Adds the carve-out to `.claude/rules/ux-changes.md`'s 'does not require approval' list. Companion memory entry `feedback_bugfix_vs_design_choice.md` updated locally with the same clarification.

Tiny one-line addition; no code, no behavior, no other docs touched.