### PR TITLE
Fix #435: Auth approval screen unreachable

### DIFF
--- a/app/src/main/java/com/rousecontext/app/MainActivity.kt
+++ b/app/src/main/java/com/rousecontext/app/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import com.rousecontext.app.ui.navigation.RouseContextApp
 import com.rousecontext.app.ui.navigation.Routes
+import com.rousecontext.notifications.AuthRequestNotifier
 import com.rousecontext.notifications.PerToolCallNotifier
 import com.rousecontext.notifications.SessionSummaryNotifier
 import com.rousecontext.tunnel.CertificateStore
@@ -27,6 +28,19 @@ import org.koin.android.ext.android.inject
 
 class MainActivity : ComponentActivity() {
     private val certStore: CertificateStore by inject()
+
+    /**
+     * Deep-link route delivered by [onNewIntent] when the activity is already
+     * running (FLAG_ACTIVITY_SINGLE_TOP). The composition observes this and
+     * navigates when it becomes non-null, then resets it to null.
+     */
+    internal var pendingNavRoute: String? by mutableStateOf(null)
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        val route = destinationForNotificationIntent(intent) ?: return
+        pendingNavRoute = route
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val splashScreen = installSplashScreen()
@@ -87,7 +101,11 @@ class MainActivity : ComponentActivity() {
             // Only compose the app once the destination is resolved — the splash screen
             // covers the window until then, so the user never sees a blank frame.
             startDestination?.let { dest ->
-                RouseContextApp(startDestination = dest)
+                RouseContextApp(
+                    startDestination = dest,
+                    pendingNavRoute = pendingNavRoute,
+                    onPendingNavConsumed = { pendingNavRoute = null }
+                )
             }
         }
     }
