### PR TITLE
Fix #420: Complete CompletableDeferreds on all termination paths in WS/MCP/tunnel layers

### DIFF
--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/McpSession.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/McpSession.kt
@@ -44,7 +44,14 @@ class McpSession(
     private val serverName: String = "rouse-context",
     private val serverVersion: String = "0.1.0",
     private val unknownClientLabeler: UnknownClientLabeler? = null,
-    private val log: (LogLevel, String) -> Unit = { _, _ -> }
+    private val log: (LogLevel, String) -> Unit = { _, _ -> },
+    /**
+     * Starter seam used by [start] to launch the embedded HTTP server.
+     * Production code uses the default which calls
+     * `server.start(wait = false)`. Tests inject a starter that throws to
+     * exercise the error path that would otherwise leave [awaitClose] hung.
+     */
+    private val serverStarter: (EmbeddedServer<*, *>) -> Unit = { it.start(wait = false) }
 ) {
 
     private var done = CompletableDeferred<Unit>()
@@ -110,7 +117,16 @@ class McpSession(
             )
         }
         engine = server
-        server.start(wait = false)
+        try {
+            serverStarter(server)
+        } catch (e: Throwable) {
+            // If start() blows up after we reset `done` above, anyone awaiting
+            // close would otherwise hang forever. Surface the failure on that
+            // path and re-throw so the synchronous caller still sees it. See
+            // #420.
+            done.completeExceptionally(e)
+            throw e
+        }
     }
 
     /**

--- a/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/core/McpSessionStartFailureTest.kt
+++ b/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/core/McpSessionStartFailureTest.kt
@@ -1,0 +1,67 @@
+package com.rousecontext.mcp.core
+
+import java.io.IOException
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Regression test for issue #420 finding #5: if the embedded server fails to
+ * start after `done` was reset (e.g. on a restart), `awaitClose()` would
+ * previously block forever because `done` was only completed in `stop()`.
+ * Post-fix, `start()` propagates the failure into `done` so `awaitClose()`
+ * surfaces the start error instead of hanging.
+ */
+class McpSessionStartFailureTest {
+
+    @Test
+    fun `awaitClose surfaces start failure rather than hanging`() = runBlocking {
+        val registry = InMemoryProviderRegistry()
+        val tokenStore = InMemoryTokenStore()
+        val boom = IOException("simulated start() failure")
+
+        val session = McpSession(
+            registry = registry,
+            tokenStore = tokenStore,
+            hostname = "test.rousecontext.com",
+            integration = "health",
+            serverStarter = { throw boom }
+        )
+
+        try {
+            session.start(port = 0)
+            fail("start() should have rethrown the simulated failure")
+        } catch (e: IOException) {
+            assertEquals(boom, e)
+        }
+
+        // Pre-fix: `awaitClose()` would suspend indefinitely. Post-fix:
+        // `done` is completed exceptionally, so `await()` throws.
+        val result = runCatching {
+            withTimeout(2000L) { session.awaitClose() }
+        }
+        assertTrue(
+            "awaitClose() should fail with the start error, not hang. result=$result",
+            result.isFailure
+        )
+        // CompletableDeferred re-wraps the original cause when await() rethrows.
+        // Walk the cause chain to find our marker exception.
+        val thrown = result.exceptionOrNull()
+        var matches = false
+        var current: Throwable? = thrown
+        while (current != null) {
+            if (current === boom) {
+                matches = true
+                break
+            }
+            current = current.cause
+        }
+        assertTrue(
+            "awaitClose() should surface the original start error in its cause chain, got $thrown",
+            matches
+        )
+    }
+}

