### PR TITLE
Fix #427: Wrap McpTool error paths in JSON envelope

### DIFF
--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/McpTool.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/McpTool.kt
@@ -13,6 +13,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 
@@ -120,7 +121,9 @@ abstract class McpTool {
             val b = binding as ParamBinding<Any>
             when (val ex = b.param.extract(args)) {
                 is ParamExtract.Value -> b.cached = ex.value
-                is ParamExtract.Error -> return ToolResult.Error(ex.message)
+                is ParamExtract.Error -> return ToolResult.Error(
+                    ToolErrorResponse.json.encodeToString(ToolErrorResponse(error = ex.message))
+                )
             }
         }
         return try {
@@ -131,7 +134,13 @@ abstract class McpTool {
             @Suppress("TooGenericExceptionCaught")
             t: Throwable
         ) {
-            ToolResult.Error(t.message ?: t::class.qualifiedName ?: "unknown error")
+            ToolResult.Error(
+                ToolErrorResponse.json.encodeToString(
+                    ToolErrorResponse(
+                        error = t.message ?: t::class.qualifiedName ?: "unknown error"
+                    )
+                )
+            )
         }
     }
 

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/ToolErrorResponse.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/tool/ToolErrorResponse.kt
@@ -1,0 +1,20 @@
+package com.rousecontext.mcp.tool
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Standard JSON envelope for tool error results. Ensures every error path in
+ * the MCP DSL produces valid JSON that the Anthropic connector proxy can parse,
+ * matching the shape used by integration-level error helpers (e.g. `outreachError`).
+ */
+@Serializable
+data class ToolErrorResponse(val success: Boolean = false, val error: String) {
+    companion object {
+        /**
+         * Json instance that encodes defaults so the `success` field always
+         * appears in the wire output, matching the Outreach/Usage providers.
+         */
+        internal val json: Json = Json { encodeDefaults = true }
+    }
+}

--- a/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/McpToolEndToEndTest.kt
+++ b/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/McpToolEndToEndTest.kt
@@ -8,11 +8,14 @@ import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -75,7 +78,7 @@ class McpToolEndToEndTest {
     }
 
     @Test
