### PR TITLE
Fix #426: harness-level JSON parse assertion + CI grep against manual-template JSON

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -56,6 +56,12 @@ jobs:
         run: ./gradlew ktlintCheck
       - name: Check for zombie screen files
         run: bash scripts/check-zombie-screens.sh
+      - name: Check for manual-template JSON in production code
+        # Per #426: prevents reintroduction of the #417 bug class where
+        # """{"field":"$value"}""" string templates produce malformed JSON
+        # when interpolated values contain quotes, backslashes, or control
+        # characters. Production code must use @Serializable + encodeToString.
+        run: bash scripts/check-no-manual-json.sh
       - name: Build
         run: ./gradlew assembleDebug
       - name: Unit tests

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -1,0 +1,79 @@
+# Agent Quickstart
+
+A short reference for agents (and humans) writing code in this repo. For the
+full architecture and module layout, see `docs/workflow.md` and the
+project-root `CLAUDE.md`.
+
+## JSON construction
+
+Tools that return structured data MUST use `@Serializable` data classes plus
+`Json.encodeToString` (or `Json.encodeToJsonElement` if a tree is preferable).
+Manual template literals — `"""{"field":"$value"}"""` — are NOT permitted in
+production code.
+
+### Why
+
+Issue [#417](https://github.com/Monkopedia/rouse-context/issues/417) shipped
+malformed JSON to user testing because a template-literal error helper
+interpolated a raw exception message containing quotes, producing output the
+connector proxy refused to parse. The `@Serializable` + `encodeToString` path
+escapes embedded quotes/backslashes/control characters automatically; the
+manual path does not.
+
+### Enforcement
+
+Two gates run in CI:
+
+1. **Test harness** (`McpToolTestHarness` in
+   `integrations/src/test/kotlin/com/rousecontext/integrations/testing/`) —
+   parse-asserts every `CallToolResult` body returned through the harness.
+   Any tool whose result body fails `Json.parseToJsonElement` causes the
+   test to fail with the offending tool name and body content.
+2. **Static check** (`scripts/check-no-manual-json.sh`) — runs in the
+   `Android CI` workflow. Greps for `"""{` in `*/src/main/*.kt` and fails the
+   build if any match isn't allowlisted.
+
+### The `// allow-manual-json` marker
+
+For the rare case where a template literal is genuinely safe (e.g. a
+`@Preview`-only Compose fixture with hard-coded literals that never see
+runtime input), append a marker comment to the line:
+
+```kotlin
+val sample = """{"steps":7000}""" // allow-manual-json: @Preview fixture, no interpolation
+```
+
+The reason text after the colon should describe **why this isn't a runtime
+risk** — typically because no user-controlled value flows into the template.
+A reviewer should treat the absence of a clear reason as a blocker.
+
+`AuditDetailScreen.kt` is implicitly allowlisted in the script because its
+preview fixtures exist purely for IDE rendering and never reach runtime; new
+files should use the inline marker rather than expanding the file allowlist.
+
+## Test harness
+
+When writing or refactoring an `*McpProvider*Test`, use
+`McpToolTestHarness` rather than hand-rolling the mockk capture pattern:
+
+```kotlin
+private val harness = McpToolTestHarness()
+private val fakeConnection: ClientConnection = mockk(relaxed = true)
+
+@Before fun setUp() {
+    val server = harness.createMockServer()
+    MyMcpProvider(...).register(server)
+}
+
+@Test fun `tool does the thing`() = runBlocking {
+    val result = harness.callTool(
+        name = "my_tool",
+        arguments = buildJsonObject { put("x", JsonPrimitive(1)) },
+        connection = fakeConnection
+    )
+    // Body is guaranteed JSON-parseable; assert further as needed.
+}
+```
+
+Pass `expectJsonBody = false` only for tools whose contract specifies a
+plain-text body (rare). Document the reason inline if you do.

--- a/integrations/src/test/java/com/rousecontext/integrations/notifications/NotificationMcpProviderToolsTest.kt
+++ b/integrations/src/test/java/com/rousecontext/integrations/notifications/NotificationMcpProviderToolsTest.kt
@@ -1,9 +1,8 @@
 package com.rousecontext.integrations.notifications
 
 import android.service.notification.StatusBarNotification
-import io.mockk.every
+import com.rousecontext.integrations.testing.McpToolTestHarness
 import io.mockk.mockk
-import io.mockk.slot
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.serialization.json.Json
@@ -24,26 +23,13 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class NotificationMcpProviderToolsTest {
 
+    private lateinit var harness: McpToolTestHarness
     private lateinit var server: Server
-    private val toolNames = mutableListOf<String>()
-    private val toolSchemas = mutableMapOf<String, ToolSchema>()
 
     @Before
     fun setUp() {
-        server = mockk(relaxed = true)
-        val nameSlot = slot<String>()
-        val schemaSlot = slot<ToolSchema>()
-        every {
-            server.addTool(
-                name = capture(nameSlot),
-                description = any(),
-                inputSchema = capture(schemaSlot),
-                handler = any()
-            )
-        } answers {
-            toolNames.add(nameSlot.captured)
-            toolSchemas[nameSlot.captured] = schemaSlot.captured
-        }
+        harness = McpToolTestHarness()
+        server = harness.createMockServer()
     }
 
     private fun buildProvider(): NotificationMcpProvider = NotificationMcpProvider(
@@ -65,9 +51,9 @@ class NotificationMcpProviderToolsTest {
 
         buildProvider().register(server)
 
-        assertEquals(expected, toolNames.toSet())
-        // No duplicates — every name appears exactly once.
-        assertEquals(expected.size, toolNames.size)
+        assertEquals(expected, harness.toolHandlers.keys)
+        // No duplicates — every name appears exactly once (harness keyed by name).
+        assertEquals(expected.size, harness.toolHandlers.size)
     }
 
     @Test
@@ -75,7 +61,7 @@ class NotificationMcpProviderToolsTest {
         buildProvider().register(server)
 
         val json = Json { ignoreUnknownKeys = true }
-        toolSchemas.forEach { (name, schema) ->
+        harness.toolSchemas.forEach { (name, schema) ->
             val serialized = json.encodeToString(ToolSchema.serializer(), schema)
             val parsed = json.decodeFromString(ToolSchema.serializer(), serialized)
             assertEquals("$name schema round-trip", schema, parsed)

--- a/integrations/src/test/java/com/rousecontext/integrations/notifications/NotificationMcpToolExecutionTest.kt
+++ b/integrations/src/test/java/com/rousecontext/integrations/notifications/NotificationMcpToolExecutionTest.kt
@@ -5,17 +5,14 @@ import android.content.Context
 import android.os.Bundle
 import android.service.notification.StatusBarNotification
 import androidx.test.core.app.ApplicationProvider
+import com.rousecontext.integrations.testing.McpToolTestHarness
 import com.rousecontext.notifications.FieldEncryptor
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import io.modelcontextprotocol.kotlin.sdk.server.ClientConnection
 import io.modelcontextprotocol.kotlin.sdk.server.Server
-import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
-import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
-import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -45,13 +42,10 @@ class NotificationMcpToolExecutionTest {
     private lateinit var context: Context
     private lateinit var database: NotificationDatabase
     private lateinit var dao: NotificationDao
+    private lateinit var harness: McpToolTestHarness
     private lateinit var server: Server
 
     private val fakeConnection: ClientConnection = mockk(relaxed = true)
-    private val toolHandlers = mutableMapOf<
-        String,
-        suspend ClientConnection.(CallToolRequest) -> CallToolResult
-        >()
 
     // Mutable active-notifications list the provider's source callback returns.
     private var activeNotifications: Array<StatusBarNotification> = emptyArray()
@@ -67,19 +61,8 @@ class NotificationMcpToolExecutionTest {
         database = NotificationDatabase.createInMemory(context)
         dao = database.notificationDao()
 
-        server = mockk(relaxed = true)
-        val nameSlot = slot<String>()
-        val handlerSlot = slot<suspend ClientConnection.(CallToolRequest) -> CallToolResult>()
-        every {
-            server.addTool(
-                name = capture(nameSlot),
-                description = any(),
-                inputSchema = any<ToolSchema>(),
-                handler = capture(handlerSlot)
-            )
-        } answers {
-            toolHandlers[nameSlot.captured] = handlerSlot.captured
-        }
+        harness = McpToolTestHarness()
+        server = harness.createMockServer()
     }
 
     @After
@@ -119,7 +102,6 @@ class NotificationMcpToolExecutionTest {
     }
 
     private suspend fun call(name: String, args: Map<String, Any> = emptyMap()): CallToolResult {
-        val handler = toolHandlers[name] ?: error("Tool not registered: $name")
         val jsonArgs = buildJsonObject {
             for ((k, v) in args) {
                 when (v) {
@@ -131,11 +113,10 @@ class NotificationMcpToolExecutionTest {
                 }
             }
         }
-        return handler.invoke(
-            fakeConnection,
-            CallToolRequest(
-                params = CallToolRequestParams(name = name, arguments = jsonArgs)
-            )
+        return harness.callTool(
+            name = name,
+            arguments = jsonArgs,
+            connection = fakeConnection
         )
     }
 
@@ -581,7 +562,7 @@ class NotificationMcpToolExecutionTest {
     @Test
     fun `search_notification_history registered with correct schema`() {
         registerProvider()
-        assertNotNull(toolHandlers["search_notification_history"])
+        assertNotNull(harness.toolHandlers["search_notification_history"])
     }
 
     private fun record(

--- a/integrations/src/test/kotlin/com/rousecontext/integrations/outreach/OutreachMcpProviderTest.kt
+++ b/integrations/src/test/kotlin/com/rousecontext/integrations/outreach/OutreachMcpProviderTest.kt
@@ -3,17 +3,12 @@ package com.rousecontext.integrations.outreach
 import android.app.NotificationManager
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import com.rousecontext.integrations.testing.McpToolTestHarness
 import com.rousecontext.mcp.core.Clock
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import io.modelcontextprotocol.kotlin.sdk.server.ClientConnection
-import io.modelcontextprotocol.kotlin.sdk.server.Server
-import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
-import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequestParams
 import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
-import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -30,36 +25,17 @@ import org.robolectric.Shadows
 class OutreachMcpProviderTest {
 
     private lateinit var context: Context
-    private lateinit var server: Server
+    private lateinit var harness: McpToolTestHarness
     private lateinit var provider: OutreachMcpProvider
 
     private val fakeConnection: ClientConnection = mockk(relaxed = true)
-    private val toolHandlers = mutableMapOf<
-        String,
-        suspend ClientConnection.(
-            CallToolRequest
-        ) -> CallToolResult
-        >()
 
     @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
 
-        server = mockk(relaxed = true)
-
-        // Capture tool registrations
-        val nameSlot = slot<String>()
-        val handlerSlot = slot<suspend ClientConnection.(CallToolRequest) -> CallToolResult>()
-        every {
-            server.addTool(
-                name = capture(nameSlot),
-                description = any(),
-                inputSchema = any<ToolSchema>(),
-                handler = capture(handlerSlot)
-            )
-        } answers {
-            toolHandlers[nameSlot.captured] = handlerSlot.captured
-        }
+        harness = McpToolTestHarness()
+        val server = harness.createMockServer()
 
         provider = OutreachMcpProvider(context, dndEnabled = true)
         provider.register(server)
@@ -86,51 +62,29 @@ class OutreachMcpProviderTest {
             "get_dnd_state",
             "set_dnd_state"
         )
-        assertEquals(expectedTools, toolHandlers.keys)
+        assertEquals(expectedTools, harness.toolHandlers.keys)
     }
 
     @Test
     fun `register without dnd skips DND tools`() {
-        val noDndHandlers = mutableMapOf<
-            String,
-            suspend ClientConnection.(
-                CallToolRequest
-            ) -> CallToolResult
-            >()
-        val noDndServer = mockk<Server>(relaxed = true)
-        val nameSlot2 = slot<String>()
-        val handlerSlot2 = slot<suspend ClientConnection.(CallToolRequest) -> CallToolResult>()
-        every {
-            noDndServer.addTool(
-                name = capture(nameSlot2),
-                description = any(),
-                inputSchema = any<ToolSchema>(),
-                handler = capture(handlerSlot2)
-            )
-        } answers {
-            noDndHandlers[nameSlot2.captured] = handlerSlot2.captured
-        }
-
+        val noDndHarness = McpToolTestHarness()
         val noDndProvider = OutreachMcpProvider(context, dndEnabled = false)
-        noDndProvider.register(noDndServer)
+        noDndProvider.register(noDndHarness.createMockServer())
 
-        assertFalse(noDndHandlers.containsKey("get_dnd_state"))
-        assertFalse(noDndHandlers.containsKey("set_dnd_state"))
-        assertTrue(noDndHandlers.containsKey("launch_app"))
+        assertFalse(noDndHarness.toolHandlers.containsKey("get_dnd_state"))
+        assertFalse(noDndHarness.toolHandlers.containsKey("set_dnd_state"))
+        assertTrue(noDndHarness.toolHandlers.containsKey("launch_app"))
     }
 
     @Test
     fun `open_link rejects non-http schemes`() = runBlocking {
-        val handler = toolHandlers["open_link"]!!
-        val request = CallToolRequest(
-            params = CallToolRequestParams(
-                name = "open_link",
-                arguments = buildJsonObject {
-                    put("url", JsonPrimitive("file:///etc/passwd"))
-                }
-            )
+        val result = harness.callTool(
+            name = "open_link",
+            arguments = buildJsonObject {
+                put("url", JsonPrimitive("file:///etc/passwd"))
+            },
+            connection = fakeConnection
         )
-        val result = handler.invoke(fakeConnection, request)
         assertTrue(result.isError == true)
         val text = (result.content.first() as TextContent).text!!
         assertTrue(text.contains("Only http and https"))
@@ -138,37 +92,30 @@ class OutreachMcpProviderTest {
 
     @Test
     fun `open_link accepts https`() = runBlocking {
-        val handler = toolHandlers["open_link"]!!
-        val request = CallToolRequest(
-            params = CallToolRequestParams(
-                name = "open_link",
-                arguments = buildJsonObject {
-                    put("url", JsonPrimitive("https://example.com"))
-                }
-            )
+        val result = harness.callTool(
+            name = "open_link",
+            arguments = buildJsonObject {
+                put("url", JsonPrimitive("https://example.com"))
+            },
+            connection = fakeConnection
         )
-        val result = handler.invoke(fakeConnection, request)
         assertFalse(result.isError == true)
     }
 
     @Test
     fun `open_link posts notification fallback when direct launch is denied`() = runBlocking {
         val notifier = mockk<com.rousecontext.api.LaunchRequestNotifierApi>(relaxed = true)
-        val fallbackHandlers = registerProvider(
+        val fallbackHarness = registerProvider(
             canLaunchDirectly = { false },
             launchNotifier = notifier
         )
-        val handler = fallbackHandlers["open_link"]!!
-        val request = CallToolRequest(
-            params = CallToolRequestParams(
-                name = "open_link",
-                arguments = buildJsonObject {
-                    put("url", JsonPrimitive("https://example.com"))
-                }
-            )
+        val result = fallbackHarness.callTool(
+            name = "open_link",
+            arguments = buildJsonObject {
+                put("url", JsonPrimitive("https://example.com"))
+            },
+            connection = fakeConnection
         )
-
-        val result = handler.invoke(fakeConnection, request)
 
         assertFalse(result.isError == true)
         io.mockk.verify(exactly = 1) {
@@ -184,21 +131,17 @@ class OutreachMcpProviderTest {
     @Test
     fun `open_link uses direct launch when permission is granted`() = runBlocking {
         val notifier = mockk<com.rousecontext.api.LaunchRequestNotifierApi>(relaxed = true)
-        val directHandlers = registerProvider(
+        val directHarness = registerProvider(
             canLaunchDirectly = { true },
             launchNotifier = notifier
         )
-        val handler = directHandlers["open_link"]!!
-        val request = CallToolRequest(
-            params = CallToolRequestParams(
-                name = "open_link",
-                arguments = buildJsonObject {
-                    put("url", JsonPrimitive("https://example.com"))
-                }
-            )
+        val result = directHarness.callTool(
+            name = "open_link",
+            arguments = buildJsonObject {
+                put("url", JsonPrimitive("https://example.com"))
+            },
+            connection = fakeConnection
         )
-
-        val result = handler.invoke(fakeConnection, request)
 
         assertFalse(result.isError == true)
         io.mockk.verify(exactly = 0) {
@@ -209,23 +152,20 @@ class OutreachMcpProviderTest {
     @Test
     fun `launch_app posts notification fallback when direct launch is denied`() = runBlocking {
         val notifier = mockk<com.rousecontext.api.LaunchRequestNotifierApi>(relaxed = true)
-        val fallbackHandlers = registerProvider(
+        val fallbackHarness = registerProvider(
             canLaunchDirectly = { false },
             launchNotifier = notifier
         )
-        val handler = fallbackHandlers["launch_app"]!!
         // Use this test app's own package so the launch intent resolves
         val selfPkg = context.packageName
-        val request = CallToolRequest(
-            params = CallToolRequestParams(
-                name = "launch_app",
-                arguments = buildJsonObject {
-                    put("package_name", JsonPrimitive(selfPkg))
-                }
-            )
-        )
 
-        val result = handler.invoke(fakeConnection, request)
+        val result: CallToolResult = fallbackHarness.callTool(
+            name = "launch_app",
+            arguments = buildJsonObject {
+                put("package_name", JsonPrimitive(selfPkg))
+            },
+            connection = fakeConnection
+        )
 
         // Either the launch-intent resolves and we post, or the package has no
         // launch intent and we error. Both are acceptable runtime outcomes; here
@@ -241,48 +181,26 @@ class OutreachMcpProviderTest {
     private fun registerProvider(
         canLaunchDirectly: suspend () -> Boolean,
         launchNotifier: com.rousecontext.api.LaunchRequestNotifierApi?
-    ): MutableMap<
-        String,
-        suspend ClientConnection.(CallToolRequest) -> CallToolResult
-        > {
-        val handlers = mutableMapOf<
-            String,
-            suspend ClientConnection.(CallToolRequest) -> CallToolResult
-            >()
-        val srv = mockk<Server>(relaxed = true)
-        val nameSlot = slot<String>()
-        val handlerSlot = slot<suspend ClientConnection.(CallToolRequest) -> CallToolResult>()
-        every {
-            srv.addTool(
-                name = capture(nameSlot),
-                description = any(),
-                inputSchema = any<ToolSchema>(),
-                handler = capture(handlerSlot)
-            )
-        } answers {
-            handlers[nameSlot.captured] = handlerSlot.captured
-        }
+    ): McpToolTestHarness {
+        val h = McpToolTestHarness()
         OutreachMcpProvider(
             context = context,
             dndEnabled = false,
             canLaunchDirectly = canLaunchDirectly,
             launchNotifier = launchNotifier
-        ).register(srv)
-        return handlers
+        ).register(h.createMockServer())
+        return h
     }
 
     @Test
     fun `launch_app returns error for unknown package`() = runBlocking {
-        val handler = toolHandlers["launch_app"]!!
-        val request = CallToolRequest(
-            params = CallToolRequestParams(
-                name = "launch_app",
-                arguments = buildJsonObject {
-                    put("package_name", JsonPrimitive("com.unknown.nonexistent.app"))
-                }
-            )
+        val result = harness.callTool(
+            name = "launch_app",
+            arguments = buildJsonObject {
+                put("package_name", JsonPrimitive("com.unknown.nonexistent.app"))
+            },
+            connection = fakeConnection
         )
-        val result = handler.invoke(fakeConnection, request)
         assertTrue(result.isError == true)
         val text = (result.content.first() as TextContent).text!!
         assertTrue(text.contains("App not found"))
@@ -290,17 +208,14 @@ class OutreachMcpProviderTest {
 
     @Test
     fun `send_notification succeeds`() = runBlocking {
-        val handler = toolHandlers["send_notification"]!!
-        val request = CallToolRequest(
-            params = CallToolRequestParams(
-                name = "send_notification",
-                arguments = buildJsonObject {
-                    put("title", JsonPrimitive("Test Title"))
-                    put("message", JsonPrimitive("Test Body"))
-                }
-            )
+        val result = harness.callTool(
+            name = "send_notification",
+            arguments = buildJsonObject {
+                put("title", JsonPrimitive("Test Title"))
+                put("message", JsonPrimitive("Test Body"))
+            },
+            connection = fakeConnection
         )
-        val result = handler.invoke(fakeConnection, request)
         assertFalse(result.isError == true)
         val text = (result.content.first() as TextContent).text!!
         assertTrue(text.contains("\"success\":true"))
@@ -313,55 +228,42 @@ class OutreachMcpProviderTest {
             var time = 1000L
             override fun currentTimeMillis(): Long = time
         }
-        val rateLimitHandlers = mutableMapOf<
-            String,
-            suspend ClientConnection.(
-                CallToolRequest
-            ) -> CallToolResult
-            >()
-        val rlServer = mockk<Server>(relaxed = true)
-        val nameSlot3 = slot<String>()
-        val handlerSlot3 = slot<suspend ClientConnection.(CallToolRequest) -> CallToolResult>()
-        every {
-            rlServer.addTool(
-                name = capture(nameSlot3),
-                description = any(),
-                inputSchema = any<ToolSchema>(),
-                handler = capture(handlerSlot3)
-            )
-        } answers {
-            rateLimitHandlers[nameSlot3.captured] = handlerSlot3.captured
-        }
-
+        val rlHarness = McpToolTestHarness()
         val rlProvider = OutreachMcpProvider(context, dndEnabled = false, clock = clock)
-        rlProvider.register(rlServer)
+        rlProvider.register(rlHarness.createMockServer())
 
-        val handler = rateLimitHandlers["send_notification"]!!
-        val request = CallToolRequest(
-            params = CallToolRequestParams(
-                name = "send_notification",
-                arguments = buildJsonObject {
-                    put("title", JsonPrimitive("Test"))
-                    put("message", JsonPrimitive("Body"))
-                }
-            )
-        )
+        val args = buildJsonObject {
+            put("title", JsonPrimitive("Test"))
+            put("message", JsonPrimitive("Body"))
+        }
 
         // Send 10 notifications (should all succeed)
         repeat(10) {
-            val result = handler.invoke(fakeConnection, request)
+            val result = rlHarness.callTool(
+                name = "send_notification",
+                arguments = args,
+                connection = fakeConnection
+            )
             assertFalse("Notification $it should succeed", result.isError == true)
         }
 
         // 11th should be rate limited
-        val result = handler.invoke(fakeConnection, request)
+        val result = rlHarness.callTool(
+            name = "send_notification",
+            arguments = args,
+            connection = fakeConnection
+        )
         assertTrue("11th notification should be rate limited", result.isError == true)
         val text = (result.content.first() as TextContent).text!!
         assertTrue(text.contains("Rate limited"))
 
         // Advance clock past the window
         clock.time += 61_000L
-        val afterWindowResult = handler.invoke(fakeConnection, request)
+        val afterWindowResult = rlHarness.callTool(
+            name = "send_notification",
+            arguments = args,
+            connection = fakeConnection
+        )
         assertFalse("Should succeed after window resets", afterWindowResult.isError == true)
     }
 
@@ -370,14 +272,11 @@ class OutreachMcpProviderTest {
         val nm = context.getSystemService(NotificationManager::class.java)
         nm.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_PRIORITY)
 
-        val handler = toolHandlers["get_dnd_state"]!!
-        val request = CallToolRequest(
-            params = CallToolRequestParams(
-                name = "get_dnd_state",
-                arguments = buildJsonObject {}
-            )
+        val result = harness.callTool(
+            name = "get_dnd_state",
+            arguments = buildJsonObject {},
+            connection = fakeConnection
         )
-        val result = handler.invoke(fakeConnection, request)
         val text = (result.content.first() as TextContent).text!!
         assertTrue(text.contains("\"enabled\":true"))
         assertTrue(text.contains("\"mode\":\"priority_only\""))
@@ -385,16 +284,13 @@ class OutreachMcpProviderTest {
 
     @Test
     fun `set_dnd_state rejects when permission not granted`() = runBlocking {
-        val handler = toolHandlers["set_dnd_state"]!!
-        val request = CallToolRequest(
-            params = CallToolRequestParams(
-                name = "set_dnd_state",
-                arguments = buildJsonObject {
-                    put("enabled", JsonPrimitive("true"))
-                }
-            )
+        val result = harness.callTool(
+            name = "set_dnd_state",
+            arguments = buildJsonObject {
+                put("enabled", JsonPrimitive("true"))
+            },
+            connection = fakeConnection
         )
-        val result = handler.invoke(fakeConnection, request)
         assertTrue(result.isError == true)
         val text = (result.content.first() as TextContent).text!!
         assertTrue(text.contains("permission not granted"))
@@ -406,17 +302,14 @@ class OutreachMcpProviderTest {
         val shadowNm = Shadows.shadowOf(nm)
         shadowNm.setNotificationPolicyAccessGranted(true)
 
-        val handler = toolHandlers["set_dnd_state"]!!
-        val request = CallToolRequest(
-            params = CallToolRequestParams(
-                name = "set_dnd_state",
-                arguments = buildJsonObject {
-                    put("enabled", JsonPrimitive("true"))
-                    put("mode", JsonPrimitive("total_silence"))
-                }
-            )
+        val result = harness.callTool(
+            name = "set_dnd_state",
+            arguments = buildJsonObject {
+                put("enabled", JsonPrimitive("true"))
+                put("mode", JsonPrimitive("total_silence"))
+            },
+            connection = fakeConnection
         )
-        val result = handler.invoke(fakeConnection, request)
         assertFalse(result.isError == true)
         val text = (result.content.first() as TextContent).text!!
         assertTrue(text.contains("\"success\":true"))

--- a/integrations/src/test/kotlin/com/rousecontext/integrations/testing/McpToolTestHarness.kt
+++ b/integrations/src/test/kotlin/com/rousecontext/integrations/testing/McpToolTestHarness.kt
@@ -1,0 +1,153 @@
+package com.rousecontext.integrations.testing
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.modelcontextprotocol.kotlin.sdk.server.ClientConnection
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequestParams
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+
+/**
+ * Shared harness for `*McpProvider*Test` classes that need to capture tool
+ * registrations against a mocked [Server], invoke them with sample
+ * [CallToolRequest]s, and assert on the resulting [CallToolResult].
+ *
+ * **Why this exists (#426 / #417):** the malformed-JSON bug in #417 shipped
+ * because individual tool tests asserted on substrings of the result body but
+ * never verified the body was parseable JSON. The connector proxy that
+ * actually consumes these results fails on malformed JSON; our tests didn't.
+ *
+ * Every tool body returned via [callTool] is automatically run through
+ * [Json.parseToJsonElement]. Parse failures surface as a clear
+ * [AssertionError] naming the tool and the offending body. Tools whose bodies
+ * are intentionally non-JSON can opt out per-call with `expectJsonBody = false`.
+ *
+ * Usage:
+ * ```
+ * private val harness = McpToolTestHarness()
+ *
+ * @Before fun setUp() {
+ *     val server = harness.createMockServer()
+ *     MyMcpProvider(...).register(server)
+ * }
+ *
+ * @Test fun `tool does the thing`() = runBlocking {
+ *     val result = harness.callTool(
+ *         name = "my_tool",
+ *         arguments = buildJsonObject { put("x", JsonPrimitive(1)) },
+ *         connection = fakeConnection
+ *     )
+ *     // body is guaranteed parseable; substring assertions still allowed
+ * }
+ * ```
+ */
+class McpToolTestHarness {
+
+    private val handlers =
+        mutableMapOf<String, suspend ClientConnection.(CallToolRequest) -> CallToolResult>()
+    private val schemas = mutableMapOf<String, ToolSchema>()
+
+    /** Names of all registered tools, in registration order is not guaranteed. */
+    val toolHandlers: Map<String, suspend ClientConnection.(CallToolRequest) -> CallToolResult>
+        get() = handlers
+
+    /** Schemas captured during tool registration. */
+    val toolSchemas: Map<String, ToolSchema>
+        get() = schemas
+
+    /**
+     * Build a `mockk<Server>(relaxed = true)` whose `addTool(...)` call captures
+     * the registered name, schema, and handler into this harness instance.
+     *
+     * Multiple servers can share the same harness — handler maps merge. Tests
+     * that need isolated capture (e.g. a "no DND" variant alongside the default
+     * setup) should construct a separate [McpToolTestHarness].
+     */
+    fun createMockServer(): Server {
+        val server = mockk<Server>(relaxed = true)
+        val nameSlot = slot<String>()
+        val schemaSlot = slot<ToolSchema>()
+        val handlerSlot = slot<suspend ClientConnection.(CallToolRequest) -> CallToolResult>()
+        every {
+            server.addTool(
+                name = capture(nameSlot),
+                description = any(),
+                inputSchema = capture(schemaSlot),
+                handler = capture(handlerSlot)
+            )
+        } answers {
+            handlers[nameSlot.captured] = handlerSlot.captured
+            schemas[nameSlot.captured] = schemaSlot.captured
+        }
+        return server
+    }
+
+    /**
+     * Invoke a previously-registered tool with the given arguments and return
+     * its result. The result body is validated as JSON unless [expectJsonBody]
+     * is `false`.
+     *
+     * @throws AssertionError if no tool with [name] was registered.
+     * @throws AssertionError if [expectJsonBody] is `true` and any
+     *   [TextContent] in the result fails to parse as JSON. The message
+     *   includes the tool name and the offending body content.
+     */
+    suspend fun callTool(
+        name: String,
+        arguments: JsonObject = buildJsonObject {},
+        connection: ClientConnection,
+        expectJsonBody: Boolean = true
+    ): CallToolResult {
+        val handler = handlers[name]
+            ?: throw AssertionError(
+                "No tool registered with name '$name'. Registered: ${handlers.keys}"
+            )
+
+        val request = CallToolRequest(
+            params = CallToolRequestParams(name = name, arguments = arguments)
+        )
+        val result = handler.invoke(connection, request)
+
+        if (expectJsonBody) {
+            assertResultIsJson(name, result)
+        }
+        return result
+    }
+
+    /**
+     * Validate every [TextContent] body in [result] parses as JSON. Used
+     * internally by [callTool]; exposed for tests that invoke handlers
+     * directly but still want the gate.
+     */
+    fun assertResultIsJson(toolName: String, result: CallToolResult) {
+        result.content
+            .mapIndexedNotNull { index, content ->
+                val text = (content as? TextContent)?.text
+                if (text != null) index to text else null
+            }
+            .forEach { (index, body) ->
+                try {
+                    Json.parseToJsonElement(body)
+                } catch (e: kotlinx.serialization.SerializationException) {
+                    throw AssertionError(
+                        buildString {
+                            append("Tool '").append(toolName).append("' returned non-JSON body")
+                            if (result.content.size > 1) {
+                                append(" (content[").append(index).append("])")
+                            }
+                            append(": ").append(body)
+                            append(" — parse error: ").append(e.message)
+                        },
+                        e
+                    )
+                }
+            }
+    }
+}

--- a/integrations/src/test/kotlin/com/rousecontext/integrations/testing/McpToolTestHarnessTest.kt
+++ b/integrations/src/test/kotlin/com/rousecontext/integrations/testing/McpToolTestHarnessTest.kt
@@ -1,0 +1,175 @@
+package com.rousecontext.integrations.testing
+
+import io.mockk.mockk
+import io.modelcontextprotocol.kotlin.sdk.server.ClientConnection
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Regression test for [McpToolTestHarness] — proves the JSON parse assertion
+ * fires when a tool returns a non-JSON body. This is the gate that catches
+ * the malformed-JSON bug class that shipped in #417.
+ */
+class McpToolTestHarnessTest {
+
+    private val fakeConnection: ClientConnection = mockk(relaxed = true)
+
+    @Test
+    fun `harness throws when tool returns non-JSON body and expectJsonBody is true`() =
+        runBlocking {
+            val harness = McpToolTestHarness()
+            val server = harness.createMockServer()
+
+            // Register a fake tool whose body is intentionally NOT valid JSON.
+            server.addTool(
+                name = "broken_tool",
+                description = "returns garbage",
+                inputSchema = ToolSchema(properties = buildJsonObject {}),
+                handler = { _ ->
+                    CallToolResult(
+                        content = listOf(TextContent(text = "not valid json")),
+                        isError = false
+                    )
+                }
+            )
+
+            try {
+                harness.callTool(
+                    name = "broken_tool",
+                    arguments = buildJsonObject {},
+                    connection = fakeConnection
+                )
+                fail("Harness should have thrown on non-JSON body")
+            } catch (e: AssertionError) {
+                val msg = e.message ?: ""
+                assertTrue(
+                    "Message should name the offending tool (was: $msg)",
+                    msg.contains("broken_tool")
+                )
+                assertTrue(
+                    "Message should include the bad body (was: $msg)",
+                    msg.contains("not valid json")
+                )
+            }
+        }
+
+    @Test
+    fun `harness allows non-JSON body when expectJsonBody is false`() = runBlocking {
+        val harness = McpToolTestHarness()
+        val server = harness.createMockServer()
+
+        server.addTool(
+            name = "plain_text_tool",
+            description = "returns plain text",
+            inputSchema = ToolSchema(properties = buildJsonObject {}),
+            handler = { _ ->
+                CallToolResult(
+                    content = listOf(TextContent(text = "just a string")),
+                    isError = false
+                )
+            }
+        )
+
+        // Should not throw with the opt-out flag.
+        val result = harness.callTool(
+            name = "plain_text_tool",
+            arguments = buildJsonObject {},
+            connection = fakeConnection,
+            expectJsonBody = false
+        )
+
+        assertEquals("just a string", (result.content.first() as TextContent).text)
+    }
+
+    @Test
+    fun `harness passes when tool returns valid JSON body`() = runBlocking {
+        val harness = McpToolTestHarness()
+        val server = harness.createMockServer()
+
+        server.addTool(
+            name = "good_tool",
+            description = "returns proper JSON",
+            inputSchema = ToolSchema(properties = buildJsonObject {}),
+            handler = { _ ->
+                CallToolResult(
+                    content = listOf(TextContent(text = """{"ok":true}""")),
+                    isError = false
+                )
+            }
+        )
+
+        val result = harness.callTool(
+            name = "good_tool",
+            arguments = buildJsonObject {},
+            connection = fakeConnection
+        )
+
+        assertEquals("""{"ok":true}""", (result.content.first() as TextContent).text)
+    }
+
+    @Test
+    fun `harness validates JSON on error results too`() = runBlocking {
+        val harness = McpToolTestHarness()
+        val server = harness.createMockServer()
+
+        server.addTool(
+            name = "broken_error_tool",
+            description = "error path returns bad JSON",
+            inputSchema = ToolSchema(properties = buildJsonObject {}),
+            handler = { _ ->
+                CallToolResult(
+                    content = listOf(
+                        TextContent(text = """{"error": "exception with " quotes"}""")
+                    ),
+                    isError = true
+                )
+            }
+        )
+
+        try {
+            harness.callTool(
+                name = "broken_error_tool",
+                arguments = buildJsonObject {},
+                connection = fakeConnection
+            )
+            fail("Harness should have thrown on malformed JSON in error path")
+        } catch (e: AssertionError) {
+            assertTrue(e.message!!.contains("broken_error_tool"))
+        }
+    }
+
+    @Test
+    fun `harness captures tool names for inspection`() {
+        val harness = McpToolTestHarness()
+        val server = harness.createMockServer()
+
+        server.addTool(
+            name = "tool_a",
+            description = "a",
+            inputSchema = ToolSchema(properties = buildJsonObject {}),
+            handler = { _ -> CallToolResult(content = listOf(TextContent(text = "{}"))) }
+        )
+        server.addTool(
+            name = "tool_b",
+            description = "b",
+            inputSchema = ToolSchema(properties = buildJsonObject {}),
+            handler = { _ -> CallToolResult(content = listOf(TextContent(text = "{}"))) }
+        )
+
+        assertEquals(setOf("tool_a", "tool_b"), harness.toolHandlers.keys)
+    }
+
+    // Suppress unused import warnings for Server / Tool which appear when imports
+    // are present but the class is created via mockk.
+    @Suppress("unused")
+    private fun keepImports(): Pair<Server?, Tool?> = null to null
+}

--- a/integrations/src/test/kotlin/com/rousecontext/integrations/usage/UsageMcpProviderTest.kt
+++ b/integrations/src/test/kotlin/com/rousecontext/integrations/usage/UsageMcpProviderTest.kt
@@ -6,16 +6,11 @@ import android.app.usage.UsageStatsManager
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
+import com.rousecontext.integrations.testing.McpToolTestHarness
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.slot
 import io.modelcontextprotocol.kotlin.sdk.server.ClientConnection
-import io.modelcontextprotocol.kotlin.sdk.server.Server
-import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
-import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequestParams
-import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
-import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -30,11 +25,9 @@ class UsageMcpProviderTest {
     private lateinit var context: Context
     private lateinit var usageStatsManager: UsageStatsManager
     private lateinit var packageManager: PackageManager
-    private lateinit var server: Server
+    private lateinit var harness: McpToolTestHarness
     private lateinit var provider: UsageMcpProvider
 
-    private val toolHandlers =
-        mutableMapOf<String, suspend ClientConnection.(CallToolRequest) -> CallToolResult>()
     private val fakeConnection: ClientConnection = mockk(relaxed = true)
 
     @Before
@@ -53,23 +46,9 @@ class UsageMcpProviderTest {
             packageManager.getApplicationInfo(any<String>(), any<Int>())
         } returns appInfo
 
-        server = mockk(relaxed = true)
-
-        val nameSlot = slot<String>()
-        val handlerSlot = slot<suspend ClientConnection.(CallToolRequest) -> CallToolResult>()
-        every {
-            server.addTool(
-                name = capture(nameSlot),
-                description = any(),
-                inputSchema = any<ToolSchema>(),
-                handler = capture(handlerSlot)
-            )
-        } answers {
-            toolHandlers[nameSlot.captured] = handlerSlot.captured
-        }
-
+        harness = McpToolTestHarness()
         provider = UsageMcpProvider(context)
-        provider.register(server)
+        provider.register(harness.createMockServer())
     }
 
     @Test
@@ -80,7 +59,7 @@ class UsageMcpProviderTest {
             "get_usage_events",
             "compare_usage"
         )
-        assertEquals(expectedTools, toolHandlers.keys)
+        assertEquals(expectedTools, harness.toolHandlers.keys)
     }
 
     @Test
@@ -98,17 +77,12 @@ class UsageMcpProviderTest {
         setupAppLabel("com.example.app2", "App Two")
         setupAppLabel("com.example.app3", "App Three")
 
-        val handler = toolHandlers["get_usage_summary"]!!
-        val result = handler.invoke(
-            fakeConnection,
-            CallToolRequest(
-                params = CallToolRequestParams(
-                    name = "get_usage_summary",
-                    arguments = buildJsonObject {
-                        put("period", JsonPrimitive("today"))
-                    }
-                )
-            )
+        val result = harness.callTool(
+            name = "get_usage_summary",
+            arguments = buildJsonObject {
+                put("period", JsonPrimitive("today"))
+            },
+            connection = fakeConnection
         )
 
         assertFalse(result.isError == true)
@@ -136,17 +110,12 @@ class UsageMcpProviderTest {
         setupAppLabel("com.example.app1", "Rouse Context")
         setupAppLabel("com.example.app2", "Other App")
 
-        val handler = toolHandlers["get_usage_summary"]!!
-        val result = handler.invoke(
-            fakeConnection,
-            CallToolRequest(
-                params = CallToolRequestParams(
-                    name = "get_usage_summary",
-                    arguments = buildJsonObject {
-                        put("period", JsonPrimitive("today"))
-                    }
-                )
-            )
+        val result = harness.callTool(
+            name = "get_usage_summary",
+            arguments = buildJsonObject {
+                put("period", JsonPrimitive("today"))
+            },
+            connection = fakeConnection
         )
 
         assertFalse(result.isError == true)
@@ -175,18 +144,13 @@ class UsageMcpProviderTest {
             setupAppLabel("com.example.app$i", "App$i")
         }
 
-        val handler = toolHandlers["get_usage_summary"]!!
-        val result = handler.invoke(
-            fakeConnection,
-            CallToolRequest(
-                params = CallToolRequestParams(
-                    name = "get_usage_summary",
-                    arguments = buildJsonObject {
-                        put("period", JsonPrimitive("week"))
-                        put("limit", JsonPrimitive(2))
-                    }
-                )
-            )
+        val result = harness.callTool(
+            name = "get_usage_summary",
+            arguments = buildJsonObject {
+                put("period", JsonPrimitive("week"))
+                put("limit", JsonPrimitive(2))
+            },
+            connection = fakeConnection
         )
 
         assertFalse(result.isError == true)
@@ -199,17 +163,12 @@ class UsageMcpProviderTest {
 
     @Test
     fun `get_usage_summary rejects invalid period`() = runBlocking {
-        val handler = toolHandlers["get_usage_summary"]!!
-        val result = handler.invoke(
-            fakeConnection,
-            CallToolRequest(
-                params = CallToolRequestParams(
-                    name = "get_usage_summary",
-                    arguments = buildJsonObject {
-                        put("period", JsonPrimitive("invalid"))
-                    }
-                )
-            )
+        val result = harness.callTool(
+            name = "get_usage_summary",
+            arguments = buildJsonObject {
+                put("period", JsonPrimitive("invalid"))
+            },
+            connection = fakeConnection
         )
 
         assertTrue(result.isError == true)
@@ -226,18 +185,13 @@ class UsageMcpProviderTest {
 
         setupAppLabel("com.example.target", "Target App")
 
-        val handler = toolHandlers["get_app_usage"]!!
-        val result = handler.invoke(
-            fakeConnection,
-            CallToolRequest(
-                params = CallToolRequestParams(
-                    name = "get_app_usage",
-                    arguments = buildJsonObject {
-                        put("package_name", JsonPrimitive("com.example.target"))
-                        put("period", JsonPrimitive("week"))
-                    }
-                )
-            )
+        val result = harness.callTool(
+            name = "get_app_usage",
+            arguments = buildJsonObject {
+                put("package_name", JsonPrimitive("com.example.target"))
+                put("period", JsonPrimitive("week"))
+            },
+            connection = fakeConnection
         )
 
         assertFalse(result.isError == true)
@@ -248,17 +202,17 @@ class UsageMcpProviderTest {
 
     @Test
     fun `get_app_usage returns error for missing package_name`() = runBlocking {
-        val handler = toolHandlers["get_app_usage"]!!
-        val result = handler.invoke(
-            fakeConnection,
-            CallToolRequest(
-                params = CallToolRequestParams(
-                    name = "get_app_usage",
-                    arguments = buildJsonObject {
-                        put("period", JsonPrimitive("today"))
-                    }
-                )
-            )
+        // expectJsonBody = false: the framework-level "Missing required parameter"
+        // path emits plain text, not JSON. Tracked separately in #427 (the
+        // harness in #426 surfaced this gap). Once #427 lands and ToolResult.Error
+        // wraps in a JSON envelope, this opt-out can be removed.
+        val result = harness.callTool(
+            name = "get_app_usage",
+            arguments = buildJsonObject {
+                put("period", JsonPrimitive("today"))
+            },
+            connection = fakeConnection,
+            expectJsonBody = false
         )
 
         assertTrue(result.isError == true)
@@ -273,18 +227,13 @@ class UsageMcpProviderTest {
             usageStatsManager.queryEvents(any(), any())
         } returns events
 
-        val handler = toolHandlers["get_usage_events"]!!
-        val result = handler.invoke(
-            fakeConnection,
-            CallToolRequest(
-                params = CallToolRequestParams(
-                    name = "get_usage_events",
-                    arguments = buildJsonObject {
-                        put("since", JsonPrimitive("today"))
-                        put("until", JsonPrimitive("today"))
-                    }
-                )
-            )
+        val result = harness.callTool(
+            name = "get_usage_events",
+            arguments = buildJsonObject {
+                put("since", JsonPrimitive("today"))
+                put("until", JsonPrimitive("today"))
+            },
+            connection = fakeConnection
         )
 
         assertFalse(result.isError == true)
@@ -294,18 +243,13 @@ class UsageMcpProviderTest {
 
     @Test
     fun `get_usage_events rejects invalid since period`() = runBlocking {
-        val handler = toolHandlers["get_usage_events"]!!
-        val result = handler.invoke(
-            fakeConnection,
-            CallToolRequest(
-                params = CallToolRequestParams(
-                    name = "get_usage_events",
-                    arguments = buildJsonObject {
-                        put("since", JsonPrimitive("bad"))
-                        put("until", JsonPrimitive("today"))
-                    }
-                )
-            )
+        val result = harness.callTool(
+            name = "get_usage_events",
+            arguments = buildJsonObject {
+                put("since", JsonPrimitive("bad"))
+                put("until", JsonPrimitive("today"))
+            },
+            connection = fakeConnection
         )
 
         assertTrue(result.isError == true)
@@ -329,18 +273,13 @@ class UsageMcpProviderTest {
 
         setupAppLabel("com.example.app1", "App One")
 
-        val handler = toolHandlers["compare_usage"]!!
-        val result = handler.invoke(
-            fakeConnection,
-            CallToolRequest(
-                params = CallToolRequestParams(
-                    name = "compare_usage",
-                    arguments = buildJsonObject {
-                        put("period1", JsonPrimitive("yesterday"))
-                        put("period2", JsonPrimitive("today"))
-                    }
-                )
-            )
+        val result = harness.callTool(
+            name = "compare_usage",
+            arguments = buildJsonObject {
+                put("period1", JsonPrimitive("yesterday"))
+                put("period2", JsonPrimitive("today"))
+            },
+            connection = fakeConnection
         )
 
         assertFalse(result.isError == true)
@@ -350,18 +289,13 @@ class UsageMcpProviderTest {
 
     @Test
     fun `compare_usage rejects invalid period1`() = runBlocking {
-        val handler = toolHandlers["compare_usage"]!!
-        val result = handler.invoke(
-            fakeConnection,
-            CallToolRequest(
-                params = CallToolRequestParams(
-                    name = "compare_usage",
-                    arguments = buildJsonObject {
-                        put("period1", JsonPrimitive("bad"))
-                        put("period2", JsonPrimitive("today"))
-                    }
-                )
-            )
+        val result = harness.callTool(
+            name = "compare_usage",
+            arguments = buildJsonObject {
+                put("period1", JsonPrimitive("bad"))
+                put("period2", JsonPrimitive("today"))
+            },
+            connection = fakeConnection
         )
 
         assertTrue(result.isError == true)

--- a/scripts/check-no-manual-json.sh
+++ b/scripts/check-no-manual-json.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reject manual-template JSON construction in production Kotlin code.
+#
+# Per #417: """{...}""" with field-interpolation produces malformed JSON when
+# values contain quotes, backslashes, or control chars. Use @Serializable
+# data classes + Json.encodeToString instead. The harness assertion in #426
+# catches runtime cases at test time; this static check prevents reintroduction
+# at review time.
+#
+# Allowlist:
+#   - app/src/main/.../AuditDetailScreen.kt — @Preview Compose fixtures only.
+#   - Lines containing the marker `// allow-manual-json: <reason>`.
+#
+# Usage: bash scripts/check-no-manual-json.sh
+
+hits=$(git grep -nE '"""\{' -- '*/src/main/*.kt' \
+    | grep -v -E '//\s*allow-manual-json' \
+    | grep -v 'AuditDetailScreen.kt' \
+    || true)
+
+if [ -n "$hits" ]; then
+    cat <<EOF >&2
+Manual-template JSON construction found in production code.
+Per #417, this risks producing malformed JSON when interpolated values contain
+quotes, backslashes, or control characters. Use @Serializable + Json.encodeToString.
+
+If you have a legitimate non-runtime use (e.g. a UI preview fixture), add
+"// allow-manual-json: <reason>" on the line.
+
+$hits
+EOF
+    exit 1
+fi
+echo "No manual-template JSON in production code."


### PR DESCRIPTION
## Summary

Closes #426. Two gates to prevent reintroduction of the #417 malformed-JSON bug class:

- **(A) Test harness:** new `McpToolTestHarness` consolidates the duplicated `mockk<Server>(...)` + `addTool` capture pattern across `OutreachMcpProviderTest`, `UsageMcpProviderTest`, `NotificationMcpToolExecutionTest`, and `NotificationMcpProviderToolsTest`. Every result body returned through `harness.callTool(...)` is run through `Json.parseToJsonElement`; parse failures throw with the offending tool name + body. Per-call `expectJsonBody = false` opt-out exists for plain-text contracts.
- **(B) CI grep check:** new `scripts/check-no-manual-json.sh` greps `*/src/main/*.kt` for `"""{` and fails on unmarked hits. Wired into `.github/workflows/android-ci.yml` next to `check-zombie-screens.sh`. Allowlist: existing `AuditDetailScreen.kt` (Compose preview fixtures) and inline `// allow-manual-json: <reason>` markers.

Documented the convention in new `docs/agent-quickstart.md`.

## Files touched

- `integrations/src/test/kotlin/com/rousecontext/integrations/testing/McpToolTestHarness.kt` (new)
- `integrations/src/test/kotlin/com/rousecontext/integrations/testing/McpToolTestHarnessTest.kt` (new — regression test)
- `integrations/src/test/kotlin/com/rousecontext/integrations/outreach/OutreachMcpProviderTest.kt`
- `integrations/src/test/kotlin/com/rousecontext/integrations/usage/UsageMcpProviderTest.kt`
- `integrations/src/test/java/com/rousecontext/integrations/notifications/NotificationMcpToolExecutionTest.kt`
- `integrations/src/test/java/com/rousecontext/integrations/notifications/NotificationMcpProviderToolsTest.kt`
- `scripts/check-no-manual-json.sh` (new)
- `.github/workflows/android-ci.yml`
- `docs/agent-quickstart.md` (new)

## Notable finding (filed as #427)

The harness immediately caught a real malformed-JSON path on first run: `UsageMcpProviderTest > get_app_usage returns error for missing package_name` failed because the core MCP DSL's framework-level `ToolResult.Error("Missing required parameter '...'")` produces plain text, not JSON — the same bug class as #417, just hiding behind the param-extract path. To stay scoped to test/infra here, that one test now uses `expectJsonBody = false` with a comment referencing #427, which tracks the core fix.

## Test plan

- [x] `./gradlew :integrations:testDebugUnitTest :app:testDebugUnitTest` — all green
- [x] `./gradlew ktlintCheck detekt` — clean
- [x] `bash scripts/check-no-manual-json.sh` — passes on current main (no production manual-template JSON)
- [x] Synthetic violation check: temporarily injected `val foo = """{"x":"$bar"}"""` into `api/src/main/...`, confirmed script exits 1 with the file:line in the report. Adding `// allow-manual-json: <reason>` to the same line clears the check.
- [ ] CI run on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)