### PR TITLE
Fix #417: Migrate manual JSON in MCP providers to @Serializable data classes

### DIFF
--- a/integrations/build.gradle.kts
+++ b/integrations/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kover)
 }

--- a/integrations/src/main/java/com/rousecontext/integrations/health/query/SleepQueries.kt
+++ b/integrations/src/main/java/com/rousecontext/integrations/health/query/SleepQueries.kt
@@ -4,6 +4,7 @@ import androidx.health.connect.client.records.SleepSessionRecord
 import java.time.Duration
 import java.time.Instant
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -49,16 +50,26 @@ class SleepQueries(private val reader: RecordReader) : CategoryQueries {
         val records = reader.read(SleepSessionRecord::class, from, to)
         return records
             .map { record ->
+                // The legacy wire shape stored stages as a string-encoded JSON
+                // array (`"stages":"[{...},{...}]"`). Preserve that exact shape:
+                // build the array using kotlinx.serialization for proper escaping
+                // of `start`/`end`, then put its `toString()` representation as
+                // a string field.
+                val stagesArray = buildJsonArray {
+                    record.stages.forEach { stage ->
+                        add(
+                            buildJsonObject {
+                                put("stage", mapSleepStage(stage.stage))
+                                put("start", stage.startTime.toString())
+                                put("end", stage.endTime.toString())
+                            }
+                        )
+                    }
+                }
                 buildJsonObject {
                     put("start_time", record.startTime.toString())
                     put("end_time", record.endTime.toString())
-                    put(
-                        "stages",
-                        record.stages.joinToString(",") { stage ->
-                            """{"stage":"${mapSleepStage(stage.stage)}",""" +
-                                """"start":"${stage.startTime}","end":"${stage.endTime}"}"""
-                        }.let { "[$it]" }
-                    )
+                    put("stages", stagesArray.toString())
                 }
             }
             .let { if (limit != null) it.take(limit) else it }

--- a/integrations/src/main/java/com/rousecontext/integrations/health/query/VitalsQueries.kt
+++ b/integrations/src/main/java/com/rousecontext/integrations/health/query/VitalsQueries.kt
@@ -12,6 +12,7 @@ import androidx.health.connect.client.records.RestingHeartRateRecord
 import androidx.health.connect.client.records.SkinTemperatureRecord
 import java.time.Instant
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -228,17 +229,27 @@ class VitalsQueries(private val reader: RecordReader) : CategoryQueries {
         val records = reader.read(SkinTemperatureRecord::class, from, to)
         return records
             .map { record ->
+                // The legacy wire shape stored deltas as a string-encoded JSON
+                // array (`"deltas":"[{...},{...}]"`). Preserve that exact shape:
+                // build the array using kotlinx.serialization for proper escaping
+                // of `time` (and any future string fields), then put its
+                // `toString()` representation as a string field.
+                val deltasArray = buildJsonArray {
+                    record.deltas.forEach { delta ->
+                        add(
+                            buildJsonObject {
+                                put("time", delta.time.toString())
+                                put("delta_celsius", delta.delta.inCelsius)
+                            }
+                        )
+                    }
+                }
                 buildJsonObject {
                     put("start_time", record.startTime.toString())
                     put("end_time", record.endTime.toString())
                     record.baseline?.let { put("baseline_celsius", it.inCelsius) }
                     put("measurement_location", record.measurementLocation)
-                    put(
-                        "deltas",
-                        record.deltas.joinToString(",") { delta ->
-                            """{"time":"${delta.time}","delta_celsius":${delta.delta.inCelsius}}"""
-                        }.let { "[$it]" }
-                    )
+                    put("deltas", deltasArray.toString())
                 }
             }
             .let { if (limit != null) it.take(limit) else it }

--- a/integrations/src/main/java/com/rousecontext/integrations/notifications/NotificationMcpProvider.kt
+++ b/integrations/src/main/java/com/rousecontext/integrations/notifications/NotificationMcpProvider.kt
@@ -11,6 +11,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
@@ -67,8 +68,13 @@ class NotificationMcpProvider(
 
     companion object {
         internal const val DEFAULT_SEARCH_LIMIT = 50
-        internal const val ERR_ACTIONS_DISABLED =
-            """{"success":false,"message":"Notification actions are disabled by the user."}"""
+
+        internal fun errActionsDisabled(): String = NotificationJson.encodeToString(
+            NotificationStatusMessage(
+                success = false,
+                message = "Notification actions are disabled by the user."
+            )
+        )
     }
 }
 
@@ -109,7 +115,7 @@ internal class PerformNotificationActionTool(
 
     override suspend fun execute(): ToolResult {
         if (!allowActions) {
-            return ToolResult.Error(NotificationMcpProvider.ERR_ACTIONS_DISABLED)
+            return ToolResult.Error(NotificationMcpProvider.errActionsDisabled())
         }
 
         val key = notificationKey!!
@@ -119,13 +125,22 @@ internal class PerformNotificationActionTool(
             .any { it.key == key && NotificationCaptureService.isOwnPackage(it.packageName) }
         if (isOwn) {
             return ToolResult.Error(
-                """{"success":false,"message":"Cannot act on Rouse Context notifications"}"""
+                NotificationJson.encodeToString(
+                    NotificationStatusMessage(
+                        success = false,
+                        message = "Cannot act on Rouse Context notifications"
+                    )
+                )
             )
         }
 
         val success = actionPerformer(key, actionIndex!!)
         val message = if (success) "Action performed" else "Failed to perform action"
-        return ToolResult.Success("""{"success":$success,"message":"$message"}""")
+        return ToolResult.Success(
+            NotificationJson.encodeToString(
+                NotificationStatusMessage(success = success, message = message)
+            )
+        )
     }
 }
 
@@ -141,7 +156,7 @@ internal class DismissNotificationTool(
 
     override suspend fun execute(): ToolResult {
         if (!allowActions) {
-            return ToolResult.Error(NotificationMcpProvider.ERR_ACTIONS_DISABLED)
+            return ToolResult.Error(NotificationMcpProvider.errActionsDisabled())
         }
 
         val key = notificationKey!!
@@ -151,12 +166,19 @@ internal class DismissNotificationTool(
             .any { it.key == key && NotificationCaptureService.isOwnPackage(it.packageName) }
         if (isOwn) {
             return ToolResult.Error(
-                """{"success":false,"message":"Cannot dismiss Rouse Context notifications"}"""
+                NotificationJson.encodeToString(
+                    NotificationStatusMessage(
+                        success = false,
+                        message = "Cannot dismiss Rouse Context notifications"
+                    )
+                )
             )
         }
 
         val success = notificationDismisser(key)
-        return ToolResult.Success("""{"success":$success}""")
+        return ToolResult.Success(
+            NotificationJson.encodeToString(NotificationSuccess(success = success))
+        )
     }
 }
 

--- a/integrations/src/main/kotlin/com/rousecontext/integrations/notifications/NotificationJsonModels.kt
+++ b/integrations/src/main/kotlin/com/rousecontext/integrations/notifications/NotificationJsonModels.kt
@@ -1,0 +1,34 @@
+package com.rousecontext.integrations.notifications
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Wire models for [NotificationMcpProvider] tool results.
+ *
+ * Built as `@Serializable` data classes so user-supplied content (notification
+ * keys, action labels, error messages) is JSON-escaped by `kotlinx.serialization`
+ * rather than concatenated into a string template. See issue #417.
+ *
+ * Field names and order match the previous handcrafted JSON exactly — this is
+ * a behavior-preserving migration of the encoding step, not a wire format change.
+ */
+
+/**
+ * Wraps `success` + `message` (e.g. action errors and confirmations).
+ * Preserves the exact wire shape `{"success":<bool>,"message":"..."}`.
+ */
+@Serializable
+internal data class NotificationStatusMessage(val success: Boolean, val message: String)
+
+/**
+ * Wraps just `success` (used by dismiss_notification's success path).
+ */
+@Serializable
+internal data class NotificationSuccess(val success: Boolean)
+
+/**
+ * Single shared [Json] instance. `encodeDefaults = true` so the constant
+ * `success` defaults serialize, matching the previous string-template output.
+ */
+internal val NotificationJson: Json = Json { encodeDefaults = true }

--- a/integrations/src/main/kotlin/com/rousecontext/integrations/outreach/OutreachJsonModels.kt
+++ b/integrations/src/main/kotlin/com/rousecontext/integrations/outreach/OutreachJsonModels.kt
@@ -1,0 +1,59 @@
+package com.rousecontext.integrations.outreach
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Wire models for [OutreachMcpProvider] tool results.
+ *
+ * Built as `@Serializable` data classes so user-supplied content (exception
+ * messages, app names, channel descriptions) is JSON-escaped by
+ * `kotlinx.serialization` rather than concatenated into a string template.
+ *
+ * The field names and order match the previous handcrafted JSON exactly —
+ * these classes are a behavior-preserving migration of the encoding step,
+ * not a wire format change. See issue #417.
+ */
+
+@Serializable
+internal data class OutreachError(val success: Boolean = false, val error: String)
+
+@Serializable
+internal data class OutreachOk(val success: Boolean = true, val message: String)
+
+@Serializable
+internal data class SendNotificationResult(
+    val success: Boolean = true,
+    @SerialName("notification_id") val notificationId: Int
+)
+
+@Serializable
+internal data class DndState(val enabled: Boolean, val mode: String)
+
+@Serializable
+internal data class SetDndStateResult(
+    val success: Boolean = true,
+    @SerialName("previous_state") val previousState: DndState
+)
+
+@Serializable
+internal data class NotificationChannelDto(
+    val id: String,
+    val name: String,
+    val description: String,
+    val importance: String,
+    val vibration: Boolean,
+    val sound: Boolean,
+    @SerialName("show_badge") val showBadge: Boolean
+)
+
+@Serializable
+internal data class InstalledApp(val `package`: String, val name: String, val system: Boolean)
+
+/**
+ * Single shared [Json] instance. `encodeDefaults = true` so the constant
+ * `success` defaults serialize to wire alongside dynamic fields, matching the
+ * previous string-template output where these were always present.
+ */
+internal val OutreachJson: Json = Json { encodeDefaults = true }

--- a/integrations/src/main/kotlin/com/rousecontext/integrations/outreach/OutreachMcpProvider.kt
+++ b/integrations/src/main/kotlin/com/rousecontext/integrations/outreach/OutreachMcpProvider.kt
@@ -28,6 +28,8 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -232,7 +234,9 @@ internal class SendNotificationTool(
         addNotificationActions(context, builder, rawArgs, notificationId)
         val nm = context.getSystemService(NotificationManager::class.java)
         nm.notify(notificationId, builder.build())
-        return ToolResult.Success("""{"success":true,"notification_id":$notificationId}""")
+        return ToolResult.Success(
+            OutreachJson.encodeToString(SendNotificationResult(notificationId = notificationId))
+        )
     }
 }
 
@@ -244,7 +248,9 @@ internal class ListInstalledAppsTool(private val context: Context) : McpTool() {
 
     override suspend fun execute(): ToolResult {
         val apps = queryInstalledApps(context, filter?.lowercase())
-        return ToolResult.Success("[${apps.joinToString(",")}]")
+        return ToolResult.Success(
+            OutreachJson.encodeToString(ListSerializer(InstalledApp.serializer()), apps)
+        )
     }
 }
 
@@ -287,7 +293,9 @@ internal class CreateNotificationChannelTool(private val context: Context) : Mcp
         }
         val nm = context.getSystemService(NotificationManager::class.java)
         nm.createNotificationChannel(channel)
-        return ToolResult.Success(buildChannelJson(nm.getNotificationChannel(channelId)))
+        return ToolResult.Success(
+            OutreachJson.encodeToString(buildChannelDto(nm.getNotificationChannel(channelId)))
+        )
     }
 }
 
