### PR TITLE
Fix #429: Suppress security-check re-notifications for ongoing warning streak

### DIFF
--- a/work/src/main/kotlin/com/rousecontext/work/SecurityCheckPreferences.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/SecurityCheckPreferences.kt
@@ -3,6 +3,7 @@ package com.rousecontext.work
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
@@ -82,6 +83,23 @@ class SecurityCheckPreferences(private val context: Context) {
     suspend fun resetWarningStreak(sourceName: String) {
         dataStore.edit { prefs ->
             prefs[warningStreakKey(sourceName)] = 0
+            prefs[notifiedForStreakKey(sourceName)] = false
+        }
+    }
+
+    /**
+     * Issue #429: per-source flag indicating that we already notified the user
+     * for the current Warning streak. Once set, subsequent Warning runs in the
+     * same streak log silently rather than re-firing the notification every
+     * scheduled interval. Cleared by [resetWarningStreak] when the streak ends
+     * via a Verified or Skipped result.
+     */
+    suspend fun hasNotifiedForStreak(sourceName: String): Boolean =
+        dataStore.data.first()[notifiedForStreakKey(sourceName)] ?: false
+
+    suspend fun markNotifiedForStreak(sourceName: String) {
+        dataStore.edit { prefs ->
+            prefs[notifiedForStreakKey(sourceName)] = true
         }
     }
 
@@ -93,6 +111,8 @@ class SecurityCheckPreferences(private val context: Context) {
             prefs[KEY_LAST_CHECK_TIME] = 0L
             prefs[warningStreakKey(SOURCE_SELF_CERT)] = 0
             prefs[warningStreakKey(SOURCE_CT_LOG)] = 0
+            prefs[notifiedForStreakKey(SOURCE_SELF_CERT)] = false
+            prefs[notifiedForStreakKey(SOURCE_CT_LOG)] = false
         }
     }
 
@@ -111,5 +131,8 @@ class SecurityCheckPreferences(private val context: Context) {
 
         private fun warningStreakKey(sourceName: String) =
             intPreferencesKey("warning_streak_$sourceName")
+
+        private fun notifiedForStreakKey(sourceName: String) =
+            booleanPreferencesKey("notified_for_streak_$sourceName")
     }
 }

--- a/work/src/main/kotlin/com/rousecontext/work/SecurityCheckWorker.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/SecurityCheckWorker.kt
@@ -109,9 +109,20 @@ class SecurityCheckWorker(context: Context, params: WorkerParameters) :
 
             is SecurityCheckResult.Warning -> {
                 val streak = prefs.incrementWarningStreak(sourceName)
-                if (streak >= WARNING_NOTIFICATION_THRESHOLD) {
+                val alreadyNotified = prefs.hasNotifiedForStreak(sourceName)
+                if (streak >= WARNING_NOTIFICATION_THRESHOLD && !alreadyNotified) {
                     Log.w(TAG, "$checkName: warning (streak=$streak) - ${result.reason}")
                     notifier.postInfo(check, result.reason)
+                    prefs.markNotifiedForStreak(sourceName)
+                } else if (streak >= WARNING_NOTIFICATION_THRESHOLD) {
+                    // Issue #429: streak still above threshold but we already
+                    // notified. Don't re-fire every interval — log silently
+                    // until the streak breaks (Verified / Skipped) and resets.
+                    Log.d(
+                        TAG,
+                        "$checkName: warning (streak=$streak, already notified) - " +
+                            result.reason
+                    )
                 } else {
                     // Below threshold -- single/transient flaps are absorbed
                     // silently. Issue #256: crt.sh 5xx hiccups should not

--- a/work/src/test/kotlin/com/rousecontext/work/SecurityCheckWorkerTest.kt
+++ b/work/src/test/kotlin/com/rousecontext/work/SecurityCheckWorkerTest.kt
@@ -162,6 +162,77 @@ class SecurityCheckWorkerTest {
         }
 
     @Test
+    fun `continued warning past threshold does not re-notify until streak breaks`() = runBlocking {
+        // Issue #429: streak >= threshold fires once; subsequent runs while
+        // the streak is unbroken must stay silent (logged only). User was
+        // getting a CT-log Warning notification every interval while crt.sh
+        // was flaking — the threshold reaches 3 once, then every later run
+        // re-fired because nothing reset the "already notified" state.
+        repeat(5) {
+            val worker = buildWorker(
+                selfCertResult = SecurityCheckResult.Verified,
+                ctResult = SecurityCheckResult.Warning("could not reach CT log")
+            )
+            worker.doWork()
+        }
+
+        assertEquals(
+            "Streak crossing threshold must fire exactly once, not on every subsequent run",
+            listOf(
+                FakeSecurityCheckNotifier.Call.Info(
+                    SecurityCheck.CT_LOG,
+                    "could not reach CT log"
+                )
+            ),
+            fakeNotifier.calls
+        )
+    }
+
+    @Test
+    fun `verified after notified streak resets state and next streak fires again`() = runBlocking {
+        // Issue #429: once the streak breaks via Verified, the notified
+        // flag must clear so the NEXT streak crossing threshold can fire
+        // a fresh notification. Otherwise the user would never hear about
+        // a recurring upstream outage.
+        repeat(3) {
+            val worker = buildWorker(
+                selfCertResult = SecurityCheckResult.Verified,
+                ctResult = SecurityCheckResult.Warning("first outage")
+            )
+            worker.doWork()
+        }
+
+        val verifiedWorker = buildWorker(
+            selfCertResult = SecurityCheckResult.Verified,
+            ctResult = SecurityCheckResult.Verified
+        )
+        verifiedWorker.doWork()
+
+        repeat(3) {
+            val worker = buildWorker(
+                selfCertResult = SecurityCheckResult.Verified,
+                ctResult = SecurityCheckResult.Warning("second outage")
+            )
+            worker.doWork()
+        }
+
+        assertEquals(
+            "First streak fires once; Verified resets; second streak fires once",
+            listOf(
+                FakeSecurityCheckNotifier.Call.Info(
+                    SecurityCheck.CT_LOG,
+                    "first outage"
+                ),
+                FakeSecurityCheckNotifier.Call.Info(
+                    SecurityCheck.CT_LOG,
+                    "second outage"
+                )
+            ),
+            fakeNotifier.calls
+        )
+    }
+
+    @Test
     fun `warning counter resets on verified result`() = runBlocking {
         // Two warning runs, then a verified run -- counter MUST reset so the
         // NEXT two warnings do not cross the threshold.


### PR DESCRIPTION
## Summary

Closes #429. Once a Warning streak crossed the 3-run notification threshold (#256), every subsequent scheduled run re-fired the same notification because nothing tracked \"we already told the user\". User reports: crt.sh flake → 502 notifications every interval for hours.

Add a per-source \`notifiedForStreak\` flag set on first notification past threshold; clear it when the streak resets (Verified / Skipped). Subsequent Warning runs in the same streak log silently.

If the streak breaks and a new 3-run streak builds, the next notification fires normally — recurring outages still surface.

## Test plan

- [x] \`./gradlew :work:testDebugUnitTest --tests '*SecurityCheckWorkerTest*'\` — all green, including two new cases:
  - \`continued warning past threshold does not re-notify until streak breaks\`
  - \`verified after notified streak resets state and next streak fires again\`
- [x] \`./gradlew :work:ktlintCheck detekt\` — clean

## Closes

Closes #429.

🤖 Generated with [Claude Code](https://claude.com/claude-code)