--- a/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/KtorWebSocketFactory.kt
+++ b/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/KtorWebSocketFactory.kt
@@ -9,7 +9,6 @@ import io.ktor.websocket.close
 import io.ktor.websocket.readBytes
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 /**
@@ -17,10 +16,14 @@ import kotlinx.coroutines.launch
  *
  * Used for JVM tests. NOT suitable for Android mTLS because Ktor CIO engine
  * does not properly present client certificates during TLS handshake.
+ *
+ * [scope] must be a structured scope owned by the caller (e.g. the surrounding
+ * `runBlocking` in tests). The factory does not own a scope of its own — see
+ * `.claude/rules/coroutines.md`.
  */
 class KtorWebSocketFactory(
-    private val httpClient: HttpClient = HttpClient { install(WebSockets) },
-    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+    private val scope: CoroutineScope,
+    private val httpClient: HttpClient = HttpClient { install(WebSockets) }
 ) : WebSocketFactory {
 
     override fun connect(url: String, listener: WebSocketListener): WebSocketHandle {
@@ -43,6 +46,10 @@ class KtorWebSocketFactory(
                 if (handle.isBound()) {
                     listener.onClosing(1006, e.message ?: "Connection lost")
                 } else {
+                    // Awaiters of sendBinary/sendText would otherwise hang
+                    // forever waiting for sessionDeferred. Propagate the failure
+                    // so they observe the connect error.
+                    handle.failBind(e)
                     listener.onFailure(e)
                 }
             }
@@ -59,6 +66,10 @@ private class KtorWebSocketHandle : WebSocketHandle {
 
     fun bind(session: WebSocketSession) {
         sessionDeferred.complete(session)
+    }
+
+    fun failBind(error: Throwable) {
+        sessionDeferred.completeExceptionally(error)
     }
 
     override suspend fun sendBinary(data: ByteArray): Boolean {

--- a/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/TunnelClientImpl.kt
+++ b/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/TunnelClientImpl.kt
@@ -90,6 +90,17 @@ class TunnelClientImpl(
                     }
 
                     override fun onClosing(code: Int, reason: String) {
+                        // If the server closes before onOpen ever fires, the
+                        // pre-CONNECTED awaiter on `opened.await()` would hang
+                        // until the surrounding scope is cancelled. Surface the
+                        // close as a connect failure on that path. See #420.
+                        if (!opened.isCompleted) {
+                            opened.completeExceptionally(
+                                TunnelError.WebSocketClosed(
+                                    "WebSocket closed during handshake: $code $reason"
+                                )
+                            )
+                        }
                         scope.launch {
                             handleDisconnect(
                                 TunnelError.WebSocketClosed(

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/KtorWebSocketFactoryFailBindTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/KtorWebSocketFactoryFailBindTest.kt
@@ -1,0 +1,62 @@
+package com.rousecontext.tunnel
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Regression test for issue #420 finding #4: when `webSocketSession(url)`
+ * throws before the session is bound, the handle's internal `sessionDeferred`
+ * must be completed exceptionally so anyone awaiting `sendBinary` /
+ * `sendText` does not hang forever.
+ */
+class KtorWebSocketFactoryFailBindTest {
+
+    @Test
+    fun `sendBinary fails fast when connect throws before bind`() = runBlocking {
+        // Connecting to a port that nothing is listening on causes
+        // `webSocketSession()` to throw inside the launched coroutine before
+        // `handle.bind()` is called. Pre-fix: `sessionDeferred` was never
+        // completed, so `handle.sendBinary()` hung on `sessionDeferred.await()`
+        // until the surrounding scope was cancelled. Post-fix: the catch in
+        // `connect()` calls `handle.failBind(e)` so awaiters surface the error
+        // instead of hanging.
+        val factory = KtorWebSocketFactory(scope = this)
+
+        val onFailureCalled = CompletableDeferred<Throwable>()
+        val listener = object : WebSocketListener {
+            override fun onOpen() = Unit
+            override fun onBinaryMessage(data: ByteArray) = Unit
+            override fun onClosing(code: Int, reason: String) = Unit
+            override fun onFailure(error: Throwable) {
+                onFailureCalled.complete(error)
+            }
+        }
+
+        val handle = factory.connect("ws://localhost:1/nope", listener)
+
+        val result = runCatching {
+            withTimeout(2000L) {
+                handle.sendBinary(ByteArray(0))
+            }
+        }
+        assertTrue(
+            result.isFailure,
+            "sendBinary should fail (not hang) when connect() never bound the session"
+        )
+        val cause = result.exceptionOrNull()
+        assertTrue(
+            cause !is TimeoutCancellationException,
+            "sendBinary timed out instead of failing fast: $cause"
+        )
+
+        // Belt-and-braces: onFailure must have fired too.
+        withTimeout(2000L) { onFailureCalled.await() }
+
+        coroutineContext.cancelChildren()
+    }
+}

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/TunnelClientImplOnClosingDuringHandshakeTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/TunnelClientImplOnClosingDuringHandshakeTest.kt
@@ -1,0 +1,73 @@
+package com.rousecontext.tunnel
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Regression test for issue #420 finding #6: if the WebSocket handshake
+ * completes but the server immediately calls `onClosing` without first
+ * calling `onOpen`, the `opened` deferred inside `connect()` was never
+ * completed, leaving `connect()` hung on `opened.await()` until its scope
+ * was cancelled. Post-fix, `onClosing` completes `opened` exceptionally on
+ * that path so `connect()` surfaces an error promptly.
+ */
+class TunnelClientImplOnClosingDuringHandshakeTest {
+
+    /**
+     * A fake [WebSocketFactory] that synchronously calls [WebSocketListener.onClosing]
+     * without a preceding [WebSocketListener.onOpen] and without throwing.
+     */
+    private class CloseDuringHandshakeFactory : WebSocketFactory {
+        override fun connect(url: String, listener: WebSocketListener): WebSocketHandle {
+            listener.onClosing(1011, "server policy")
+            return object : WebSocketHandle {
+                override suspend fun sendBinary(data: ByteArray): Boolean = false
+                override suspend fun sendText(text: String): Boolean = false
+                override suspend fun close(code: Int, reason: String) = Unit
+            }
+        }
+    }
+
+    @Test
+    fun `connect surfaces error promptly when server closes during handshake`() = runBlocking {
+        val client = TunnelClientImpl(this, CloseDuringHandshakeFactory())
+
+        // Fast timeout: pre-fix, `opened.await()` would block until the
+        // surrounding scope is cancelled, so this would consistently time out.
+        // Post-fix, `onClosing` completes `opened` exceptionally so connect()
+        // surfaces an error well within the budget.
+        val budgetMillis = 500L
+        val started = System.nanoTime()
+        val result = runCatching {
+            withTimeout(budgetMillis) { client.connect("ws://example.test/tunnel") }
+        }
+        val elapsedMillis = (System.nanoTime() - started) / 1_000_000
+
+        assertTrue(
+            result.isFailure,
+            "connect() should fail when server closes before onOpen, but result was: $result"
+        )
+        val cause = result.exceptionOrNull()
+        assertTrue(
+            cause is TunnelError.WebSocketClosed,
+            "connect() should surface TunnelError.WebSocketClosed, got $cause"
+        )
+        // Cause chain must reference the handshake-time close, not just any
+        // TunnelError emitted by an unrelated path.
+        assertTrue(
+            (cause?.message ?: "").contains("handshake"),
+            "TunnelError should mention the handshake-time close, got message: ${cause?.message}"
+        )
+        assertTrue(
+            elapsedMillis < budgetMillis,
+            "connect() should fail much faster than the timeout but took ${elapsedMillis}ms"
+        )
+        assertEquals(TunnelState.DISCONNECTED, client.state.value)
+
+        coroutineContext.cancelChildren()
+    }
+}

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/TunnelClientImplTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/TunnelClientImplTest.kt
@@ -42,7 +42,7 @@ class TunnelClientImplTest {
         server.start(wait = false)
 
         try {
-            val client = TunnelClientImpl(this, KtorWebSocketFactory())
+            val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
 
             assertEquals(TunnelState.DISCONNECTED, client.state.value)
 
@@ -91,7 +91,7 @@ class TunnelClientImplTest {
         server.start(wait = false)
 
         try {
-            val client = TunnelClientImpl(this, KtorWebSocketFactory())
+            val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
             client.connect("ws://localhost:$port/tunnel")
 
             val sessionReceived = CompletableDeferred<MuxStream>()
@@ -150,7 +150,7 @@ class TunnelClientImplTest {
         server.start(wait = false)
 
         try {
-            val client = TunnelClientImpl(this, KtorWebSocketFactory())
+            val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
             client.connect("ws://localhost:$port/tunnel")
 
             val sessionReceived = CompletableDeferred<MuxStream>()
@@ -206,7 +206,7 @@ class TunnelClientImplTest {
         server.start(wait = false)
 
         try {
-            val client = TunnelClientImpl(this, KtorWebSocketFactory())
+            val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
 
             val errorReceived = CompletableDeferred<TunnelError>()
             val errorJob =
@@ -266,7 +266,7 @@ class TunnelClientImplTest {
         server.start(wait = false)
 
         try {
-            val client = TunnelClientImpl(this, KtorWebSocketFactory())
+            val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
             client.connect("ws://localhost:$port/tunnel")
 
             client.sendFcmToken("test-fcm-token-123")
@@ -283,7 +283,7 @@ class TunnelClientImplTest {
 
     @Test
     fun `sendFcmToken before connect is a no-op`() = runBlocking {
-        val client = TunnelClientImpl(this, KtorWebSocketFactory())
+        val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
 
         // Should not throw
         client.sendFcmToken("some-token")
@@ -293,7 +293,7 @@ class TunnelClientImplTest {
 
     @Test
     fun `disconnect when already disconnected does not throw or corrupt state`() = runBlocking {
-        val client = TunnelClientImpl(this, KtorWebSocketFactory())
+        val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
 
         // Initial state is DISCONNECTED
         assertEquals(TunnelState.DISCONNECTED, client.state.value)
@@ -327,7 +327,7 @@ class TunnelClientImplTest {
         server.start(wait = false)
 
         try {
-            val client = TunnelClientImpl(this, KtorWebSocketFactory())
+            val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
 
             // Connect, disconnect, connect again
             client.connect("ws://localhost:$port/tunnel")
@@ -372,7 +372,7 @@ class TunnelClientImplTest {
         server.start(wait = false)
 
         try {
-            val client = TunnelClientImpl(this, KtorWebSocketFactory())
+            val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
 
             // Connect/disconnect 5 times with brief settling delays
             repeat(5) { i ->
@@ -408,7 +408,7 @@ class TunnelClientImplTest {
         val captured = mutableListOf<Pair<LogLevel, String>>()
         val client = TunnelClientImpl(
             this,
-            KtorWebSocketFactory(),
+            KtorWebSocketFactory(this),
             log = { level, msg -> captured.add(level to msg) }
         )
 
@@ -450,7 +450,7 @@ class TunnelClientImplTest {
         try {
             val client = TunnelClientImpl(
                 scope = this,
-                webSocketFactory = KtorWebSocketFactory(),
+                webSocketFactory = KtorWebSocketFactory(this),
                 // Aggressive timing so the test doesn't wait 90s.
                 keepaliveIntervalMillis = 50L,
                 keepaliveTimeoutMillis = 50L,
@@ -501,7 +501,7 @@ class TunnelClientImplTest {
         server.start(wait = false)
 
         try {
-            val client = TunnelClientImpl(this, KtorWebSocketFactory())
+            val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
             client.connect("ws://localhost:$port/tunnel")
 
             val live = client.healthCheck(kotlin.time.Duration.parse("2s"))
@@ -532,7 +532,7 @@ class TunnelClientImplTest {
         server.start(wait = false)
 
         try {
-            val client = TunnelClientImpl(this, KtorWebSocketFactory())
+            val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
             client.connect("ws://localhost:$port/tunnel")
 
             val live = client.healthCheck(kotlin.time.Duration.parse("0.3s"))
@@ -547,7 +547,7 @@ class TunnelClientImplTest {
 
     @Test
     fun `healthCheck returns false when not connected`() = runBlocking {
-        val client = TunnelClientImpl(this, KtorWebSocketFactory())
+        val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
         // No connect() called.
         val live = client.healthCheck(kotlin.time.Duration.parse("0.2s"))
         assertTrue(!live, "healthCheck must not claim healthy when never connected")
@@ -571,7 +571,7 @@ class TunnelClientImplTest {
         server.start(wait = false)
 
         try {
-            val client = TunnelClientImpl(this, KtorWebSocketFactory())
+            val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
             client.connect("ws://localhost:$port/tunnel")
             assertEquals(TunnelState.CONNECTED, client.state.value)
 
@@ -633,7 +633,7 @@ class TunnelClientImplTest {
         server.start(wait = false)
 
         try {
-            val client = TunnelClientImpl(this, KtorWebSocketFactory())
+            val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
 
             // First connect: open a stream so state reaches ACTIVE, then drop.
             client.connect("ws://localhost:$port/tunnel")
@@ -726,7 +726,7 @@ class TunnelClientImplTest {
         try {
             val client = TunnelClientImpl(
                 scope = this,
-                webSocketFactory = KtorWebSocketFactory(),
+                webSocketFactory = KtorWebSocketFactory(this),
                 // Disable keepalive so it doesn't interfere with the test.
                 keepaliveIntervalMillis = 600_000L,
                 keepaliveTimeoutMillis = 10_000L,
@@ -766,7 +766,7 @@ class TunnelClientImplTest {
 
     @Test
     fun `connection failure emits error on SharedFlow`() = runBlocking {
-        val client = TunnelClientImpl(this, KtorWebSocketFactory())
+        val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
 
         val errorReceived = CompletableDeferred<TunnelError>()
         val errorJob =

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/WebSocketMuxTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/WebSocketMuxTest.kt
@@ -42,7 +42,7 @@ class WebSocketMuxTest {
         server.start(wait = false)
 
         try {
-            val client = TunnelClientImpl(this, KtorWebSocketFactory())
+            val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
 
             client.connect("ws://localhost:$port/tunnel")
 
@@ -78,7 +78,7 @@ class WebSocketMuxTest {
         server.start(wait = false)
 
         try {
-            val client = TunnelClientImpl(this, KtorWebSocketFactory())
+            val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
             client.connect("ws://localhost:$port/tunnel")
 
             val sessionReceived = CompletableDeferred<MuxStream>()
@@ -149,7 +149,7 @@ class WebSocketMuxTest {
         server.start(wait = false)
 
         try {
-            val client = TunnelClientImpl(this, KtorWebSocketFactory())
+            val client = TunnelClientImpl(this, KtorWebSocketFactory(this))
             client.connect("ws://localhost:$port/tunnel")
 
             val sessions = mutableListOf<MuxStream>()


### PR DESCRIPTION
## Summary

Three independent defensive fixes from chunk A audit on #415, each addressing a `CompletableDeferred` that was only completed on some termination paths and could leave `await()` callers hung in edge cases.

### #4 — `KtorWebSocketFactory.connect()` never failed `sessionDeferred` on connect throw

**Files:** `core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/KtorWebSocketFactory.kt`

If `httpClient.webSocketSession(url)` threw before `handle.bind(session)`, the catch block called `listener.onFailure(e)` but never completed the handle's `sessionDeferred`. Anyone awaiting `sendBinary` / `sendText` (which awaits `sessionDeferred`) would hang forever.

Fix: added `handle.failBind(e)` on the pre-bind failure path. Also dropped the `CoroutineScope(Dispatchers.IO)` default (violates `.claude/rules/coroutines.md`) and made `scope` a required constructor parameter; updated test call sites in `TunnelClientImplTest.kt` and `WebSocketMuxTest.kt` to pass the surrounding `runBlocking` scope.

### #5 — `McpSession.awaitClose()` hung forever if `start()` failed silently

**Files:** `core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/McpSession.kt`

`done` was only completed in `stop()`. If `embeddedServer.start(wait = false)` threw after `done` was reset, `awaitClose()` would block indefinitely.

Fix: wrap the `start(wait = false)` call in try/catch, call `done.completeExceptionally(e)` on failure, and re-throw so the synchronous caller still surfaces the start error. Added an internal `serverStarter` constructor seam so tests can inject a starter that throws.

### #6 — `TunnelClientImpl.connect`'s `opened` deferred not completed on pre-`onOpen` `onClosing`

**Files:** `core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/TunnelClientImpl.kt`

`opened` was completed only in `onOpen` and `onFailure`. If the WebSocket handshake completed but the server immediately called `onClosing` without `onOpen` and without throwing, `opened.await()` would hang until the surrounding scope was cancelled.

Fix: in the `onClosing` callback, if `opened` is not yet completed, call `opened.completeExceptionally(TunnelError.WebSocketClosed("WebSocket closed during handshake: ..."))`.

## Regression tests

Each test was verified to fail without the corresponding fix and pass with it.

- **#4** — `KtorWebSocketFactoryFailBindTest.sendBinary fails fast when connect throws before bind`
- **#5** — `McpSessionStartFailureTest.awaitClose surfaces start failure rather than hanging`
- **#6** — `TunnelClientImplOnClosingDuringHandshakeTest.connect surfaces error promptly when server closes during handshake`

## Test plan

- [x] `:core:tunnel:jvmTest` green
- [x] `:core:mcp:jvmTest` green
- [x] `ktlintCheck` + `detekt` green
- [x] `:app:compileDebugKotlin` still compiles (no behavior change for `McpSession` callers using named args)
- [x] Each new test verified to fail without its corresponding fix

Closes #420.

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)