-    fun `tools-call with missing required param returns MCP error`() = runBlocking {
+    fun `tools-call with missing required param returns JSON error`() = runBlocking {
         val server = server()
         server.registerTool { GreetTool() }
         val handler = server.tools["greet"]!!.handler
@@ -88,11 +91,16 @@ class McpToolEndToEndTest {
         val result = handler.invoke(StubClientConnection, request)
         assertTrue(result.isError == true)
         val text = (result.content.first() as TextContent).text!!
-        assertTrue(text, text.contains("Missing required parameter 'who'"))
+        val json = Json.parseToJsonElement(text).jsonObject
+        assertFalse(json["success"]!!.jsonPrimitive.boolean)
+        assertTrue(
+            text,
+            json["error"]!!.jsonPrimitive.content.contains("Missing required parameter 'who'")
+        )
     }
 
     @Test
-    fun `tools-call with wrong type returns MCP error`() = runBlocking {
+    fun `tools-call with wrong type returns JSON error`() = runBlocking {
         val server = server()
         server.registerTool { GreetTool() }
         val handler = server.tools["greet"]!!.handler
@@ -105,6 +113,8 @@ class McpToolEndToEndTest {
         val result = handler.invoke(StubClientConnection, request)
         assertTrue(result.isError == true)
         val text = (result.content.first() as TextContent).text!!
-        assertTrue(text, text.contains("must be a string"))
+        val json = Json.parseToJsonElement(text).jsonObject
+        assertFalse(json["success"]!!.jsonPrimitive.boolean)
+        assertTrue(text, json["error"]!!.jsonPrimitive.content.contains("must be a string"))
     }
 }

--- a/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/ToolErrorJsonTest.kt
+++ b/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/tool/ToolErrorJsonTest.kt
@@ -1,0 +1,126 @@
+package com.rousecontext.mcp.tool
+
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Verifies that both framework-level error paths in [McpTool] -- missing required
+ * param and unhandled exception -- produce JSON-parseable error bodies matching
+ * the `{"success":false,"error":"..."}` envelope. This is the core-framework
+ * fix for #427.
+ */
+class ToolErrorJsonTest {
+
+    /** Tool with a required param, used to trigger param-extraction errors. */
+    private class RequiredParamTool : McpTool() {
+        override val name = "required_param_tool"
+        override val description = "Tool with a required param"
+        val target by stringParam("target", "Required target")
+        override suspend fun execute(): ToolResult =
+            ToolResult.Success("""{"success":true,"value":"$target"}""")
+    }
+
+    /** Tool that always throws, used to trigger the catch-all error path. */
+    private class ThrowingTool : McpTool() {
+        override val name = "throwing_tool"
+        override val description = "Tool that always throws"
+        override suspend fun execute(): ToolResult = error("something broke badly")
+    }
+
+    /** Tool that throws with a null message. */
+    private class NullMessageThrowingTool : McpTool() {
+        override val name = "null_msg_tool"
+        override val description = "Tool that throws with null message"
+        override suspend fun execute(): ToolResult =
+            throw object : RuntimeException(null as String?) {}
+    }
+
+    @Test
+    fun `missing required param produces JSON error envelope`() = runBlocking {
+        val tool = RequiredParamTool()
+        val result = tool.invoke(buildJsonObject {})
+
+        assertTrue(result is ToolResult.Error)
+        val error = result as ToolResult.Error
+        val json = Json.parseToJsonElement(error.message).jsonObject
+        assertFalse(json["success"]!!.jsonPrimitive.boolean)
+        assertTrue(json["error"]!!.jsonPrimitive.content.contains("Missing required parameter"))
+        assertTrue(json["error"]!!.jsonPrimitive.content.contains("target"))
+    }
+
+    @Test
+    fun `unhandled exception produces JSON error envelope`() = runBlocking {
+        val tool = ThrowingTool()
+        val result = tool.invoke(buildJsonObject {})
+
+        assertTrue(result is ToolResult.Error)
+        val error = result as ToolResult.Error
+        val json = Json.parseToJsonElement(error.message).jsonObject
+        assertFalse(json["success"]!!.jsonPrimitive.boolean)
+        assertEquals("something broke badly", json["error"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `exception with null message uses class name`() = runBlocking {
+        val tool = NullMessageThrowingTool()
+        val result = tool.invoke(buildJsonObject {})
+
+        assertTrue(result is ToolResult.Error)
+        val error = result as ToolResult.Error
+        val json = Json.parseToJsonElement(error.message).jsonObject
+        assertFalse(json["success"]!!.jsonPrimitive.boolean)
+        // Falls back to qualified class name or "unknown error"
+        assertTrue(json["error"]!!.jsonPrimitive.content.isNotEmpty())
+    }
+
+    @Test
+    fun `error envelope round-trips through toCallToolResult`() = runBlocking {
+        val tool = RequiredParamTool()
+        val toolResult = tool.invoke(buildJsonObject {})
+        val callResult = toolResult.toCallToolResult()
+
+        assertTrue(callResult.isError == true)
+        val text = (callResult.content.first() as TextContent).text!!
+        val json = Json.parseToJsonElement(text).jsonObject
+        assertFalse(json["success"]!!.jsonPrimitive.boolean)
+        assertTrue(json["error"]!!.jsonPrimitive.content.contains("Missing required parameter"))
+    }
+
+    @Test
+    fun `error message with special characters produces valid JSON`() = runBlocking {
+        val tool = object : McpTool() {
+            override val name = "special_chars_tool"
+            override val description = "Tool that throws with special chars"
+            override suspend fun execute(): ToolResult =
+                error("""contains "quotes" and \backslash and	tab""")
+        }
+        val result = tool.invoke(buildJsonObject {})
+
+        assertTrue(result is ToolResult.Error)
+        val error = result as ToolResult.Error
+        // Must be valid JSON despite special characters in the message
+        val json = Json.parseToJsonElement(error.message).jsonObject
+        assertFalse(json["success"]!!.jsonPrimitive.boolean)
+        assertTrue(json["error"]!!.jsonPrimitive.content.contains("quotes"))
+    }
+
+    @Test
+    fun `valid args bypass error envelope and return tool result`() = runBlocking {
+        val tool = RequiredParamTool()
+        val result = tool.invoke(
+            buildJsonObject { put("target", JsonPrimitive("hello")) }
+        )
+
+        assertTrue(result is ToolResult.Success)
+    }
+}

--- a/integrations/src/test/kotlin/com/rousecontext/integrations/usage/UsageMcpProviderTest.kt
+++ b/integrations/src/test/kotlin/com/rousecontext/integrations/usage/UsageMcpProviderTest.kt
@@ -202,17 +202,12 @@ class UsageMcpProviderTest {
 
     @Test
     fun `get_app_usage returns error for missing package_name`() = runBlocking {
-        // expectJsonBody = false: the framework-level "Missing required parameter"
-        // path emits plain text, not JSON. Tracked separately in #427 (the
-        // harness in #426 surfaced this gap). Once #427 lands and ToolResult.Error
-        // wraps in a JSON envelope, this opt-out can be removed.
         val result = harness.callTool(
             name = "get_app_usage",
             arguments = buildJsonObject {
                 put("period", JsonPrimitive("today"))
             },
-            connection = fakeConnection,
-            expectJsonBody = false
+            connection = fakeConnection
         )
 
         assertTrue(result.isError == true)


### PR DESCRIPTION
## Summary

- Add `ToolErrorResponse` `@Serializable` data class producing `{"success":false,"error":"..."}` JSON envelope for all framework-level error paths
- Wrap both `McpTool.invoke()` error sites (param-extraction failure at line 123, catch-all exception at line 134) to use `ToolErrorResponse.json.encodeToString()`
- Remove `expectJsonBody = false` bypass in `UsageMcpProviderTest.get_app_usage returns error for missing package_name` that was pinned for #427
- Update `McpToolEndToEndTest` error assertions to verify JSON structure

Closes #427

## Test plan

- [x] `ToolErrorJsonTest` — 6 new tests covering missing-param JSON, exception JSON, null-message fallback, round-trip through `toCallToolResult()`, special-character escaping, and success-path passthrough
- [x] `McpToolEndToEndTest` — updated error tests now verify JSON parseability and `{"success":false,"error":"..."}` structure
- [x] `UsageMcpProviderTest` — `expectJsonBody = false` bypass removed; test passes with default JSON validation
- [x] `./gradlew :core:mcp:jvmTest :integrations:testDebugUnitTest ktlintCheck detekt` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)