@@ -302,8 +310,13 @@ internal class ListNotificationChannelsTool(private val context: Context) : McpT
         val nm = context.getSystemService(NotificationManager::class.java)
         val channels = nm.notificationChannels
             .filter { it.id.startsWith(OutreachMcpProvider.AI_CHANNEL_PREFIX) }
-            .joinToString(",") { buildChannelJson(it) }
-        return ToolResult.Success("[$channels]")
+            .map { buildChannelDto(it) }
+        return ToolResult.Success(
+            OutreachJson.encodeToString(
+                ListSerializer(NotificationChannelDto.serializer()),
+                channels
+            )
+        )
     }
 }
 
@@ -342,7 +355,9 @@ internal class GetDndStateTool(private val context: Context) : McpTool() {
         val filter = nm.currentInterruptionFilter
         val enabled = filter != NotificationManager.INTERRUPTION_FILTER_ALL
         val mode = filterToMode(filter)
-        return ToolResult.Success("""{"enabled":$enabled,"mode":"$mode"}""")
+        return ToolResult.Success(
+            OutreachJson.encodeToString(DndState(enabled = enabled, mode = mode))
+        )
     }
 }
 
@@ -370,8 +385,14 @@ internal class SetDndStateTool(private val context: Context) : McpTool() {
         }
         nm.setInterruptionFilter(newFilter)
         return ToolResult.Success(
-            """{"success":true,"previous_state":""" +
-                """{"enabled":$previousEnabled,"mode":"$previousMode"}}"""
+            OutreachJson.encodeToString(
+                SetDndStateResult(
+                    previousState = DndState(
+                        enabled = previousEnabled,
+                        mode = previousMode
+                    )
+                )
+            )
         )
     }
 }