@@ -124,6 +142,17 @@ class MainActivity : ComponentActivity() {
          */
         internal fun destinationForNotificationIntent(intent: Intent?): String? {
             if (intent == null) return null
+
+            // Auth-request notifications use the navigate_to extra (#435)
+            // instead of a custom action, because they originate from
+            // PendingIntent.getActivity (not a broadcast).
+            val navigateTo = intent.getStringExtra(
+                AuthRequestNotifier.EXTRA_NAVIGATE_TO
+            )
+            if (navigateTo == AuthRequestNotifier.NAVIGATE_TO_AUTH_APPROVAL) {
+                return Routes.AUTH_APPROVAL
+            }
+
             return when (intent.action) {
                 PerToolCallNotifier.ACTION_OPEN_AUDIT_HISTORY,
                 SessionSummaryNotifier.ACTION_OPEN_AUDIT_HISTORY -> auditRouteFor(intent)

--- a/app/src/main/java/com/rousecontext/app/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/navigation/AppNavigation.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -105,8 +106,20 @@ private val ONBOARDING_ROUTES = setOf(
 @Composable
 fun AppNavigation(
     startDestination: String = Routes.HOME,
+    pendingNavRoute: String? = null,
+    onPendingNavConsumed: () -> Unit = {},
     navController: NavHostController = rememberNavController()
 ) {
+    // Handle deep-link navigation delivered by onNewIntent (#435).
+    // When the activity is already running and a notification tap delivers
+    // a new intent, pendingNavRoute is set and the composition navigates.
+    LaunchedEffect(pendingNavRoute) {
+        if (pendingNavRoute != null) {
+            navController.navigate(pendingNavRoute)
+            onPendingNavConsumed()
+        }
+    }
+
     val controller = remember { NavBarControllerImpl() }
     val currentEntry by navController.currentBackStackEntryAsState()
     val currentRoute = currentEntry?.destination?.route

--- a/app/src/main/java/com/rousecontext/app/ui/navigation/RouseContextApp.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/navigation/RouseContextApp.kt
@@ -22,7 +22,11 @@ import org.koin.compose.koinInject
  *   the splash screen is dismissed so there is no flash of the wrong screen.
  */
 @Composable
-fun RouseContextApp(startDestination: String = Routes.HOME) {
+fun RouseContextApp(
+    startDestination: String = Routes.HOME,
+    pendingNavRoute: String? = null,
+    onPendingNavConsumed: () -> Unit = {}
+) {
     val themePreference: ThemePreference = koinInject()
     val themeMode by themePreference.themeMode.collectAsState(initial = ThemeMode.AUTO)
     val systemDark = isSystemInDarkTheme()
@@ -48,6 +52,10 @@ fun RouseContextApp(startDestination: String = Routes.HOME) {
     }
 
     RouseContextTheme(themeMode = themeMode) {
-        AppNavigation(startDestination = startDestination)
+        AppNavigation(
+            startDestination = startDestination,
+            pendingNavRoute = pendingNavRoute,
+            onPendingNavConsumed = onPendingNavConsumed
+        )
     }
 }

--- a/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/IntegrationEnabledDestination.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/IntegrationEnabledDestination.kt
@@ -23,6 +23,8 @@ import com.rousecontext.app.ui.screens.IntegrationEnabledContent
 import com.rousecontext.app.ui.screens.IntegrationEnabledState
 import com.rousecontext.app.ui.screens.IntegrationEnabledUrlState
 import com.rousecontext.mcp.core.McpSession
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import org.koin.compose.koinInject
 
 fun NavGraphBuilder.integrationEnabledDestination(navController: NavController) {
@@ -71,13 +73,16 @@ fun NavGraphBuilder.integrationEnabledDestination(navController: NavController) 
             onBackPressed = finishToManage
         )
 
-        // Auto-navigate to approval when a client auth request arrives
+        // Auto-navigate to approval when a client auth request arrives.
+        // Uses pendingRequestsFlow (StateFlow) instead of newRequestFlow
+        // (SharedFlow with replay=0) so pre-existing requests are seen
+        // immediately when this composable enters composition (#435).
         val mcpSession: McpSession = koinInject()
         LaunchedEffect(Unit) {
-            mcpSession.authorizationCodeManager.newRequestFlow
-                .collect {
-                    navController.navigate(Routes.AUTH_APPROVAL)
-                }
+            mcpSession.authorizationCodeManager.pendingRequestsFlow
+                .filter { it.isNotEmpty() }
+                .first()
+            navController.navigate(Routes.AUTH_APPROVAL)
         }
 
         IntegrationEnabledContent(

--- a/app/src/test/java/com/rousecontext/app/MainActivityNotificationRoutingTest.kt
+++ b/app/src/test/java/com/rousecontext/app/MainActivityNotificationRoutingTest.kt
@@ -2,6 +2,7 @@ package com.rousecontext.app
 
 import android.content.Intent
 import com.rousecontext.app.ui.navigation.Routes
+import com.rousecontext.notifications.AuthRequestNotifier
 import com.rousecontext.notifications.PerToolCallNotifier
 import com.rousecontext.notifications.SessionSummaryNotifier
 import org.junit.Assert.assertEquals
@@ -120,5 +121,26 @@ class MainActivityNotificationRoutingTest {
     @Test
     fun `null intent returns null`() {
         assertNull(MainActivity.destinationForNotificationIntent(null))
+    }
+
+    @Test
+    fun `navigate_to auth_approval extra routes to AUTH_APPROVAL`() {
+        val intent = Intent().apply {
+            putExtra(
+                AuthRequestNotifier.EXTRA_NAVIGATE_TO,
+                AuthRequestNotifier.NAVIGATE_TO_AUTH_APPROVAL
+            )
+        }
+        val route = MainActivity.destinationForNotificationIntent(intent)
+        assertEquals(Routes.AUTH_APPROVAL, route)
+    }
+
+    @Test
+    fun `navigate_to with unknown value returns null`() {
+        val intent = Intent().apply {
+            putExtra(AuthRequestNotifier.EXTRA_NAVIGATE_TO, "unknown_screen")
+        }
+        val route = MainActivity.destinationForNotificationIntent(intent)
+        assertNull(route)
     }
 }

--- a/app/src/test/java/com/rousecontext/app/ui/navigation/destinations/IntegrationEnabledAutoNavTest.kt
+++ b/app/src/test/java/com/rousecontext/app/ui/navigation/destinations/IntegrationEnabledAutoNavTest.kt
@@ -1,0 +1,142 @@
+package com.rousecontext.app.ui.navigation.destinations
+
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.rousecontext.app.ui.theme.RouseContextTheme
+import com.rousecontext.mcp.core.PendingAuthRequest
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Regression tests for #435: IntegrationEnabledDestination must auto-navigate
+ * to the auth approval screen when pending auth requests exist, even if the
+ * requests arrived before the composable entered composition.
+ *
+ * The old code used `newRequestFlow` (SharedFlow with replay=0), which lost
+ * emissions that happened before the collector started. The fix switches to
+ * `pendingRequestsFlow` (StateFlow) which always replays its current value.
+ *
+ * These tests exercise the exact LaunchedEffect pattern used in production:
+ * ```
+ * pendingRequestsFlow.filter { it.isNotEmpty() }.first()
+ * ```
+ */
+@RunWith(RobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(
+    sdk = [33],
+    qualifiers = "w400dp-h800dp-xxhdpi",
+    application = com.rousecontext.app.TestApplication::class
+)
+class IntegrationEnabledAutoNavTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private fun pendingRequest(code: String = "ABC-DEF"): PendingAuthRequest = PendingAuthRequest(
+        displayCode = code,
+        integration = "test",
+        clientId = "client-1",
+        clientName = "Test Client",
+        createdAt = System.currentTimeMillis()
+    )
+
+    /**
+     * Test C (from #435): pending request exists BEFORE the composable enters
+     * composition. The StateFlow replays its current value to the new
+     * subscriber, so navigation should fire immediately.
+     */
+    @Test
+    fun `pre-existing pending request triggers navigation on composition entry`() {
+        val pendingFlow = MutableStateFlow(listOf(pendingRequest()))
+        var navigated = false
+
+        composeRule.setContent {
+            RouseContextTheme(darkTheme = true) {
+                LaunchedEffect(Unit) {
+                    pendingFlow
+                        .filter { it.isNotEmpty() }
+                        .first()
+                    navigated = true
+                }
+            }
+        }
+
+        composeRule.waitForIdle()
+        assertTrue(
+            "Navigation should fire immediately when pending requests pre-exist",
+            navigated
+        )
+    }
+
+    /**
+     * Test A (from #435): pending request arrives after the composable is
+     * already in composition. Navigation should fire when the list becomes
+     * non-empty.
+     */
+    @Test
+    fun `pending request arriving after composition triggers navigation`() {
+        val pendingFlow = MutableStateFlow<List<PendingAuthRequest>>(emptyList())
+        var navigated = false
+
+        composeRule.setContent {
+            RouseContextTheme(darkTheme = true) {
+                LaunchedEffect(Unit) {
+                    pendingFlow
+                        .filter { it.isNotEmpty() }
+                        .first()
+                    navigated = true
+                }
+            }
+        }
+
+        composeRule.waitForIdle()
+        assertFalse(
+            "Navigation must not fire while pending list is empty",
+            navigated
+        )
+
+        pendingFlow.value = listOf(pendingRequest())
+        composeRule.waitForIdle()
+
+        assertTrue(
+            "Navigation should fire once a pending request appears",
+            navigated
+        )
+    }
+
+    /**
+     * Verify that the empty-list initial state does NOT trigger navigation.
+     */
+    @Test
+    fun `empty pending list does not trigger navigation`() {
+        val pendingFlow = MutableStateFlow<List<PendingAuthRequest>>(emptyList())
+        var navigated = false
+
+        composeRule.setContent {
+            RouseContextTheme(darkTheme = true) {
+                LaunchedEffect(Unit) {
+                    pendingFlow
+                        .filter { it.isNotEmpty() }
+                        .first()
+                    navigated = true
+                }
+            }
+        }
+
+        composeRule.waitForIdle()
+        assertFalse(
+            "Empty pending list must not trigger navigation",
+            navigated
+        )
+    }
+}

--- a/notifications/src/main/java/com/rousecontext/notifications/AuthRequestNotifier.kt
+++ b/notifications/src/main/java/com/rousecontext/notifications/AuthRequestNotifier.kt
@@ -48,6 +48,7 @@ class AuthRequestNotifier(
             notificationId,
             Intent(context, activityClass).apply {
                 flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+                putExtra(EXTRA_NAVIGATE_TO, NAVIGATE_TO_AUTH_APPROVAL)
             },
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
@@ -105,5 +106,11 @@ class AuthRequestNotifier(
     companion object {
         /** Notification ID offset for auth request notifications. */
         const val BASE_ID = 5000
+
+        /** Intent extra key for deep-link navigation target. */
+        const val EXTRA_NAVIGATE_TO = "navigate_to"
+
+        /** Value for [EXTRA_NAVIGATE_TO] that routes to the auth approval screen. */
+        const val NAVIGATE_TO_AUTH_APPROVAL = "auth_approval"
     }
 }

--- a/notifications/src/test/java/com/rousecontext/notifications/AuthRequestNotifierTest.kt
+++ b/notifications/src/test/java/com/rousecontext/notifications/AuthRequestNotifierTest.kt
@@ -86,6 +86,23 @@ class AuthRequestNotifierTest {
     }
 
     @Test
+    fun `contentIntent carries navigate_to extra for auth approval`() {
+        notifier.post("NAV-TEST", "health")
+
+        val shadowManager = Shadows.shadowOf(manager)
+        val notification = shadowManager.getNotification(AuthRequestNotifier.BASE_ID)
+        assertNotNull("Notification should be posted", notification)
+
+        val shadowPendingIntent = Shadows.shadowOf(notification.contentIntent)
+        val savedIntent = shadowPendingIntent.savedIntent
+        assertEquals(
+            "contentIntent must carry navigate_to=auth_approval",
+            AuthRequestNotifier.NAVIGATE_TO_AUTH_APPROVAL,
+            savedIntent.getStringExtra(AuthRequestNotifier.EXTRA_NAVIGATE_TO)
+        )
+    }
+
+    @Test
     fun `consecutive posts use different notification IDs`() {
         notifier.post("CODE-1", "health")
         notifier.post("CODE-2", "health")


### PR DESCRIPTION
## Summary

- Replace `newRequestFlow` (SharedFlow with replay=0) with `pendingRequestsFlow` (StateFlow) in `IntegrationEnabledDestination` so pre-existing auth requests trigger auto-navigation immediately when the composable enters composition
- Add `navigate_to=auth_approval` extra to `AuthRequestNotifier`'s contentIntent so notification taps route to the approval screen
- Handle `navigate_to` extra in `MainActivity.destinationForNotificationIntent` and add `onNewIntent` override + `pendingNavRoute` compose state for warm-start deep links through `AppNavigation`

## Test plan

- [ ] `IntegrationEnabledAutoNavTest` -- 3 tests covering: pre-existing pending request triggers immediate navigation, pending request arriving after composition triggers navigation, empty list does not trigger
- [ ] `AuthRequestNotifierTest.contentIntent carries navigate_to extra` -- verifies the notification's PendingIntent contains the deep-link extra
- [ ] `MainActivityNotificationRoutingTest` -- 2 new tests: navigate_to=auth_approval routes correctly, unknown navigate_to value returns null
- [ ] Manual: on adolin, fire `/authorize` curl, verify app auto-navigates to approval; verify notification tap also navigates there

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)