### PR TITLE
Fix #437: test- prefix for debug-build subdomains

### DIFF
--- a/app/src/main/java/com/rousecontext/app/di/AppModule.kt
+++ b/app/src/main/java/com/rousecontext/app/di/AppModule.kt
@@ -232,7 +232,8 @@ val appModule = module {
         val httpClient = createMtlsRelayHttpClient(certSource)
         RelayApiClient(
             baseUrl = "$httpScheme://${BuildConfig.RELAY_HOST}",
-            httpClient = httpClient
+            httpClient = httpClient,
+            subdomainPrefix = if (BuildConfig.DEBUG) "test" else null
         )
     }
     single {

--- a/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/RelayApiClient.kt
+++ b/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/RelayApiClient.kt
@@ -19,7 +19,8 @@ import kotlinx.serialization.json.Json
  */
 class RelayApiClient(
     private val baseUrl: String,
-    private val httpClient: HttpClient = createDefaultClient()
+    private val httpClient: HttpClient = createDefaultClient(),
+    private val subdomainPrefix: String? = null
 ) {
 
     /**
@@ -38,7 +39,12 @@ class RelayApiClient(
         executeRequest {
             httpClient.post("$baseUrl/request-subdomain") {
                 contentType(ContentType.Application.Json)
-                setBody(RequestSubdomainRequest(firebaseToken = firebaseToken))
+                setBody(
+                    RequestSubdomainRequest(
+                        firebaseToken = firebaseToken,
+                        prefix = subdomainPrefix
+                    )
+                )
             }
         }
 
@@ -231,7 +237,10 @@ sealed class RelayApiResult<out T> {
 }
 
 @Serializable
-data class RequestSubdomainRequest(@SerialName("firebase_token") val firebaseToken: String)
+data class RequestSubdomainRequest(
+    @SerialName("firebase_token") val firebaseToken: String,
+    @SerialName("prefix") val prefix: String? = null
+)
 
 @Serializable
 data class RequestSubdomainResponse(

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/RelayApiClientTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/RelayApiClientTest.kt
@@ -16,6 +16,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -84,6 +85,119 @@ class RelayApiClientTest {
             "fake-firebase-token",
             parsed["firebase_token"]?.jsonPrimitive?.content,
             "request body must use snake_case firebase_token field"
+        )
+
+        httpClient.close()
+    }
+
+    @Test
+    fun `requestSubdomain includes prefix when configured`(): Unit = runBlocking {
+        var capturedBody: String? = null
+
+        val httpClient = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    capturedBody = (request.body as? TextContent)?.text
+                        ?: (request.body as? OutgoingContent.ByteArrayContent)?.bytes()?.let {
+                            String(it)
+                        } ?: ""
+                    respond(
+                        content = ByteReadChannel(
+                            """
+                            {
+                              "subdomain": "test-zephyr",
+                              "base_domain": "rousecontext.com",
+                              "fqdn": "test-zephyr.rousecontext.com",
+                              "reservation_ttl_seconds": 600
+                            }
+                            """.trimIndent()
+                        ),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+            }
+            install(ContentNegotiation) {
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                        encodeDefaults = true
+                    }
+                )
+            }
+        }
+
+        val api = RelayApiClient(
+            baseUrl = "https://relay.example",
+            httpClient = httpClient,
+            subdomainPrefix = "test"
+        )
+        val result = api.requestSubdomain(firebaseToken = "fake-firebase-token")
+
+        assertTrue(result is RelayApiResult.Success)
+        assertEquals("test-zephyr", result.data.subdomain)
+
+        val parsed = Json.parseToJsonElement(capturedBody!!) as JsonObject
+        assertEquals(
+            "test",
+            parsed["prefix"]?.jsonPrimitive?.content,
+            "request body must include prefix field when configured"
+        )
+
+        httpClient.close()
+    }
+
+    @Test
+    fun `requestSubdomain omits prefix when not configured`(): Unit = runBlocking {
+        var capturedBody: String? = null
+
+        val httpClient = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    capturedBody = (request.body as? TextContent)?.text
+                        ?: (request.body as? OutgoingContent.ByteArrayContent)?.bytes()?.let {
+                            String(it)
+                        } ?: ""
+                    respond(
+                        content = ByteReadChannel(
+                            """
+                            {
+                              "subdomain": "zephyr",
+                              "base_domain": "rousecontext.com",
+                              "fqdn": "zephyr.rousecontext.com",
+                              "reservation_ttl_seconds": 600
+                            }
+                            """.trimIndent()
+                        ),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+            }
+            install(ContentNegotiation) {
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                        encodeDefaults = true
+                    }
+                )
+            }
+        }
+
+        val api = RelayApiClient(
+            baseUrl = "https://relay.example",
+            httpClient = httpClient
+        )
+        val result = api.requestSubdomain(firebaseToken = "fake-firebase-token")
+
+        assertTrue(result is RelayApiResult.Success)
+
+        val parsed = Json.parseToJsonElement(capturedBody!!) as JsonObject
+        val prefixElement = parsed["prefix"]
+        assertTrue(
+            prefixElement == null ||
+                prefixElement is kotlinx.serialization.json.JsonNull,
+            "request body must not include a non-null prefix when not configured, got: $prefixElement"
         )
 
         httpClient.close()

--- a/relay/src/api/request_subdomain.rs
+++ b/relay/src/api/request_subdomain.rs
@@ -27,6 +27,11 @@ use crate::firestore::{FirestoreError, SubdomainReservation};
 #[derive(Debug, Deserialize)]
 pub struct RequestSubdomainRequest {
     pub firebase_token: String,
+    /// Optional prefix prepended (with a hyphen) to single-word subdomains.
+    /// Debug builds send `"test"` so testing doesn't burn the finite
+    /// single-word pool. See issue #437.
+    #[serde(default)]
+    pub prefix: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -49,6 +54,21 @@ pub async fn handle_request_subdomain(
 ) -> Response {
     if req.firebase_token.is_empty() {
         return ApiError::bad_request("Missing required field: firebase_token").into_response();
+    }
+
+    // Validate optional prefix (issue #437).
+    if let Some(ref prefix) = req.prefix {
+        if prefix.is_empty()
+            || prefix.len() > 10
+            || !prefix
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-')
+        {
+            return ApiError::bad_request(
+                "prefix must be 1-10 characters, alphanumeric or hyphen only",
+            )
+            .into_response();
+        }
     }
 
     let claims = match state
@@ -128,7 +148,7 @@ pub async fn handle_request_subdomain(
 
     // Candidate selection: two rounds in the single-word pool, then
     // fall back to adjective-noun for a bounded number of attempts.
-    let (subdomain, fqdn) = match select_free_subdomain(&state, &base_domain).await {
+    let (subdomain, fqdn) = match select_free_subdomain(&state, &base_domain, &req.prefix).await {
         Ok(pair) => pair,
         Err(e) => {
             return ApiError::internal(format!("Failed to select subdomain: {e}")).into_response();
@@ -175,13 +195,23 @@ async fn pick_base_domain(state: &Arc<AppState>) -> Result<String, FirestoreErro
 }
 
 /// Walk the tiered pool until we find an unused subdomain.
+///
+/// When `prefix` is `Some`, single-word candidates are prepended with
+/// `{prefix}-` (e.g. `"test"` + `"cliff"` → `"test-cliff"`). The raw word
+/// is NOT checked — `"test-cliff"` and `"cliff"` are independent subdomains,
+/// so prefixed picks never burn the single-word pool. See issue #437.
 async fn select_free_subdomain(
     state: &Arc<AppState>,
     base_domain: &str,
+    prefix: &Option<String>,
 ) -> Result<(String, String), FirestoreError> {
     // Tier 1: single-word pool (two attempts).
     for _ in 0..SINGLE_WORD_RETRIES {
-        let candidate = state.subdomain_generator.generate_single_word();
+        let word = state.subdomain_generator.generate_single_word();
+        let candidate = match prefix {
+            Some(p) => format!("{p}-{word}"),
+            None => word,
+        };
         if is_free(state, &candidate).await? {
             let fqdn = format!("{candidate}.{base_domain}");
             return Ok((candidate, fqdn));

--- a/relay/tests/request_subdomain_test.rs
+++ b/relay/tests/request_subdomain_test.rs
@@ -183,6 +183,92 @@ async fn request_subdomain_retry_returns_same_name_while_reservation_valid() {
 }
 
 #[tokio::test]
+async fn request_subdomain_with_prefix_prepends_to_single_word() {
+    let firestore = MockFirestore::new();
+    let auth = MockFirebaseAuth::new().with_token("valid-token", "uid-abc");
+    let app = make_app(firestore, auth);
+
+    let resp = post_request(
+        app,
+        serde_json::json!({ "firebase_token": "valid-token", "prefix": "test" }),
+    )
+    .await;
+    assert_eq!(resp.status(), 200);
+
+    let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let subdomain = json["subdomain"].as_str().unwrap();
+
+    assert!(
+        subdomain.starts_with("test-"),
+        "Expected subdomain to start with 'test-', got: {subdomain}"
+    );
+}
+
+#[tokio::test]
+async fn request_subdomain_rejects_invalid_prefix() {
+    // Too long
+    let app = make_app(
+        MockFirestore::new(),
+        MockFirebaseAuth::new().with_token("valid-token", "uid-abc"),
+    );
+    let resp = post_request(
+        app,
+        serde_json::json!({ "firebase_token": "valid-token", "prefix": "toolongprefix" }),
+    )
+    .await;
+    assert_eq!(resp.status(), 400);
+
+    // Invalid characters
+    let app = make_app(
+        MockFirestore::new(),
+        MockFirebaseAuth::new().with_token("valid-token", "uid-abc"),
+    );
+    let resp = post_request(
+        app,
+        serde_json::json!({ "firebase_token": "valid-token", "prefix": "bad!" }),
+    )
+    .await;
+    assert_eq!(resp.status(), 400);
+
+    // Empty string
+    let app = make_app(
+        MockFirestore::new(),
+        MockFirebaseAuth::new().with_token("valid-token", "uid-abc"),
+    );
+    let resp = post_request(
+        app,
+        serde_json::json!({ "firebase_token": "valid-token", "prefix": "" }),
+    )
+    .await;
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn request_subdomain_without_prefix_returns_unprefixed() {
+    // When prefix is omitted, subdomains should NOT start with "test-".
+    let firestore = MockFirestore::new();
+    let auth = MockFirebaseAuth::new().with_token("valid-token", "uid-abc");
+    let app = make_app(firestore, auth);
+
+    let resp = post_request(app, serde_json::json!({ "firebase_token": "valid-token" })).await;
+    assert_eq!(resp.status(), 200);
+
+    let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let subdomain = json["subdomain"].as_str().unwrap();
+
+    assert!(
+        !subdomain.starts_with("test-"),
+        "Without prefix, subdomain should not start with 'test-', got: {subdomain}"
+    );
+}
+
+#[tokio::test]
 async fn request_subdomain_uses_single_word_pool_when_free() {
     // With an empty pool, subdomains from /request-subdomain should not
     // contain hyphens (single-word tier).


### PR DESCRIPTION
## Summary

- **Relay**: `/request-subdomain` accepts an optional `prefix` field (alphanumeric + hyphen, max 10 chars). When present, prepends `{prefix}-` to single-word candidates. `test-cliff` and `cliff` are independent subdomains -- prefixed picks never burn the single-word pool.
- **Android**: `RelayApiClient` gains a `subdomainPrefix` constructor parameter. `AppModule` passes `"test"` for debug builds, `null` for release.
- Tests for both sides.

Closes #437

## Test plan

- [x] `cargo test` -- all 182 unit + 10 request_subdomain tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `:core:tunnel:jvmTest` -- 177 tests pass (includes 2 new prefix tests)
- [x] `:app:testDebugUnitTest` -- passes
- [x] `ktlintCheck detekt` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)