@@ -467,23 +488,26 @@ internal fun addNotificationActions(
 }
 
 @Suppress("MagicNumber")
-internal fun buildChannelJson(channel: NotificationChannel): String {
+internal fun buildChannelDto(channel: NotificationChannel): NotificationChannelDto {
     val imp = when (channel.importance) {
         NotificationManager.IMPORTANCE_MIN -> "min"
         NotificationManager.IMPORTANCE_LOW -> "low"
         NotificationManager.IMPORTANCE_HIGH -> "high"
         else -> "default"
     }
-    val desc = channel.description?.escapeJson() ?: ""
-    return """{"id":"${channel.id}","name":"${channel.name.toString().escapeJson()}",""" +
-        """"description":"$desc","importance":"$imp",""" +
-        """"vibration":${channel.shouldVibrate()},""" +
-        """"sound":${channel.sound != null},""" +
-        """"show_badge":${channel.canShowBadge()}}"""
+    return NotificationChannelDto(
+        id = channel.id,
+        name = channel.name.toString(),
+        description = channel.description ?: "",
+        importance = imp,
+        vibration = channel.shouldVibrate(),
+        sound = channel.sound != null,
+        showBadge = channel.canShowBadge()
+    )
 }
 
 @Suppress("DEPRECATION")
-internal fun queryInstalledApps(context: Context, filter: String?): List<String> {
+internal fun queryInstalledApps(context: Context, filter: String?): List<InstalledApp> {
     val pm = context.packageManager
     val allApps = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         pm.getInstalledApplications(PackageManager.ApplicationInfoFlags.of(0))
@@ -499,12 +523,13 @@ internal fun queryInstalledApps(context: Context, filter: String?): List<String>
         if (filter != null && !appName.lowercase().contains(filter)) {
             null
         } else {
-            val systemFlag = isSystem && !isUpdatedSystem
-            """{"package":"${appInfo.packageName}",""" +
-                """"name":"${appName.escapeJson()}",""" +
-                """"system":$systemFlag}"""
+            InstalledApp(
+                `package` = appInfo.packageName,
+                name = appName,
+                system = isSystem && !isUpdatedSystem
+            )
         }
-    }.sorted()
+    }.sortedBy { it.`package` }
 }
 
 internal fun parseImportance(importance: String?): Int = when (importance?.lowercase()) {
@@ -534,15 +559,9 @@ internal fun modeToFilter(mode: String?): Int = when (mode) {
 }
 
 internal fun outreachError(message: String): ToolResult = ToolResult.Error(
-    """{"success":false,"error":"$message"}"""
+    OutreachJson.encodeToString(OutreachError(error = message))
 )
 
 internal fun outreachSuccess(message: String): ToolResult = ToolResult.Success(
-    """{"success":true,"message":"$message"}"""
+    OutreachJson.encodeToString(OutreachOk(message = message))
 )
-
-internal fun String.escapeJson(): String = replace("\\", "\\\\")
-    .replace("\"", "\\\"")
-    .replace("\n", "\\n")
-    .replace("\r", "\\r")
-    .replace("\t", "\\t")

--- a/integrations/src/main/kotlin/com/rousecontext/integrations/usage/UsageJsonModels.kt
+++ b/integrations/src/main/kotlin/com/rousecontext/integrations/usage/UsageJsonModels.kt
@@ -1,0 +1,84 @@
+package com.rousecontext.integrations.usage
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Wire models for [UsageMcpProvider] tool results.
+ *
+ * Built as `@Serializable` data classes so user-supplied content (resolved app
+ * labels, package names) is JSON-escaped by `kotlinx.serialization` rather
+ * than concatenated into a string template. See issue #417.
+ *
+ * Field names and order match the previous handcrafted JSON exactly — this is
+ * a behavior-preserving migration of the encoding step, not a wire format change.
+ */
+
+@Serializable
+internal data class UsageError(val success: Boolean = false, val error: String)
+
+@Serializable
+internal data class AppUsageEntry(
+    val `package`: String,
+    val name: String,
+    @SerialName("foreground_minutes") val foregroundMinutes: Long
+)
+
+@Serializable
+internal data class UsageSummary(
+    val period: String,
+    @SerialName("total_minutes") val totalMinutes: Long,
+    val apps: List<AppUsageEntry>
+)
+
+@Serializable
+internal data class DailyUsage(
+    val date: String,
+    @SerialName("foreground_minutes") val foregroundMinutes: Long
+)
+
+@Serializable
+internal data class AppUsage(
+    val `package`: String,
+    val name: String,
+    val period: String,
+    @SerialName("total_minutes") val totalMinutes: Long,
+    val daily: List<DailyUsage>
+)
+
+@Serializable
+internal data class UsageEvent(
+    val `package`: String,
+    val name: String,
+    val type: String,
+    val timestamp: String
+)
+
+@Serializable
+internal data class UsageEventList(val events: List<UsageEvent>)
+
+@Serializable
+internal data class UsageDelta(
+    val `package`: String,
+    val name: String,
+    @SerialName("period1_minutes") val period1Minutes: Long,
+    @SerialName("period2_minutes") val period2Minutes: Long,
+    val change: String
+)
+
+@Serializable
+internal data class UsageComparison(
+    val period1: String,
+    val period2: String,
+    @SerialName("total1_minutes") val total1Minutes: Long,
+    @SerialName("total2_minutes") val total2Minutes: Long,
+    val apps: List<UsageDelta>
+)
+
+/**
+ * Single shared [Json] instance. `encodeDefaults = true` so the constant
+ * `success` defaults serialize, matching the previous string-template output
+ * where these were always present.
+ */
+internal val UsageJson: Json = Json { encodeDefaults = true }

--- a/integrations/src/main/kotlin/com/rousecontext/integrations/usage/UsageMcpProvider.kt
+++ b/integrations/src/main/kotlin/com/rousecontext/integrations/usage/UsageMcpProvider.kt
@@ -15,6 +15,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.TimeZone
+import kotlinx.serialization.encodeToString
 
 /**
  * MCP server provider that exposes device usage statistics
@@ -90,12 +91,16 @@ internal class GetUsageSummaryTool(private val context: Context) : McpTool() {
             .take(lim)
 
         val totalMs = filtered.sumOf { (_, ms) -> ms }
-        val apps = filtered.joinToString(",") { (pkg, ms) -> appToJson(context, pkg, ms) }
+        val apps = filtered.map { (pkg, ms) -> appUsageEntry(context, pkg, ms) }
 
         return ToolResult.Success(
-            """{"period":"$periodStr",""" +
-                """"total_minutes":${totalMs / UsageMcpProvider.MS_PER_MIN},""" +
-                """"apps":[$apps]}"""
+            UsageJson.encodeToString(
+                UsageSummary(
+                    period = periodStr,
+                    totalMinutes = totalMs / UsageMcpProvider.MS_PER_MIN,
+                    apps = apps
+                )
+            )
         )
     }
 }
@@ -123,14 +128,18 @@ internal class GetAppUsageTool(private val context: Context) : McpTool() {
         val appStats = stats.filter { it.packageName == pkg }
         val appName = resolveAppName(context, pkg)
         val totalMs = mergeByPackage(appStats)[pkg] ?: 0L
-        val daily = formatDailyBreakdown(appStats)
+        val daily = dailyBreakdown(appStats)
 
         return ToolResult.Success(
-            """{"package":"${pkg.escapeJson()}",""" +
-                """"name":"${appName.escapeJson()}",""" +
-                """"period":"$periodStr",""" +
-                """"total_minutes":${totalMs / UsageMcpProvider.MS_PER_MIN},""" +
-                """"daily":[$daily]}"""
+            UsageJson.encodeToString(
+                AppUsage(
+                    `package` = pkg,
+                    name = appName,
+                    period = periodStr,
+                    totalMinutes = totalMs / UsageMcpProvider.MS_PER_MIN,
+                    daily = daily
+                )
+            )
         )
     }
 }
@@ -152,13 +161,9 @@ internal class GetUsageEventsTool(private val context: Context) : McpTool() {
         val sinceStr = since!!
         val untilStr = until!!
         val sinceRange = parsePeriod(sinceStr)
-            ?: return ToolResult.Error(
-                """{"success":false,"error":"Invalid since period: $sinceStr"}"""
-            )
+            ?: return usageError("Invalid since period: $sinceStr")
         val untilRange = parsePeriod(untilStr)
-            ?: return ToolResult.Error(
-                """{"success":false,"error":"Invalid until period: $untilStr"}"""
-            )
+            ?: return usageError("Invalid until period: $untilStr")
 
         val usageStatsManager = context.getSystemService(UsageStatsManager::class.java)
         val events = usageStatsManager.queryEvents(sinceRange.first, untilRange.second)
@@ -170,7 +175,7 @@ internal class GetUsageEventsTool(private val context: Context) : McpTool() {
             limit = limit ?: UsageMcpProvider.DEFAULT_EVENT_LIMIT
         )
 
-        return ToolResult.Success("""{"events":[${entries.joinToString(",")}]}""")
+        return ToolResult.Success(UsageJson.encodeToString(UsageEventList(events = entries)))
     }
 }
 
@@ -210,15 +215,17 @@ internal class CompareUsageTool(private val context: Context) : McpTool() {
 
 // ---------- formatting helpers ----------
 
-private fun appToJson(context: Context, packageName: String, foregroundMs: Long): String {
+private fun appUsageEntry(
+    context: Context,
+    packageName: String,
+    foregroundMs: Long
+): AppUsageEntry {
     val name = resolveAppName(context, packageName)
     val mins = foregroundMs / UsageMcpProvider.MS_PER_MIN
-    return """{"package":"${packageName.escapeJson()}",""" +
-        """"name":"${name.escapeJson()}",""" +
-        """"foreground_minutes":$mins}"""
+    return AppUsageEntry(`package` = packageName, name = name, foregroundMinutes = mins)
 }
 
-private fun formatDailyBreakdown(appStats: List<UsageStats>): String {
+private fun dailyBreakdown(appStats: List<UsageStats>): List<DailyUsage> {
     val cal = Calendar.getInstance(TimeZone.getDefault())
     // Group by date string and sum foreground time per day
     val byDate = mutableMapOf<String, Long>()
@@ -232,8 +239,8 @@ private fun formatDailyBreakdown(appStats: List<UsageStats>): String {
         )
         byDate[date] = (byDate[date] ?: 0L) + stat.totalTimeInForeground
     }
-    return byDate.entries.joinToString(",") { (date, ms) ->
-        """{"date":"$date","foreground_minutes":${ms / UsageMcpProvider.MS_PER_MIN}}"""
+    return byDate.entries.map { (date, ms) ->
+        DailyUsage(date = date, foregroundMinutes = ms / UsageMcpProvider.MS_PER_MIN)
     }
 }
 
@@ -244,8 +251,8 @@ private fun collectEvents(
     packageFilter: String?,
     includeSystem: Boolean,
     limit: Int
-): List<String> {
-    val entries = mutableListOf<String>()
+): List<UsageEvent> {
+    val entries = mutableListOf<UsageEvent>()
     val event = UsageEvents.Event()
     while (usageEvents.hasNextEvent() && entries.size < limit) {
         usageEvents.getNextEvent(event)
@@ -256,10 +263,12 @@ private fun collectEvents(
         val appName = resolveAppName(context, pkg)
         val isoTime = UsageMcpProvider.formatTimestamp(event.timeStamp)
         entries.add(
-            """{"package":"${pkg.escapeJson()}",""" +
-                """"name":"${appName.escapeJson()}",""" +
-                """"type":"$typeName",""" +
-                """"timestamp":"$isoTime"}"""
+            UsageEvent(
+                `package` = pkg,
+                name = appName,
+                type = typeName,
+                timestamp = isoTime
+            )
         )
     }
     return entries
@@ -289,22 +298,29 @@ private fun buildComparisonResult(
     val total1 = map1.values.sum()
     val total2 = map2.values.sum()
 
-    val apps = changes.joinToString(",") { (pkg, t1, t2) ->
+    val apps = changes.map { (pkg, t1, t2) ->
         val name = resolveAppName(context, pkg)
         val diff = (t2 - t1) / UsageMcpProvider.MS_PER_MIN
         val sign = if (diff >= 0) "+" else ""
-        """{"package":"${pkg.escapeJson()}",""" +
-            """"name":"${name.escapeJson()}",""" +
-            """"period1_minutes":${t1 / UsageMcpProvider.MS_PER_MIN},""" +
-            """"period2_minutes":${t2 / UsageMcpProvider.MS_PER_MIN},""" +
-            """"change":"$sign$diff min"}"""
+        UsageDelta(
+            `package` = pkg,
+            name = name,
+            period1Minutes = t1 / UsageMcpProvider.MS_PER_MIN,
+            period2Minutes = t2 / UsageMcpProvider.MS_PER_MIN,
+            change = "$sign$diff min"
+        )
     }
 
     return ToolResult.Success(
-        """{"period1":"$p1Str","period2":"$p2Str",""" +
-            """"total1_minutes":${total1 / UsageMcpProvider.MS_PER_MIN},""" +
-            """"total2_minutes":${total2 / UsageMcpProvider.MS_PER_MIN},""" +
-            """"apps":[$apps]}"""
+        UsageJson.encodeToString(
+            UsageComparison(
+                period1 = p1Str,
+                period2 = p2Str,
+                total1Minutes = total1 / UsageMcpProvider.MS_PER_MIN,
+                total2Minutes = total2 / UsageMcpProvider.MS_PER_MIN,
+                apps = apps
+            )
+        )
     )
 }
 
@@ -326,10 +342,10 @@ private fun resolveAppName(context: Context, packageName: String): String = try 
 }
 
 private fun invalidPeriodError(period: String, label: String = "period"): ToolResult =
-    ToolResult.Error(
-        """{"success":false,"error":"Invalid $label: $period. """ +
-            """Use: today, yesterday, week, month"}"""
-    )
+    usageError("Invalid $label: $period. Use: today, yesterday, week, month")
+
+internal fun usageError(message: String): ToolResult =
+    ToolResult.Error(UsageJson.encodeToString(UsageError(error = message)))
 
 // ---------- Period parsing ----------
 
@@ -417,11 +433,3 @@ private val EVENT_TYPE_NAMES: Map<Int, String> = mapOf(
     29 to "user_stopped",
     30 to "locus_id_set"
 )
-
-// ---------- JSON helpers ----------
-
-private fun String.escapeJson(): String = replace("\\", "\\\\")
-    .replace("\"", "\\\"")
-    .replace("\n", "\\n")
-    .replace("\r", "\\r")
-    .replace("\t", "\\t")

--- a/integrations/src/test/java/com/rousecontext/integrations/notifications/NotificationJsonShapeTest.kt
+++ b/integrations/src/test/java/com/rousecontext/integrations/notifications/NotificationJsonShapeTest.kt
@@ -1,0 +1,91 @@
+package com.rousecontext.integrations.notifications
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for issue #417 — manual JSON construction in
+ * [NotificationMcpProvider] tool results was producing malformed payloads
+ * when notification keys or messages contained quotes/backslashes.
+ *
+ * These tests verify that the migrated [NotificationStatusMessage] and
+ * [NotificationSuccess] paths emit JSON that round-trips cleanly even with
+ * adversarial payloads.
+ */
+class NotificationJsonShapeTest {
+
+    @Test
+    fun `NotificationStatusMessage with quotes and backslash round-trips`() {
+        val json = NotificationJson.encodeToString(
+            NotificationStatusMessage.serializer(),
+            NotificationStatusMessage(
+                success = false,
+                message = "Cannot act on \"Rouse\" \\ notifications"
+            )
+        )
+        val parsed = Json.parseToJsonElement(json).jsonObject
+        assertEquals(false, parsed["success"]?.jsonPrimitive?.boolean)
+        assertEquals(
+            "Cannot act on \"Rouse\" \\ notifications",
+            parsed["message"]?.jsonPrimitive?.content
+        )
+    }
+
+    @Test
+    fun `NotificationStatusMessage with newline and tab round-trips`() {
+        val json = NotificationJson.encodeToString(
+            NotificationStatusMessage.serializer(),
+            NotificationStatusMessage(
+                success = true,
+                message = "Action\nperformed\twith newlines"
+            )
+        )
+        val parsed = Json.parseToJsonElement(json).jsonObject
+        assertEquals(
+            "Action\nperformed\twith newlines",
+            parsed["message"]?.jsonPrimitive?.content
+        )
+    }
+
+    @Test
+    fun `NotificationSuccess with true round-trips`() {
+        val json = NotificationJson.encodeToString(
+            NotificationSuccess.serializer(),
+            NotificationSuccess(success = true)
+        )
+        val parsed = Json.parseToJsonElement(json).jsonObject
+        assertEquals(true, parsed["success"]?.jsonPrimitive?.boolean)
+        // Must NOT contain a `message` field (legacy shape was just `{"success":bool}`).
+        assertFalse(
+            "NotificationSuccess must not include a message field",
+            parsed.containsKey("message")
+        )
+    }
+
+    @Test
+    fun `errActionsDisabled emits stable shape`() {
+        val text = NotificationMcpProvider.errActionsDisabled()
+        val parsed = Json.parseToJsonElement(text).jsonObject
+        assertEquals(false, parsed["success"]?.jsonPrimitive?.boolean)
+        assertEquals(
+            "Notification actions are disabled by the user.",
+            parsed["message"]?.jsonPrimitive?.content
+        )
+    }
+
+    @Test
+    fun `errActionsDisabled is parseable JSON not literal template`() {
+        val text = NotificationMcpProvider.errActionsDisabled()
+        // Verify it parses cleanly (the original `const` literal was already
+        // safe because it had no interpolated content; this ensures the
+        // refactor doesn't regress that property).
+        Json.parseToJsonElement(text)
+        assertTrue(text.contains("\"success\":false"))
+    }
+}

--- a/integrations/src/test/kotlin/com/rousecontext/integrations/outreach/OutreachJsonShapeTest.kt
+++ b/integrations/src/test/kotlin/com/rousecontext/integrations/outreach/OutreachJsonShapeTest.kt
@@ -1,0 +1,180 @@
+package com.rousecontext.integrations.outreach
+
+import com.rousecontext.mcp.tool.ToolResult
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for issue #417 — manual JSON construction in
+ * [OutreachMcpProvider] tool results was producing malformed payloads when
+ * exception messages contained quotes/backslashes/control chars.
+ *
+ * These tests verify that the migrated [outreachError] / [outreachSuccess] /
+ * [SendNotificationResult] / [DndState] / [SetDndStateResult] /
+ * [NotificationChannelDto] / [InstalledApp] paths emit JSON that round-trips
+ * cleanly even with adversarial payloads.
+ *
+ * No Android plumbing is required — these are pure JSON shape tests that
+ * exercise the serialization layer.
+ */
+class OutreachJsonShapeTest {
+
+    // ---- outreachError ----
+
+    @Test
+    fun `outreachError with plain message round-trips`() {
+        val result = outreachError("Something broke")
+        require(result is ToolResult.Error)
+        val parsed = Json.parseToJsonElement(result.message).jsonObject
+        assertEquals(false, parsed["success"]?.jsonPrimitive?.boolean)
+        assertEquals("Something broke", parsed["error"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `outreachError with double quotes round-trips`() {
+        val result = outreachError("App \"X\" not found")
+        require(result is ToolResult.Error)
+        val parsed = Json.parseToJsonElement(result.message).jsonObject
+        assertEquals("App \"X\" not found", parsed["error"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `outreachError with backslash round-trips`() {
+        val result = outreachError("Path C:\\Windows\\System32 is invalid")
+        require(result is ToolResult.Error)
+        val parsed = Json.parseToJsonElement(result.message).jsonObject
+        assertEquals(
+            "Path C:\\Windows\\System32 is invalid",
+            parsed["error"]?.jsonPrimitive?.content
+        )
+    }
+
+    @Test
+    fun `outreachError with newline and tab round-trips`() {
+        val result = outreachError("line1\nline2\twith tab")
+        require(result is ToolResult.Error)
+        val parsed = Json.parseToJsonElement(result.message).jsonObject
+        assertEquals("line1\nline2\twith tab", parsed["error"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `outreachError contains success false default`() {
+        val result = outreachError("anything")
+        require(result is ToolResult.Error)
+        assertTrue(result.message.contains("\"success\":false"))
+    }
+
+    // ---- outreachSuccess ----
+
+    @Test
+    fun `outreachSuccess round-trips with quotes and backslash`() {
+        val result = outreachSuccess("Launched: \"My App\" \\path")
+        require(result is ToolResult.Success)
+        val parsed = Json.parseToJsonElement(result.text).jsonObject
+        assertEquals(true, parsed["success"]?.jsonPrimitive?.boolean)
+        assertEquals("Launched: \"My App\" \\path", parsed["message"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `outreachSuccess contains success true default`() {
+        val result = outreachSuccess("ok")
+        require(result is ToolResult.Success)
+        assertTrue(result.text.contains("\"success\":true"))
+    }
+
+    // ---- SendNotificationResult ----
+
+    @Test
+    fun `SendNotificationResult round-trips`() {
+        val json = OutreachJson.encodeToString(
+            SendNotificationResult.serializer(),
+            SendNotificationResult(notificationId = 12345)
+        )
+        val parsed = Json.parseToJsonElement(json).jsonObject
+        assertEquals(true, parsed["success"]?.jsonPrimitive?.boolean)
+        assertEquals(12345, parsed["notification_id"]?.jsonPrimitive?.int)
+    }
+
+    // ---- DndState / SetDndStateResult ----
+
+    @Test
+    fun `DndState round-trips without success field`() {
+        val json = OutreachJson.encodeToString(
+            DndState.serializer(),
+            DndState(enabled = true, mode = "priority_only")
+        )
+        val parsed = Json.parseToJsonElement(json).jsonObject
+        // get_dnd_state never wrote a success field; preserve that.
+        assertTrue("get_dnd_state must not include success", !parsed.containsKey("success"))
+        assertEquals(true, parsed["enabled"]?.jsonPrimitive?.boolean)
+        assertEquals("priority_only", parsed["mode"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `SetDndStateResult preserves nested previous_state`() {
+        val json = OutreachJson.encodeToString(
+            SetDndStateResult.serializer(),
+            SetDndStateResult(
+                previousState = DndState(enabled = false, mode = "off")
+            )
+        )
+        val parsed = Json.parseToJsonElement(json).jsonObject
+        assertEquals(true, parsed["success"]?.jsonPrimitive?.boolean)
+        val prev = parsed["previous_state"]?.jsonObject
+        assertEquals(false, prev?.get("enabled")?.jsonPrimitive?.boolean)
+        assertEquals("off", prev?.get("mode")?.jsonPrimitive?.content)
+    }
+
+    // ---- NotificationChannelDto ----
+
+    @Test
+    fun `NotificationChannelDto with quoted name round-trips`() {
+        val json = OutreachJson.encodeToString(
+            NotificationChannelDto.serializer(),
+            NotificationChannelDto(
+                id = "rouse_ai_quote\"test",
+                name = "Channel \"with quotes\"",
+                description = "Desc with \\backslash and \"quote\"",
+                importance = "high",
+                vibration = true,
+                sound = false,
+                showBadge = true
+            )
+        )
+        val parsed = Json.parseToJsonElement(json).jsonObject
+        assertEquals("rouse_ai_quote\"test", parsed["id"]?.jsonPrimitive?.content)
+        assertEquals("Channel \"with quotes\"", parsed["name"]?.jsonPrimitive?.content)
+        assertEquals(
+            "Desc with \\backslash and \"quote\"",
+            parsed["description"]?.jsonPrimitive?.content
+        )
+        assertEquals("high", parsed["importance"]?.jsonPrimitive?.content)
+        assertEquals(true, parsed["vibration"]?.jsonPrimitive?.boolean)
+        assertEquals(false, parsed["sound"]?.jsonPrimitive?.boolean)
+        assertEquals(true, parsed["show_badge"]?.jsonPrimitive?.boolean)
+    }
+
+    // ---- InstalledApp ----
+
+    @Test
+    fun `InstalledApp with apostrophe and unicode in name round-trips`() {
+        val json = OutreachJson.encodeToString(
+            InstalledApp.serializer(),
+            InstalledApp(
+                `package` = "com.example.app",
+                name = "Bob's “Smart” App ☕",
+                system = false
+            )
+        )
+        val parsed = Json.parseToJsonElement(json).jsonObject
+        assertEquals("com.example.app", parsed["package"]?.jsonPrimitive?.content)
+        assertEquals("Bob's “Smart” App ☕", parsed["name"]?.jsonPrimitive?.content)
+        assertEquals(false, parsed["system"]?.jsonPrimitive?.boolean)
+    }
+}

--- a/integrations/src/test/kotlin/com/rousecontext/integrations/outreach/OutreachQueryInstalledAppsTest.kt
+++ b/integrations/src/test/kotlin/com/rousecontext/integrations/outreach/OutreachQueryInstalledAppsTest.kt
@@ -46,7 +46,7 @@ class OutreachQueryInstalledAppsTest {
 
         assertTrue(
             "User app with launcher should be returned",
-            results.any { it.contains("com.example.myapp") }
+            results.any { it.`package` == "com.example.myapp" }
         )
     }
 
@@ -63,7 +63,7 @@ class OutreachQueryInstalledAppsTest {
 
         assertTrue(
             "System app without launcher should be filtered out",
-            results.none { it.contains("com.android.systemui") }
+            results.none { it.`package` == "com.android.systemui" }
         )
     }
 
@@ -80,7 +80,7 @@ class OutreachQueryInstalledAppsTest {
 
         assertTrue(
             "System app with launcher should be returned",
-            results.any { it.contains("com.android.settings") }
+            results.any { it.`package` == "com.android.settings" }
         )
     }
 
@@ -98,7 +98,7 @@ class OutreachQueryInstalledAppsTest {
 
         assertTrue(
             "Updated system app should be returned even without launcher",
-            results.any { it.contains("com.android.webview") }
+            results.any { it.`package` == "com.android.webview" }
         )
     }
 
@@ -111,7 +111,7 @@ class OutreachQueryInstalledAppsTest {
         val results = queryInstalledApps(context, filter = "beta")
 
         assertEquals("Filter should return only matching app", 1, results.size)
-        assertTrue(results[0].contains("com.example.beta"))
+        assertEquals("com.example.beta", results[0].`package`)
     }
 
     @Test
@@ -122,7 +122,7 @@ class OutreachQueryInstalledAppsTest {
 
         assertTrue(
             "Case-insensitive filter should match",
-            results.any { it.contains("com.example.app") }
+            results.any { it.`package` == "com.example.app" }
         )
     }
 
@@ -136,25 +136,16 @@ class OutreachQueryInstalledAppsTest {
     }
 
     @Test
-    fun `result JSON contains expected fields`() {
+    fun `result fields are populated`() {
         installApp("com.example.json", "JSON App", isSystem = false, hasLauncher = true)
 
         val results = queryInstalledApps(context, filter = "json")
 
         assertEquals(1, results.size)
         val entry = results[0]
-        assertTrue(
-            "Should contain package field",
-            entry.contains("\"package\":\"com.example.json\"")
-        )
-        assertTrue(
-            "Should contain name field",
-            entry.contains("\"name\":\"JSON App\"")
-        )
-        assertTrue(
-            "Should contain system field",
-            entry.contains("\"system\":false")
-        )
+        assertEquals("com.example.json", entry.`package`)
+        assertEquals("JSON App", entry.name)
+        assertEquals(false, entry.system)
     }
 
     @Test
@@ -164,7 +155,7 @@ class OutreachQueryInstalledAppsTest {
         val results = queryInstalledApps(context, filter = "phone")
 
         assertEquals(1, results.size)
-        assertTrue("System flag should be true", results[0].contains("\"system\":true"))
+        assertTrue("System flag should be true", results[0].system)
     }
 
     // ---- Test 2: Manifest <queries> assertion ----

--- a/integrations/src/test/kotlin/com/rousecontext/integrations/usage/UsageJsonShapeTest.kt
+++ b/integrations/src/test/kotlin/com/rousecontext/integrations/usage/UsageJsonShapeTest.kt
@@ -1,0 +1,169 @@
+package com.rousecontext.integrations.usage
+
+import com.rousecontext.mcp.tool.ToolResult
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for issue #417 — manual JSON construction in
+ * [UsageMcpProvider] tool results was producing malformed payloads when
+ * package names or app labels contained quotes/backslashes/control chars.
+ *
+ * These tests verify that the migrated DTOs ([UsageError], [AppUsageEntry],
+ * [UsageSummary], [AppUsage], [UsageEvent], [UsageEventList], [UsageDelta],
+ * [UsageComparison], [DailyUsage]) emit JSON that round-trips cleanly even
+ * with adversarial payloads.
+ */
+class UsageJsonShapeTest {
+
+    // ---- usageError ----
+
+    @Test
+    fun `usageError with quotes and backslash round-trips`() {
+        val result = usageError("Bad value: \"foo\\bar\"")
+        require(result is ToolResult.Error)
+        val parsed = Json.parseToJsonElement(result.message).jsonObject
+        assertEquals(false, parsed["success"]?.jsonPrimitive?.boolean)
+        assertEquals("Bad value: \"foo\\bar\"", parsed["error"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `usageError with newline round-trips`() {
+        val result = usageError("multi\nline\terror")
+        require(result is ToolResult.Error)
+        val parsed = Json.parseToJsonElement(result.message).jsonObject
+        assertEquals("multi\nline\terror", parsed["error"]?.jsonPrimitive?.content)
+    }
+
+    // ---- AppUsageEntry ----
+
+    @Test
+    fun `AppUsageEntry with adversarial app name round-trips`() {
+        val json = UsageJson.encodeToString(
+            AppUsageEntry.serializer(),
+            AppUsageEntry(
+                `package` = "com.evil.app",
+                name = "Evil \"App\" \\ name",
+                foregroundMinutes = 42L
+            )
+        )
+        val parsed = Json.parseToJsonElement(json).jsonObject
+        assertEquals("com.evil.app", parsed["package"]?.jsonPrimitive?.content)
+        assertEquals("Evil \"App\" \\ name", parsed["name"]?.jsonPrimitive?.content)
+        assertEquals(42L, parsed["foreground_minutes"]?.jsonPrimitive?.long)
+    }
+
+    // ---- UsageSummary ----
+
+    @Test
+    fun `UsageSummary with empty apps and odd period name round-trips`() {
+        val json = UsageJson.encodeToString(
+            UsageSummary.serializer(),
+            UsageSummary(
+                period = "today",
+                totalMinutes = 0L,
+                apps = emptyList()
+            )
+        )
+        val parsed = Json.parseToJsonElement(json).jsonObject
+        assertEquals("today", parsed["period"]?.jsonPrimitive?.content)
+        assertEquals(0L, parsed["total_minutes"]?.jsonPrimitive?.long)
+        assertEquals(0, parsed["apps"]?.jsonArray?.size)
+    }
+
+    // ---- AppUsage ----
+
+    @Test
+    fun `AppUsage daily breakdown round-trips`() {
+        val json = UsageJson.encodeToString(
+            AppUsage.serializer(),
+            AppUsage(
+                `package` = "com.app",
+                name = "Quoted \"App\"",
+                period = "week",
+                totalMinutes = 100L,
+                daily = listOf(
+                    DailyUsage(date = "2024-01-01", foregroundMinutes = 60L),
+                    DailyUsage(date = "2024-01-02", foregroundMinutes = 40L)
+                )
+            )
+        )
+        val parsed = Json.parseToJsonElement(json).jsonObject
+        assertEquals("com.app", parsed["package"]?.jsonPrimitive?.content)
+        assertEquals("Quoted \"App\"", parsed["name"]?.jsonPrimitive?.content)
+        assertEquals("week", parsed["period"]?.jsonPrimitive?.content)
+        assertEquals(100L, parsed["total_minutes"]?.jsonPrimitive?.long)
+        val daily = parsed["daily"]?.jsonArray
+        assertEquals(2, daily?.size)
+        assertEquals("2024-01-01", daily?.get(0)?.jsonObject?.get("date")?.jsonPrimitive?.content)
+    }
+
+    // ---- UsageEvent / UsageEventList ----
+
+    @Test
+    fun `UsageEventList round-trips`() {
+        val json = UsageJson.encodeToString(
+            UsageEventList.serializer(),
+            UsageEventList(
+                events = listOf(
+                    UsageEvent(
+                        `package` = "com.x",
+                        name = "X \"app\"",
+                        type = "activity_resumed",
+                        timestamp = "2024-01-01T00:00:00Z"
+                    )
+                )
+            )
+        )
+        val parsed = Json.parseToJsonElement(json).jsonObject
+        val events = parsed["events"]?.jsonArray
+        assertEquals(1, events?.size)
+        val first = events?.get(0)?.jsonObject
+        assertEquals("com.x", first?.get("package")?.jsonPrimitive?.content)
+        assertEquals("X \"app\"", first?.get("name")?.jsonPrimitive?.content)
+    }
+
+    // ---- UsageComparison ----
+
+    @Test
+    fun `UsageComparison with negative change round-trips`() {
+        val json = UsageJson.encodeToString(
+            UsageComparison.serializer(),
+            UsageComparison(
+                period1 = "today",
+                period2 = "yesterday",
+                total1Minutes = 100L,
+                total2Minutes = 80L,
+                apps = listOf(
+                    UsageDelta(
+                        `package` = "com.x",
+                        name = "X",
+                        period1Minutes = 50L,
+                        period2Minutes = 30L,
+                        change = "-20 min"
+                    )
+                )
+            )
+        )
+        val parsed = Json.parseToJsonElement(json).jsonObject
+        assertEquals("today", parsed["period1"]?.jsonPrimitive?.content)
+        assertEquals(100L, parsed["total1_minutes"]?.jsonPrimitive?.long)
+        val apps = parsed["apps"]?.jsonArray
+        val first = apps?.get(0)?.jsonObject
+        assertEquals("-20 min", first?.get("change")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `usageError contains success false default`() {
+        val result = usageError("oops")
+        require(result is ToolResult.Error)
+        assertTrue(result.message.contains("\"success\":false"))
+    }
+}


### PR DESCRIPTION
## Summary

The manual `"""{"key":"$value"}"""` pattern in five integrations files routinely produced malformed JSON when interpolated values contained `"`, `\`, newlines, or tabs — the exact contents `Throwable.message` from Android exceptions tends to carry. The bug surfaced as the Phone Outreach connector returning "malformed responses through the Anthropic proxy" on every failure path.

This PR replaces every interpolated JSON template in the integration MCP providers with `@Serializable` data classes encoded via `kotlinx.serialization`, so user-supplied content is escaped by the serializer rather than concatenated into a string template.

**Wire shapes are unchanged** (same field names, types, nesting). Only the encoding step is migrated. This is a behavior-preserving change.

## Files changed

Production:
- `integrations/build.gradle.kts` — added `kotlin.serialization` plugin so `@Serializable` works in this module.
- `integrations/.../outreach/OutreachMcpProvider.kt` — ~10 sites migrated.
- `integrations/.../outreach/OutreachJsonModels.kt` — new DTOs (`OutreachError`, `OutreachOk`, `SendNotificationResult`, `DndState`, `SetDndStateResult`, `NotificationChannelDto`, `InstalledApp`) and shared `OutreachJson`.
- `integrations/.../usage/UsageMcpProvider.kt` — ~10 sites migrated.
- `integrations/.../usage/UsageJsonModels.kt` — new DTOs (`UsageError`, `AppUsageEntry`, `UsageSummary`, `DailyUsage`, `AppUsage`, `UsageEvent`, `UsageEventList`, `UsageDelta`, `UsageComparison`) and shared `UsageJson`.
- `integrations/.../notifications/NotificationMcpProvider.kt` — 5 sites migrated; `ERR_ACTIONS_DISABLED` const replaced by `errActionsDisabled()` factory using the typed serializer.
- `integrations/.../notifications/NotificationJsonModels.kt` — new DTOs (`NotificationStatusMessage`, `NotificationSuccess`) and shared `NotificationJson`.
- `integrations/.../health/query/VitalsQueries.kt` — `skin_temperature.deltas` field built with `buildJsonArray` + `toString()` to preserve the legacy "string of JSON" shape exactly.
- `integrations/.../health/query/SleepQueries.kt` — same treatment for `sleep_session.stages`.

Tests:
- `integrations/src/test/kotlin/.../outreach/OutreachJsonShapeTest.kt` — new round-trip + #417 regression tests for every Outreach DTO.
- `integrations/src/test/kotlin/.../usage/UsageJsonShapeTest.kt` — same for Usage DTOs.
- `integrations/src/test/java/.../notifications/NotificationJsonShapeTest.kt` — same for Notification DTOs and `errActionsDisabled()`.
- `integrations/src/test/kotlin/.../outreach/OutreachQueryInstalledAppsTest.kt` — updated to assert on the typed `InstalledApp` fields now that `queryInstalledApps` returns `List<InstalledApp>` rather than `List<String>`.

## Wire shape preservation

Every existing tool result keeps the same JSON shape it had before: same keys, same types, same nesting, same field ordering (with `encodeDefaults = true` so the constant `success` defaults still serialize). The only behaviour change is that `"`, `\`, `\n`, `\t`, and other JSON-special characters in dynamic content (exception messages, app names, channel descriptions, package labels) are now properly escaped by `kotlinx.serialization` — i.e., the malformation hazard is fixed.

The two health-query "string of JSON" fields (`skin_temperature.deltas`, `sleep_session.stages`) had a quirky legacy shape where the value was a *string* containing a JSON array literal rather than a nested array. That oddity is preserved exactly — the inner array is now built with `buildJsonArray` and stringified, which keeps the wire format identical while still escaping content correctly.

## `escapeJson()` status

**Deleted.** Both `OutreachMcpProvider.escapeJson()` and `UsageMcpProvider.escapeJson()` became dead code and were removed; the new `Json.encodeToString` paths handle escaping correctly. (`buildChannelJson` was renamed `buildChannelDto` and now returns the DTO type rather than a JSON string.)

## `AuditDetailScreen` audit verdict

**No change needed.** Its `"""{...}"""` occurrences are only inside `@Preview` fixture data — not runtime JSON construction. The screen's actual responsibility is JSON pretty-printing for display, which is independent of the malformation hazard.

## Cross-reference

Issue #130 (closed) did this same migration scoped to OAuth protocol responses in `McpRouting`. This PR extends the same pattern to the rest of the MCP provider tool results.

## Test plan

- [x] `./gradlew :integrations:testDebugUnitTest` — all green, including new shape tests
- [x] `./gradlew :app:testDebugUnitTest` — all green
- [x] `./gradlew :core:mcp:jvmTest` — all green
- [x] `./gradlew ktlintCheck detekt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)