### PR TITLE
Fix #414: Await IntegrationProviderRegistry first emission before checking enabledPaths()

### DIFF
--- a/app/src/main/java/com/rousecontext/app/registry/IntegrationProviderRegistry.kt
+++ b/app/src/main/java/com/rousecontext/app/registry/IntegrationProviderRegistry.kt
@@ -4,12 +4,15 @@ import com.rousecontext.api.IntegrationStateStore
 import com.rousecontext.api.McpIntegration
 import com.rousecontext.mcp.core.McpServerProvider
 import com.rousecontext.mcp.core.ProviderRegistry
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 /**
@@ -21,6 +24,14 @@ import kotlinx.coroutines.launch
  * This registry keeps its own always-on [StateFlow] of enabled IDs so that
  * synchronous callers (FCM receiver, TunnelForegroundService) get up-to-date
  * reads without blocking. The flow is launched eagerly in the provided [appScope].
+ *
+ * ### Cold-start readiness (issue #414)
+ *
+ * The [IntegrationStateStore] is DataStore-backed and emits its first value
+ * asynchronously. Between construction and the first emission, [enabledPaths]
+ * returns `emptySet()` — which historically caused FCM wakes during cold-start
+ * to be silently dropped. Callers that gate behavior on the snapshot MUST
+ * [awaitReady] (or [awaitReadyBlocking]) first.
  */
 class IntegrationProviderRegistry(
     integrations: List<McpIntegration>,
@@ -36,19 +47,36 @@ class IntegrationProviderRegistry(
     /** Live snapshot of enabled integration IDs. Exposed for tests and UI. */
     val enabledIds: StateFlow<Set<String>> = _enabledIds.asStateFlow()
 
+    private val readyDeferred = CompletableDeferred<Unit>()
+    private val readyLatch = CountDownLatch(1)
+
     init {
         val flows = integrations.map { integration ->
             stateStore.observeUserEnabled(integration.id)
         }
-        appScope.launch {
-            if (flows.isEmpty()) return@launch
-            combine(flows) { values ->
-                integrations
-                    .mapIndexedNotNull { index, integration ->
-                        if (values[index]) integration.id else null
-                    }
-                    .toSet()
-            }.collect { _enabledIds.value = it }
+        if (flows.isEmpty()) {
+            // No integrations to load — registry is trivially ready.
+            signalReady()
+        } else {
+            appScope.launch {
+                combine(flows) { values ->
+                    integrations
+                        .mapIndexedNotNull { index, integration ->
+                            if (values[index]) integration.id else null
+                        }
+                        .toSet()
+                }
+                    .onEach { _enabledIds.value = it }
+                    .collect { signalReady() }
+            }
+        }
+    }
+
+    private fun signalReady() {
+        // Idempotent: subsequent emissions just no-op on the already-completed signals.
+        readyDeferred.complete(Unit)
+        if (readyLatch.count > 0) {
+            readyLatch.countDown()
         }
     }
 
@@ -62,4 +90,11 @@ class IntegrationProviderRegistry(
         .filter { it.value.id in _enabledIds.value }
         .map { it.key }
         .toSet()
+
+    override suspend fun awaitReady() {
+        readyDeferred.await()
+    }
+
+    override fun awaitReadyBlocking(timeoutMs: Long): Boolean =
+        readyLatch.await(timeoutMs, TimeUnit.MILLISECONDS)
 }

--- a/app/src/test/java/com/rousecontext/app/registry/IntegrationProviderRegistryTest.kt
+++ b/app/src/test/java/com/rousecontext/app/registry/IntegrationProviderRegistryTest.kt
@@ -4,6 +4,7 @@ import com.rousecontext.api.IntegrationStateStore
 import com.rousecontext.api.McpIntegration
 import com.rousecontext.mcp.core.McpServerProvider
 import io.modelcontextprotocol.kotlin.sdk.server.Server
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -12,6 +13,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -19,6 +21,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -110,6 +113,92 @@ class IntegrationProviderRegistryTest {
         assertEquals(emptySet<String>(), registry.enabledPaths())
         // No need to await — flow never launches and enabledIds stays empty.
         assertEquals(emptySet<String>(), registry.enabledIds.value)
+    }
+
+    @Test
+    fun `awaitReady completes immediately when integrations list is empty`() = runBlocking {
+        val store = FakeStateStore()
+        val registry = IntegrationProviderRegistry(emptyList(), store, scope)
+        // Should not hang — empty registry is trivially ready.
+        withTimeout(TIMEOUT_MS) { registry.awaitReady() }
+        assertTrue(
+            "awaitReadyBlocking should also report ready",
+            registry.awaitReadyBlocking(TIMEOUT_MS)
+        )
+    }
+
+    @Test
+    fun `awaitReady completes after first state-store emission with empty disk state`() =
+        runBlocking {
+            val health = fakeIntegration("health", "/health")
+            val store = FakeStateStore()
+            val registry = IntegrationProviderRegistry(listOf(health), store, scope)
+
+            // Default FakeStateStore emits `false` immediately, which is a valid
+            // first emission ("nothing enabled on disk"). awaitReady must return.
+            withTimeout(TIMEOUT_MS) { registry.awaitReady() }
+            assertEquals(emptySet<String>(), registry.enabledPaths())
+        }
+
+    @Test
+    fun `awaitReady completes after first state-store emission with enabled state`() = runBlocking {
+        val health = fakeIntegration("health", "/health")
+        val store = FakeStateStore()
+        store.enabledFor("health").value = true
+        val registry = IntegrationProviderRegistry(listOf(health), store, scope)
+
+        withTimeout(TIMEOUT_MS) { registry.awaitReady() }
+        assertEquals(setOf("health"), registry.enabledPaths())
+    }
+
+    @Test
+    fun `awaitReady is idempotent across multiple calls`() = runBlocking {
+        val health = fakeIntegration("health", "/health")
+        val store = FakeStateStore()
+        val registry = IntegrationProviderRegistry(listOf(health), store, scope)
+
+        withTimeout(TIMEOUT_MS) { registry.awaitReady() }
+        // A second call must return immediately (already complete).
+        withTimeout(TIMEOUT_MS) { registry.awaitReady() }
+        // And awaitReadyBlocking with a tiny timeout must also return true.
+        assertTrue(registry.awaitReadyBlocking(50))
+    }
+
+    @Test
+    fun `awaitReady does not complete before the first emission lands`() = runBlocking {
+        // Use a slow-loading state store: its observeUserEnabled flow only emits
+        // after the test signals it. This proves awaitReady actually waits for
+        // the first emission rather than completing on construction.
+        val health = fakeIntegration("health", "/health")
+        val gate = CompletableDeferred<Unit>()
+        val slowStore = SlowFakeStateStore(gate, initialEnabled = true)
+        val registry = IntegrationProviderRegistry(listOf(health), slowStore, scope)
+
+        // awaitReadyBlocking with a short timeout must report `false` while gated.
+        assertEquals(false, registry.awaitReadyBlocking(50))
+
+        // Open the gate, then awaitReady should complete and reflect enabled state.
+        gate.complete(Unit)
+        withTimeout(TIMEOUT_MS) { registry.awaitReady() }
+        assertEquals(setOf("health"), registry.enabledPaths())
+    }
+
+    /** State store whose [observeUserEnabled] flow emits only after [gate] completes. */
+    private class SlowFakeStateStore(
+        private val gate: CompletableDeferred<Unit>,
+        private val initialEnabled: Boolean
+    ) : IntegrationStateStore {
+        override suspend fun isUserEnabled(integrationId: String): Boolean = initialEnabled
+        override suspend fun setUserEnabled(integrationId: String, enabled: Boolean) = Unit
+        override fun observeUserEnabled(integrationId: String): Flow<Boolean> = flow {
+            gate.await()
+            emit(initialEnabled)
+        }
+        override suspend fun wasEverEnabled(integrationId: String): Boolean = initialEnabled
+        override fun observeEverEnabled(integrationId: String): Flow<Boolean> = flow {
+            emit(initialEnabled)
+        }
+        override fun observeChanges(): Flow<Unit> = flow { emit(Unit) }
     }
 
     private fun fakeIntegration(integrationId: String, integrationPath: String): McpIntegration =

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/InMemoryProviderRegistry.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/InMemoryProviderRegistry.kt
@@ -45,4 +45,10 @@ class InMemoryProviderRegistry : ProviderRegistry {
             return providers.keys.filter { it in enabled }.toSet()
         }
     }
+
+    /** In-memory state is populated synchronously; the registry is always ready. */
+    override suspend fun awaitReady() = Unit
+
+    /** In-memory state is populated synchronously; the registry is always ready. */
+    override fun awaitReadyBlocking(timeoutMs: Long): Boolean = true
 }

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/ProviderRegistry.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/ProviderRegistry.kt
@@ -7,6 +7,13 @@ package com.rousecontext.mcp.core
  * per-request to resolve path prefixes to providers.
  *
  * Changes (enable/disable) are reflected immediately - no session reconstruction needed.
+ *
+ * Implementations may load enabled state asynchronously (e.g. from DataStore). Callers
+ * that need to make a decision based on [enabledPaths] at process-startup time MUST
+ * suspend on [awaitReady] (or [awaitReadyBlocking] for non-coroutine callers) before
+ * reading the snapshot — otherwise the registry may report "no integrations enabled"
+ * during the brief window between construction and the first state-store emission.
+ * See issue #414.
  */
 interface ProviderRegistry {
 
@@ -20,6 +27,29 @@ interface ProviderRegistry {
 
     /**
      * Returns the set of currently enabled path prefixes (e.g. ["health", "notifications"]).
+     *
+     * The result is a snapshot of the in-memory state. On a freshly-constructed registry,
+     * this may return an empty set even when the user has enabled integrations on disk —
+     * callers MUST [awaitReady] first if they need to act on the absence of integrations.
      */
     fun enabledPaths(): Set<String>
+
+    /**
+     * Suspends until the registry has loaded its initial enabled-state snapshot.
+     * Subsequent calls return immediately.
+     *
+     * After this returns, [enabledPaths] reflects the on-disk state (which may still be
+     * empty if no integrations are enabled — that is a valid loaded state).
+     */
+    suspend fun awaitReady()
+
+    /**
+     * Thread-blocking variant of [awaitReady] for callers that cannot suspend (e.g.
+     * [com.google.firebase.messaging.FirebaseMessagingService.onMessageReceived], which
+     * runs on a background worker thread that the FCM service holds a wakelock for).
+     *
+     * Returns `true` if the registry became ready within [timeoutMs]; `false` otherwise.
+     * MUST NOT be called from the main thread.
+     */
+    fun awaitReadyBlocking(timeoutMs: Long): Boolean
 }

--- a/work/src/main/kotlin/com/rousecontext/work/FcmReceiver.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/FcmReceiver.kt
@@ -35,22 +35,40 @@ class FcmReceiver : FirebaseMessagingService() {
         Log.d(TAG, "FCM received: type=${message.data["type"]}, action=$action")
 
         when (action) {
-            is FcmAction.StartService -> {
-                if (providerRegistry.enabledPaths().isEmpty()) {
-                    Log.i(TAG, "Ignoring wake: no integrations enabled")
-                    return
-                }
+            is FcmAction.StartService -> dispatchIfIntegrationsEnabled("wake") {
                 startTunnelService()
             }
-            is FcmAction.EnqueueRenewal -> {
-                if (providerRegistry.enabledPaths().isEmpty()) {
-                    Log.i(TAG, "Ignoring cert renewal: no integrations enabled")
-                    return
-                }
+            is FcmAction.EnqueueRenewal -> dispatchIfIntegrationsEnabled("cert renewal") {
                 enqueueCertRenewal()
             }
             is FcmAction.Ignore -> Log.w(TAG, "Ignoring unknown FCM type: ${action.type}")
         }
+    }
+
+    /**
+     * Wait for the provider registry to load its initial enabled-state snapshot
+     * (issue #414), then dispatch [action] only if at least one integration is
+     * enabled. If the registry doesn't become ready within [REGISTRY_READY_TIMEOUT_MS],
+     * drop the wake — that's safer than spinning up the tunnel against unknown state.
+     *
+     * Blocks the FCM background worker thread (NOT the main thread). FCM gives this
+     * service ~10s before the system reclaims the wakelock, so a 2s wait is safe.
+     */
+    private fun dispatchIfIntegrationsEnabled(label: String, action: () -> Unit) {
+        val ready = providerRegistry.awaitReadyBlocking(REGISTRY_READY_TIMEOUT_MS)
+        if (!ready) {
+            Log.w(
+                TAG,
+                "Ignoring $label: provider registry did not become ready within " +
+                    "${REGISTRY_READY_TIMEOUT_MS}ms"
+            )
+            return
+        }
+        if (providerRegistry.enabledPaths().isEmpty()) {
+            Log.i(TAG, "Ignoring $label: no integrations enabled")
+            return
+        }
+        action()
     }
 
     override fun onNewToken(token: String) {
@@ -89,5 +107,12 @@ class FcmReceiver : FirebaseMessagingService() {
 
     companion object {
         private const val TAG = "FcmReceiver"
+
+        /**
+         * How long to wait for the provider registry to load its first DataStore
+         * emission before dropping a wake. DataStore reads are typically <100ms,
+         * so 2s is generous. Issue #414.
+         */
+        internal const val REGISTRY_READY_TIMEOUT_MS = 2_000L
     }
 }

--- a/work/src/main/kotlin/com/rousecontext/work/TunnelForegroundService.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/TunnelForegroundService.kt
@@ -143,18 +143,24 @@ class TunnelForegroundService : LifecycleService() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         super.onStartCommand(intent, flags, startId)
 
-        if (providerRegistry.enabledPaths().isEmpty()) {
-            Log.i(TAG, "No integrations enabled, stopping service")
-            stopSelf()
-            return START_NOT_STICKY
-        }
-
         // Reset flags from any previous service instance — Koin singletons
         // and this service's own state may carry over from an idle-timeout stop.
         intentionalDisconnect = false
         idleTimeoutManager.resetTimeout()
 
-        lifecycleScope.launch { connectToRelay() }
+        // Issue #414: the provider registry may not have loaded its DataStore-backed
+        // enabled-state snapshot yet on a cold-start FCM wake. Suspend until it has,
+        // then either bail out (no integrations) or proceed to connectToRelay().
+        // Keep onStartCommand non-blocking by deferring the check to a coroutine.
+        lifecycleScope.launch {
+            providerRegistry.awaitReady()
+            if (providerRegistry.enabledPaths().isEmpty()) {
+                Log.i(TAG, "No integrations enabled, stopping service")
+                stopSelf()
+                return@launch
+            }
+            connectToRelay()
+        }
 
         return START_NOT_STICKY
     }

--- a/work/src/test/kotlin/com/rousecontext/work/FcmReceiverTest.kt
+++ b/work/src/test/kotlin/com/rousecontext/work/FcmReceiverTest.kt
@@ -1,0 +1,202 @@
+package com.rousecontext.work
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.google.firebase.messaging.RemoteMessage
+import com.rousecontext.mcp.core.McpServerProvider
+import com.rousecontext.mcp.core.ProviderRegistry
+import io.mockk.mockk
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Regression tests for issue #414: cold-start FCM wakes were silently dropped because
+ * [com.rousecontext.app.registry.IntegrationProviderRegistry] reported "no integrations
+ * enabled" before its DataStore-backed flow had emitted its first value.
+ *
+ * The fix introduces [ProviderRegistry.awaitReadyBlocking] and routes FCM-receive
+ * dispatches through it. These tests exercise the dispatch path without hitting
+ * Firebase Cloud Messaging itself by constructing [FcmReceiver] directly under
+ * Robolectric and feeding it a synthetic [RemoteMessage].
+ */
+@RunWith(RobolectricTestRunner::class)
+class FcmReceiverTest {
+
+    private lateinit var fakeRegistry: FakeProviderRegistry
+
+    @Before
+    fun setUp() {
+        fakeRegistry = FakeProviderRegistry()
+        runCatching { stopKoin() }
+        startKoin {
+            modules(
+                module {
+                    single<ProviderRegistry> { fakeRegistry }
+                    // FcmReceiver also injects FcmTokenRegistrar but only uses
+                    // it inside onNewToken, which these tests don't exercise.
+                    single { mockk<FcmTokenRegistrar>(relaxed = true) }
+                }
+            )
+        }
+    }
+
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Test
+    fun `wake dispatches to startService once registry becomes ready with enabled state`() {
+        // Reproduces the cold-start race in issue #414: registry has not yet loaded
+        // when the FCM wake arrives. The receiver must wait for the first emission
+        // (with at least one integration enabled) and THEN start the service.
+        //
+        // Critical: BEFORE readiness, enabledPaths() returns emptySet() — exactly
+        // the production race condition. A receiver that doesn't wait for ready
+        // will see emptySet() and silently drop the wake.
+        fakeRegistry.eventualEnabled = setOf("health")
+        fakeRegistry.signalReadyAfter(50.millis)
+
+        val receiver = buildReceiver()
+        receiver.onMessageReceived(wakeMessage())
+
+        val nextStarted = shadowOf(application).peekNextStartedService()
+        assertNotNull(
+            "Service must start once the registry's first emission lands",
+            nextStarted
+        )
+        assertEquals(
+            TunnelForegroundService::class.java.name,
+            nextStarted!!.component!!.className
+        )
+    }
+
+    @Test
+    fun `wake dispatches synchronously when registry is already ready`() {
+        fakeRegistry.eventualEnabled = setOf("health")
+        fakeRegistry.signalReadyNow()
+
+        val receiver = buildReceiver()
+        receiver.onMessageReceived(wakeMessage())
+
+        val nextStarted = shadowOf(application).peekNextStartedService()
+        assertNotNull(nextStarted)
+    }
+
+    @Test
+    fun `wake is dropped when registry becomes ready with empty integrations`() {
+        // The user has disabled every integration. The registry loads, reports
+        // emptySet(), and we should NOT start the service. This is the legitimate
+        // post-fix "ignore wake" path (vs. the pre-fix race that ignored wakes
+        // even when the user HAD integrations enabled on disk).
+        fakeRegistry.eventualEnabled = emptySet()
+        fakeRegistry.signalReadyNow()
+
+        val receiver = buildReceiver()
+        receiver.onMessageReceived(wakeMessage())
+
+        assertNull(
+            "Service must not start when no integrations are enabled",
+            shadowOf(application).peekNextStartedService()
+        )
+    }
+
+    @Test
+    fun `wake is dropped when registry never becomes ready within the timeout`() {
+        // If the registry hangs (DataStore stuck, etc.), drop the wake rather than
+        // spin up the tunnel against unknown state. This is the safety fallback.
+        fakeRegistry.eventualEnabled = setOf("health")
+        // Do NOT signal ready — the latch will time out.
+
+        // Override the constant via reflection would be invasive; instead exploit
+        // the small explicit timeout in our fake to keep this test fast.
+        fakeRegistry.blockingTimeoutOverride = 100L
+
+        val receiver = buildReceiver()
+        receiver.onMessageReceived(wakeMessage())
+
+        assertNull(
+            "Service must not start if the registry didn't become ready",
+            shadowOf(application).peekNextStartedService()
+        )
+    }
+
+    /** Build the receiver via Robolectric so its base-class context is wired. */
+    private fun buildReceiver(): FcmReceiver =
+        Robolectric.buildService(FcmReceiver::class.java).create().get()
+
+    private val application: Application
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun wakeMessage(): RemoteMessage = RemoteMessage.Builder("test@fcm")
+        .addData("type", "wake")
+        .build()
+
+    private val Int.millis: Long get() = toLong()
+
+    /**
+     * Hand-rolled fake of [ProviderRegistry] that mirrors the production race:
+     * [enabledPaths] returns `emptySet()` until [eventualEnabled] is "loaded"
+     * (signaled via [signalReadyAfter] or [signalReadyNow]).
+     *
+     * Pre-fix, [FcmReceiver] read `enabledPaths()` synchronously and saw the empty
+     * set on every cold-start wake, silently dropping it. Post-fix, the receiver
+     * blocks on [awaitReadyBlocking] first, so the test sees the loaded state.
+     */
+    private class FakeProviderRegistry : ProviderRegistry {
+        /** What [enabledPaths] should return AFTER readiness. */
+        var eventualEnabled: Set<String> = emptySet()
+        private val ready = MutableStateFlow(false)
+        private val latch = CountDownLatch(1)
+
+        /**
+         * Optional override for awaitReadyBlocking's caller-supplied timeout. Tests that
+         * intentionally never signal ready use this to bound the test runtime, since
+         * production FcmReceiver passes a 2s timeout.
+         */
+        var blockingTimeoutOverride: Long? = null
+
+        fun signalReadyNow() {
+            ready.value = true
+            latch.countDown()
+        }
+
+        fun signalReadyAfter(delayMillis: Long) {
+            Thread {
+                Thread.sleep(delayMillis)
+                ready.value = true
+                latch.countDown()
+            }.apply { isDaemon = true }.start()
+        }
+
+        override fun providerForPath(path: String): McpServerProvider? = null
+
+        override fun enabledPaths(): Set<String> = if (ready.value) eventualEnabled else emptySet()
+
+        override suspend fun awaitReady() {
+            while (!ready.value) {
+                delay(10)
+            }
+        }
+
+        override fun awaitReadyBlocking(timeoutMs: Long): Boolean {
+            val effective = blockingTimeoutOverride ?: timeoutMs
+            return latch.await(effective, TimeUnit.MILLISECONDS)
+        }
+    }
+}

--- a/work/src/test/kotlin/com/rousecontext/work/TunnelForegroundServiceLifecycleTest.kt
+++ b/work/src/test/kotlin/com/rousecontext/work/TunnelForegroundServiceLifecycleTest.kt
@@ -12,6 +12,7 @@ import com.rousecontext.tunnel.MuxStream
 import com.rousecontext.tunnel.TunnelClient
 import com.rousecontext.tunnel.TunnelError
 import com.rousecontext.tunnel.TunnelState
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -59,6 +60,11 @@ class TunnelForegroundServiceLifecycleTest {
         providerRegistry = mockk {
             every { enabledPaths() } returns setOf("health")
             every { providerForPath(any()) } returns null
+            // Issue #414: TunnelForegroundService.onStartCommand now suspends on
+            // awaitReady() before checking enabledPaths(). Default to "ready"
+            // so existing lifecycle tests behave the same way.
+            coEvery { awaitReady() } returns Unit
+            every { awaitReadyBlocking(any()) } returns true
         }
         idleTimeoutManager = IdleTimeoutManager(
             timeoutMillis = Long.MAX_VALUE,


### PR DESCRIPTION
## Summary

Fixes the cold-start FCM wake silent-drop bug captured in #414.

- `FcmReceiver` and `TunnelForegroundService` both read `ProviderRegistry.enabledPaths()` synchronously to gate FCM wakes. On a freshly-spawned process, the DataStore-backed `IntegrationProviderRegistry._enabledIds` is still `emptySet()` (its async `combine()` collector hasn't emitted yet), so the synchronous read returns empty, the wake is dropped, and the relay's 20s wakeup timer fires → TLS EOF on the client.
- Adds `ProviderRegistry.awaitReady()` (suspend) and `awaitReadyBlocking(timeoutMs)` (thread-blocking, for the FCM worker thread which can't suspend). The `IntegrationProviderRegistry` signals both when its first state-store emission lands, or immediately if there are no integrations to track.
- All three production callers now go through one of the await variants before reading `enabledPaths()`. On timeout (2s), drop the wake rather than spin up the tunnel against unknown state.

Direction C from the #414 root-cause analysis (fix the race at the source so all callers benefit). User-approved in the issue thread.

Diagnostic capture referenced: `/tmp/probe-fresh`, `/tmp/probe-warm1` showed the device logging `Ignoring wake: no integrations enabled` ~1ms after FCM receive on every fresh cold-start.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest :work:testDebugUnitTest :core:mcp:jvmTest :core:bridge:jvmTest :core:tunnel:jvmTest` — all green
- [x] `./gradlew ktlintCheck detekt` — clean
- [x] `./gradlew assembleDebug` — clean
- [x] New regression test: `FcmReceiverTest`.`wake dispatches to startService once registry becomes ready with enabled state` — verified to FAIL on pre-fix `FcmReceiver` (stashed-revert + re-run produces `AssertionError at FcmReceiverTest.kt:79`) and pass on this branch.
- [x] New `IntegrationProviderRegistryTest` cases cover `awaitReady` semantics: empty-list ready immediately, ready after first emission with empty/enabled disk state, idempotent across calls, blocks until gated emission lands.
- [ ] Empirical hardware verification on adolin: build debug APK, install on Pixel 6 Pro at serial `1B151FDEE008EY`, run `coldstart_probe.sh fresh-postfix` → expect `http=200` (or any non-EOF response). Pending after merge.

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)