### PR TITLE
Fix #431: Expose actions param + add click_url to send_notification

### DIFF
--- a/integrations/src/main/kotlin/com/rousecontext/integrations/outreach/OutreachMcpProvider.kt
+++ b/integrations/src/main/kotlin/com/rousecontext/integrations/outreach/OutreachMcpProvider.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -217,6 +218,14 @@ internal class SendNotificationTool(
     val priority by stringParam("priority", "")
         .optional().choices("low", "default", "high")
     val channelId by stringParam("channel_id", "From create_notification_channel").optional()
+    val actions by stringParam(
+        "actions",
+        "JSON array of action buttons, max 3. Each element: {\"label\": \"...\", \"url\": \"https://...\"}."
+    ).optional()
+    val clickUrl by stringParam(
+        "click_url",
+        "http/https URL to open when the notification is tapped"
+    ).optional()
 
     override suspend fun execute(): ToolResult {
         if (!rateLimiter.tryAcquire("send_notification")) {
@@ -232,7 +241,9 @@ internal class SendNotificationTool(
             .setContentText(message!!)
             .setAutoCancel(true)
             .setPriority(parsePriority(priority))
-        addNotificationActions(context, builder, rawArgs, notificationId)
+        addNotificationActions(context, builder, actions, notificationId)
+        val clickError = applyClickUrl(context, builder, clickUrl, notificationId)
+        if (clickError != null) return clickError
         val nm = context.getSystemService(NotificationManager::class.java)
         nm.notify(notificationId, builder.build())
         return ToolResult.Success(
@@ -464,12 +475,18 @@ internal fun resolveChannelId(channelId: String?): String {
 internal fun addNotificationActions(
     context: Context,
     builder: NotificationCompat.Builder,
-    args: kotlinx.serialization.json.JsonObject?,
+    actionsJson: String?,
     notificationId: Int
 ) {
-    args?.get("actions")?.jsonArray
-        ?.take(OutreachMcpProvider.MAX_NOTIFICATION_ACTIONS)
-        ?.forEach { actionElement ->
+    if (actionsJson == null) return
+    val elements = try {
+        Json.parseToJsonElement(actionsJson).jsonArray
+    } catch (_: Exception) {
+        return
+    }
+    elements
+        .take(OutreachMcpProvider.MAX_NOTIFICATION_ACTIONS)
+        .forEach { actionElement ->
             val action = actionElement.jsonObject
             val label = action["label"]?.jsonPrimitive?.content ?: return@forEach
             val url = action["url"]?.jsonPrimitive?.content ?: return@forEach
@@ -486,6 +503,29 @@ internal fun addNotificationActions(
                 builder.addAction(0, label, pi)
             }
         }
+}
+
+internal fun applyClickUrl(
+    context: Context,
+    builder: NotificationCompat.Builder,
+    clickUrl: String?,
+    notificationId: Int
+): ToolResult? {
+    if (clickUrl == null) return null
+    val uri = Uri.parse(clickUrl)
+    val scheme = uri.scheme?.lowercase()
+    if (scheme != "http" && scheme != "https") {
+        return outreachError("Only http and https URLs are allowed for click_url, got: $scheme")
+    }
+    val intent = Intent(Intent.ACTION_VIEW, uri)
+    val pi = PendingIntent.getActivity(
+        context,
+        notificationId,
+        intent,
+        PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_ONE_SHOT
+    )
+    builder.setContentIntent(pi)
+    return null
 }
 
 @Suppress("MagicNumber")

--- a/integrations/src/test/kotlin/com/rousecontext/integrations/outreach/OutreachMcpProviderTest.kt
+++ b/integrations/src/test/kotlin/com/rousecontext/integrations/outreach/OutreachMcpProviderTest.kt
@@ -14,6 +14,8 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -294,6 +296,88 @@ class OutreachMcpProviderTest {
         assertTrue(result.isError == true)
         val text = (result.content.first() as TextContent).text!!
         assertTrue(text.contains("permission not granted"))
+    }
+
+    @Test
+    fun `send_notification with click_url sets contentIntent`() = runBlocking {
+        val result = harness.callTool(
+            name = "send_notification",
+            arguments = buildJsonObject {
+                put("title", JsonPrimitive("Click Test"))
+                put("message", JsonPrimitive("Tap to open"))
+                put("click_url", JsonPrimitive("https://example.com/page"))
+            },
+            connection = fakeConnection
+        )
+        assertFalse(result.isError == true)
+
+        val nm = context.getSystemService(NotificationManager::class.java)
+        val shadowNm = Shadows.shadowOf(nm)
+        val posted = shadowNm.allNotifications
+        assertTrue("Expected at least one notification", posted.isNotEmpty())
+        val notification = posted.last()
+        assertNotNull("contentIntent should be set", notification.contentIntent)
+    }
+
+    @Test
+    fun `send_notification without click_url has no contentIntent`() = runBlocking {
+        val result = harness.callTool(
+            name = "send_notification",
+            arguments = buildJsonObject {
+                put("title", JsonPrimitive("No Click"))
+                put("message", JsonPrimitive("No URL"))
+            },
+            connection = fakeConnection
+        )
+        assertFalse(result.isError == true)
+
+        val nm = context.getSystemService(NotificationManager::class.java)
+        val shadowNm = Shadows.shadowOf(nm)
+        val posted = shadowNm.allNotifications
+        assertTrue("Expected at least one notification", posted.isNotEmpty())
+        val notification = posted.last()
+        assertNull("contentIntent should not be set", notification.contentIntent)
+    }
+
+    @Test
+    fun `send_notification click_url rejects non-http scheme`() = runBlocking {
+        val result = harness.callTool(
+            name = "send_notification",
+            arguments = buildJsonObject {
+                put("title", JsonPrimitive("Bad Click"))
+                put("message", JsonPrimitive("Bad URL"))
+                put("click_url", JsonPrimitive("file:///etc/passwd"))
+            },
+            connection = fakeConnection
+        )
+        assertTrue(result.isError == true)
+        val text = (result.content.first() as TextContent).text!!
+        assertTrue(text.contains("Only http and https"))
+    }
+
+    @Test
+    fun `send_notification with actions adds action buttons`() = runBlocking {
+        val actionsJson = """[{"label":"Open","url":"https://example.com"},""" +
+            """{"label":"View","url":"https://example.org"}]"""
+        val result = harness.callTool(
+            name = "send_notification",
+            arguments = buildJsonObject {
+                put("title", JsonPrimitive("Actions Test"))
+                put("message", JsonPrimitive("With buttons"))
+                put("actions", JsonPrimitive(actionsJson))
+            },
+            connection = fakeConnection
+        )
+        assertFalse(result.isError == true)
+
+        val nm = context.getSystemService(NotificationManager::class.java)
+        val shadowNm = Shadows.shadowOf(nm)
+        val posted = shadowNm.allNotifications
+        assertTrue("Expected at least one notification", posted.isNotEmpty())
+        val notification = posted.last()
+        assertEquals("Should have 2 action buttons", 2, notification.actions.size)
+        assertEquals("Open", notification.actions[0].title.toString())
+        assertEquals("View", notification.actions[1].title.toString())
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #431

- Declared `actions` as an optional `stringParam` in `SendNotificationTool` so it appears in the tool schema (`tools/list`). It accepts a JSON-serialized array of `{label, url}` objects. The `addNotificationActions` helper now parses this string instead of reading from `rawArgs` directly.
- Added `click_url` optional `stringParam` that sets the notification's `contentIntent` via `PendingIntent.getActivity`. Validates http/https scheme only (same as `OpenLinkTool`).

## Test plan

- [x] `send_notification with click_url sets contentIntent` -- verifies contentIntent is non-null via Robolectric shadow
- [x] `send_notification without click_url has no contentIntent` -- baseline: no contentIntent when param omitted
- [x] `send_notification click_url rejects non-http scheme` -- `file://` URL returns error
- [x] `send_notification with actions adds action buttons` -- verifies action count and labels on built notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)