### PR TITLE
Relay cleanup: deduplicate retry logic, add router tests, fix mutex unwraps

### DIFF
--- a/relay/src/firestore_client.rs
+++ b/relay/src/firestore_client.rs
@@ -67,14 +67,22 @@ impl RealFirestoreClient {
         }
     }
 
-    /// Authenticated GET with one retry on auth errors.
-    async fn get_with_retry(&self, path: &str) -> Result<reqwest::Response, FirestoreError> {
+    /// Send an authenticated request with one retry on auth errors.
+    ///
+    /// `build_request` receives the URL and a bearer token and must return a
+    /// ready-to-send `reqwest::RequestBuilder`. The closure is called twice
+    /// when the first attempt gets a 401/403 (with a fresh token on retry).
+    async fn authenticated_request_with_retry<F>(
+        &self,
+        path: &str,
+        build_request: F,
+    ) -> Result<reqwest::Response, FirestoreError>
+    where
+        F: Fn(&str, &str) -> reqwest::RequestBuilder,
+    {
         let url = self.url(path);
         let token = self.token().await?;
-        let resp = self
-            .http
-            .get(&url)
-            .bearer_auth(&token)
+        let resp = build_request(&url, &token)
             .send()
             .await
             .map_err(|e| FirestoreError::Http(e.to_string()))?;
@@ -83,10 +91,7 @@ impl RealFirestoreClient {
             Err(PendingError::AuthRetry(status)) => {
                 warn!(status, path, "Firestore auth error, retrying");
                 let token = self.token().await?;
-                let resp = self
-                    .http
-                    .get(&url)
-                    .bearer_auth(&token)
+                let resp = build_request(&url, &token)
                     .send()
                     .await
                     .map_err(|e| FirestoreError::Http(e.to_string()))?;
@@ -94,6 +99,14 @@ impl RealFirestoreClient {
             }
             Err(PendingError::Final(e)) => Err(e),
         }
+    }
+
+    /// Authenticated GET with one retry on auth errors.
+    async fn get_with_retry(&self, path: &str) -> Result<reqwest::Response, FirestoreError> {
+        self.authenticated_request_with_retry(path, |url, token| {
+            self.http.get(url).bearer_auth(token)
+        })
+        .await
     }
 
     /// Authenticated PATCH (upsert) with one retry on auth errors.
@@ -102,62 +115,18 @@ impl RealFirestoreClient {
         path: &str,
         body: &serde_json::Value,
     ) -> Result<reqwest::Response, FirestoreError> {
-        let url = self.url(path);
-        let token = self.token().await?;
-        let resp = self
-            .http
-            .patch(&url)
-            .bearer_auth(&token)
-            .json(body)
-            .send()
-            .await
-            .map_err(|e| FirestoreError::Http(e.to_string()))?;
-        match Self::map_status(resp, path) {
-            Ok(r) => Ok(r),
-            Err(PendingError::AuthRetry(status)) => {
-                warn!(status, path, "Firestore auth error, retrying");
-                let token = self.token().await?;
-                let resp = self
-                    .http
-                    .patch(&url)
-                    .bearer_auth(&token)
-                    .json(body)
-                    .send()
-                    .await
-                    .map_err(|e| FirestoreError::Http(e.to_string()))?;
-                Self::map_status(resp, path).map_err(PendingError::into_final)
-            }
-            Err(PendingError::Final(e)) => Err(e),
-        }
+        self.authenticated_request_with_retry(path, |url, token| {
+            self.http.patch(url).bearer_auth(token).json(body)
+        })
+        .await
     }
 
     /// Authenticated DELETE with one retry on auth errors.
     async fn delete_with_retry(&self, path: &str) -> Result<reqwest::Response, FirestoreError> {
-        let url = self.url(path);
-        let token = self.token().await?;
-        let resp = self
-            .http
-            .delete(&url)
-            .bearer_auth(&token)
-            .send()
-            .await
-            .map_err(|e| FirestoreError::Http(e.to_string()))?;
-        match Self::map_status(resp, path) {
-            Ok(r) => Ok(r),
-            Err(PendingError::AuthRetry(status)) => {
-                warn!(status, path, "Firestore auth error, retrying");
-                let token = self.token().await?;
-                let resp = self
-                    .http
-                    .delete(&url)
-                    .bearer_auth(&token)
-                    .send()
-                    .await
-                    .map_err(|e| FirestoreError::Http(e.to_string()))?;
-                Self::map_status(resp, path).map_err(PendingError::into_final)
-            }
-            Err(PendingError::Final(e)) => Err(e),
-        }
+        self.authenticated_request_with_retry(path, |url, token| {
+            self.http.delete(url).bearer_auth(token)
+        })
+        .await
     }
 }
 

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -816,7 +816,7 @@ impl rouse_relay::firestore::FirestoreClient for InMemoryFirestore {
         &self,
         subdomain: &str,
     ) -> Result<rouse_relay::firestore::DeviceRecord, rouse_relay::firestore::FirestoreError> {
-        let devices = self.devices.lock().unwrap();
+        let devices = self.devices.lock().unwrap_or_else(|e| e.into_inner());
         devices
             .get(subdomain)
             .cloned()
@@ -830,7 +830,7 @@ impl rouse_relay::firestore::FirestoreClient for InMemoryFirestore {
         Option<(String, rouse_relay::firestore::DeviceRecord)>,
         rouse_relay::firestore::FirestoreError,
     > {
-        let devices = self.devices.lock().unwrap();
+        let devices = self.devices.lock().unwrap_or_else(|e| e.into_inner());
         Ok(devices
             .iter()
             .find(|(_, r)| r.firebase_uid == firebase_uid)
@@ -842,7 +842,7 @@ impl rouse_relay::firestore::FirestoreClient for InMemoryFirestore {
         subdomain: &str,
         record: &rouse_relay::firestore::DeviceRecord,
     ) -> Result<(), rouse_relay::firestore::FirestoreError> {
-        let mut devices = self.devices.lock().unwrap();
+        let mut devices = self.devices.lock().unwrap_or_else(|e| e.into_inner());
         devices.insert(subdomain.to_string(), record.clone());
         Ok(())
     }
@@ -851,7 +851,7 @@ impl rouse_relay::firestore::FirestoreClient for InMemoryFirestore {
         &self,
         subdomain: &str,
     ) -> Result<(), rouse_relay::firestore::FirestoreError> {
-        let mut devices = self.devices.lock().unwrap();
+        let mut devices = self.devices.lock().unwrap_or_else(|e| e.into_inner());
         devices.remove(subdomain);
         Ok(())
     }
@@ -861,7 +861,7 @@ impl rouse_relay::firestore::FirestoreClient for InMemoryFirestore {
         subdomain: &str,
         pending: &rouse_relay::firestore::PendingCert,
     ) -> Result<(), rouse_relay::firestore::FirestoreError> {
-        let mut certs = self.pending_certs.lock().unwrap();
+        let mut certs = self.pending_certs.lock().unwrap_or_else(|e| e.into_inner());
         certs.insert(subdomain.to_string(), pending.clone());
         Ok(())
     }
@@ -870,7 +870,7 @@ impl rouse_relay::firestore::FirestoreClient for InMemoryFirestore {
         &self,
         subdomain: &str,
     ) -> Result<rouse_relay::firestore::PendingCert, rouse_relay::firestore::FirestoreError> {
-        let certs = self.pending_certs.lock().unwrap();
+        let certs = self.pending_certs.lock().unwrap_or_else(|e| e.into_inner());
         certs
             .get(subdomain)
             .cloned()
@@ -881,7 +881,7 @@ impl rouse_relay::firestore::FirestoreClient for InMemoryFirestore {
         &self,
         subdomain: &str,
     ) -> Result<(), rouse_relay::firestore::FirestoreError> {
-        let mut certs = self.pending_certs.lock().unwrap();
+        let mut certs = self.pending_certs.lock().unwrap_or_else(|e| e.into_inner());
         certs.remove(subdomain);
         Ok(())
     }
@@ -892,7 +892,7 @@ impl rouse_relay::firestore::FirestoreClient for InMemoryFirestore {
         Vec<(String, rouse_relay::firestore::DeviceRecord)>,
         rouse_relay::firestore::FirestoreError,
     > {
-        let devices = self.devices.lock().unwrap();
+        let devices = self.devices.lock().unwrap_or_else(|e| e.into_inner());
         Ok(devices
             .iter()
             .map(|(k, v)| (k.clone(), v.clone()))
@@ -905,7 +905,7 @@ impl rouse_relay::firestore::FirestoreClient for InMemoryFirestore {
         Vec<(String, rouse_relay::firestore::PendingCert)>,
         rouse_relay::firestore::FirestoreError,
     > {
-        let certs = self.pending_certs.lock().unwrap();
+        let certs = self.pending_certs.lock().unwrap_or_else(|e| e.into_inner());
         Ok(certs.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
     }
 
@@ -914,7 +914,7 @@ impl rouse_relay::firestore::FirestoreClient for InMemoryFirestore {
         subdomain: &str,
         reservation: &rouse_relay::firestore::SubdomainReservation,
     ) -> Result<(), rouse_relay::firestore::FirestoreError> {
-        let mut map = self.reservations.lock().unwrap();
+        let mut map = self.reservations.lock().unwrap_or_else(|e| e.into_inner());
         map.insert(subdomain.to_string(), reservation.clone());
         Ok(())
     }
@@ -924,7 +924,7 @@ impl rouse_relay::firestore::FirestoreClient for InMemoryFirestore {
         subdomain: &str,
     ) -> Result<rouse_relay::firestore::SubdomainReservation, rouse_relay::firestore::FirestoreError>
     {
-        let map = self.reservations.lock().unwrap();
+        let map = self.reservations.lock().unwrap_or_else(|e| e.into_inner());
         map.get(subdomain)
             .cloned()
             .ok_or_else(|| rouse_relay::firestore::FirestoreError::NotFound(subdomain.to_string()))
@@ -937,7 +937,7 @@ impl rouse_relay::firestore::FirestoreClient for InMemoryFirestore {
         Option<(String, rouse_relay::firestore::SubdomainReservation)>,
         rouse_relay::firestore::FirestoreError,
     > {
-        let map = self.reservations.lock().unwrap();
+        let map = self.reservations.lock().unwrap_or_else(|e| e.into_inner());
         Ok(map
             .iter()
             .find(|(_, r)| r.firebase_uid == firebase_uid)
@@ -948,7 +948,7 @@ impl rouse_relay::firestore::FirestoreClient for InMemoryFirestore {
         &self,
         subdomain: &str,
     ) -> Result<(), rouse_relay::firestore::FirestoreError> {
-        let mut map = self.reservations.lock().unwrap();
+        let mut map = self.reservations.lock().unwrap_or_else(|e| e.into_inner());
         map.remove(subdomain);
         Ok(())
     }
@@ -959,7 +959,7 @@ impl rouse_relay::firestore::FirestoreClient for InMemoryFirestore {
         Vec<(String, rouse_relay::firestore::SubdomainReservation)>,
         rouse_relay::firestore::FirestoreError,
     > {
-        let map = self.reservations.lock().unwrap();
+        let map = self.reservations.lock().unwrap_or_else(|e| e.into_inner());
         Ok(map.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
     }
 }

--- a/relay/src/router.rs
+++ b/relay/src/router.rs
@@ -24,9 +24,235 @@ pub fn route_connection(initial_bytes: &[u8], relay_hostname: &str) -> RouteDeci
 mod tests {
     use super::*;
 
+    const RELAY_HOST: &str = "relay.rousecontext.com";
+
+    /// Build a minimal TLS ClientHello containing the given SNI hostname.
+    ///
+    /// This constructs just enough of a real ClientHello for `parse_sni` to
+    /// extract the hostname. It is NOT a valid TLS handshake in the broader
+    /// sense -- cipher suites and compression are stubs.
+    fn build_client_hello(sni: &str) -> Vec<u8> {
+        // SNI extension payload: type(1) + name_len(2) + name
+        let sni_bytes = sni.as_bytes();
+        let sni_entry_len = 1 + 2 + sni_bytes.len(); // name_type + name_len + name
+        let sni_list_len = sni_entry_len;
+        let sni_ext_data_len = 2 + sni_list_len; // list_len(2) + list
+
+        let mut sni_ext = Vec::new();
+        // Extension type: SNI = 0x0000
+        sni_ext.extend_from_slice(&0x0000u16.to_be_bytes());
+        // Extension data length
+        sni_ext.extend_from_slice(&(sni_ext_data_len as u16).to_be_bytes());
+        // Server name list length
+        sni_ext.extend_from_slice(&(sni_list_len as u16).to_be_bytes());
+        // Name type: host_name = 0x00
+        sni_ext.push(0x00);
+        // Name length
+        sni_ext.extend_from_slice(&(sni_bytes.len() as u16).to_be_bytes());
+        // Name
+        sni_ext.extend_from_slice(sni_bytes);
+
+        // Extensions total
+        let extensions_len = sni_ext.len();
+
+        // ClientHello body
+        let mut hello = Vec::new();
+        // Client version: TLS 1.2
+        hello.extend_from_slice(&[0x03, 0x03]);
+        // Random: 32 bytes of zeros
+        hello.extend_from_slice(&[0u8; 32]);
+        // Session ID length: 0
+        hello.push(0x00);
+        // Cipher suites: length=2, one suite (TLS_RSA_WITH_AES_128_GCM_SHA256)
+        hello.extend_from_slice(&[0x00, 0x02, 0x00, 0x9c]);
+        // Compression methods: length=1, null
+        hello.extend_from_slice(&[0x01, 0x00]);
+        // Extensions length
+        hello.extend_from_slice(&(extensions_len as u16).to_be_bytes());
+        // Extensions
+        hello.extend_from_slice(&sni_ext);
+
+        // Handshake header
+        let mut handshake = Vec::new();
+        // Handshake type: ClientHello = 0x01
+        handshake.push(0x01);
+        // Length (3 bytes)
+        let hello_len = hello.len();
+        handshake.push(((hello_len >> 16) & 0xFF) as u8);
+        handshake.push(((hello_len >> 8) & 0xFF) as u8);
+        handshake.push((hello_len & 0xFF) as u8);
+        handshake.extend_from_slice(&hello);
+
+        // TLS record header
+        let mut record = Vec::new();
+        // Content type: Handshake = 0x16
+        record.push(0x16);
+        // Version: TLS 1.0 (record layer always says 1.0)
+        record.extend_from_slice(&[0x03, 0x01]);
+        // Record length
+        let hs_len = handshake.len();
+        record.extend_from_slice(&(hs_len as u16).to_be_bytes());
+        record.extend_from_slice(&handshake);
+
+        record
+    }
+
+    /// Build a minimal ClientHello with NO extensions at all.
+    fn build_client_hello_no_extensions() -> Vec<u8> {
+        let mut hello = Vec::new();
+        hello.extend_from_slice(&[0x03, 0x03]); // version
+        hello.extend_from_slice(&[0u8; 32]); // random
+        hello.push(0x00); // session ID length
+        hello.extend_from_slice(&[0x00, 0x02, 0x00, 0x9c]); // cipher suites
+        hello.extend_from_slice(&[0x01, 0x00]); // compression
+
+        let mut handshake = Vec::new();
+        handshake.push(0x01);
+        let hello_len = hello.len();
+        handshake.push(((hello_len >> 16) & 0xFF) as u8);
+        handshake.push(((hello_len >> 8) & 0xFF) as u8);
+        handshake.push((hello_len & 0xFF) as u8);
+        handshake.extend_from_slice(&hello);
+
+        let mut record = Vec::new();
+        record.push(0x16);
+        record.extend_from_slice(&[0x03, 0x01]);
+        let hs_len = handshake.len();
+        record.extend_from_slice(&(hs_len as u16).to_be_bytes());
+        record.extend_from_slice(&handshake);
+
+        record
+    }
+
+    // ── Garbage / malformed input ──────────────────────────────────────
+
     #[test]
     fn route_rejects_garbage() {
-        let decision = route_connection(b"not a tls handshake", "relay.rousecontext.com");
+        let decision = route_connection(b"not a tls handshake", RELAY_HOST);
         assert!(matches!(decision, RouteDecision::Reject));
+    }
+
+    #[test]
+    fn route_rejects_empty_input() {
+        let decision = route_connection(b"", RELAY_HOST);
+        assert!(matches!(decision, RouteDecision::Reject));
+    }
+
+    #[test]
+    fn route_rejects_truncated_record_header() {
+        // Only 4 bytes -- TLS record header needs 5
+        let decision = route_connection(&[0x16, 0x03, 0x01, 0x00], RELAY_HOST);
+        assert!(matches!(decision, RouteDecision::Reject));
+    }
+
+    #[test]
+    fn route_rejects_non_handshake_record_type() {
+        // Content type 0x17 = Application Data, not Handshake
+        let decision = route_connection(&[0x17, 0x03, 0x01, 0x00, 0x05, 0, 0, 0, 0, 0], RELAY_HOST);
+        assert!(matches!(decision, RouteDecision::Reject));
+    }
+
+    // ── Missing SNI ────────────────────────────────────────────────────
+
+    #[test]
+    fn route_rejects_client_hello_without_sni() {
+        let hello = build_client_hello_no_extensions();
+        let decision = route_connection(&hello, RELAY_HOST);
+        assert!(matches!(decision, RouteDecision::Reject));
+    }
+
+    // ── Relay API routing ──────────────────────────────────────────────
+
+    #[test]
+    fn route_relay_hostname_to_api() {
+        let hello = build_client_hello("relay.rousecontext.com");
+        let decision = route_connection(&hello, RELAY_HOST);
+        assert_eq!(decision, RouteDecision::RelayApi);
+    }
+
+    // ── Device passthrough routing ─────────────────────────────────────
+
+    #[test]
+    fn route_known_device_pattern_to_passthrough() {
+        let hello = build_client_hello("brave-health.cool-penguin.rousecontext.com");
+        let decision = route_connection(&hello, RELAY_HOST);
+        assert_eq!(
+            decision,
+            RouteDecision::DevicePassthrough {
+                subdomain: "cool-penguin".to_string(),
+                integration_secret: "brave-health".to_string(),
+            }
+        );
+    }
+
+    // ── Unknown / bare subdomains ──────────────────────────────────────
+
+    #[test]
+    fn route_rejects_bare_subdomain_without_secret() {
+        // "cool-penguin.rousecontext.com" has no integration secret prefix
+        let hello = build_client_hello("cool-penguin.rousecontext.com");
+        let decision = route_connection(&hello, RELAY_HOST);
+        assert_eq!(decision, RouteDecision::Reject);
+    }
+
+    #[test]
+    fn route_rejects_unknown_domain() {
+        let hello = build_client_hello("something.example.com");
+        let decision = route_connection(&hello, RELAY_HOST);
+        assert_eq!(decision, RouteDecision::Reject);
+    }
+
+    #[test]
+    fn route_rejects_too_many_subdomain_levels() {
+        // Three levels of subdomain: extra.secret.device.rousecontext.com
+        let hello = build_client_hello("extra.secret.device.rousecontext.com");
+        let decision = route_connection(&hello, RELAY_HOST);
+        assert_eq!(decision, RouteDecision::Reject);
+    }
+
+    #[test]
+    fn route_rejects_bare_base_domain() {
+        let hello = build_client_hello("rousecontext.com");
+        let decision = route_connection(&hello, RELAY_HOST);
+        assert_eq!(decision, RouteDecision::Reject);
+    }
+
+    #[test]
+    fn route_rejects_relay_as_subdomain() {
+        // "relay.rousecontext.com" is the relay itself, but if someone
+        // somehow sends "relay" as a bare subdomain it should still route
+        // to RelayApi (handled by exact match), not passthrough.
+        let hello = build_client_hello("relay.rousecontext.com");
+        let decision = route_connection(&hello, RELAY_HOST);
+        assert_eq!(decision, RouteDecision::RelayApi);
+    }
+
+    // ── Edge cases ─────────────────────────────────────────────────────
+
+    #[test]
+    fn route_handles_hyphenated_names() {
+        let hello = build_client_hello("swift-outreach.bright-owl.rousecontext.com");
+        let decision = route_connection(&hello, RELAY_HOST);
+        assert_eq!(
+            decision,
+            RouteDecision::DevicePassthrough {
+                subdomain: "bright-owl".to_string(),
+                integration_secret: "swift-outreach".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn route_handles_test_prefixed_subdomains() {
+        // Debug builds use test- prefix (#438)
+        let hello = build_client_hello("brave-health.test-cool-penguin.rousecontext.com");
+        let decision = route_connection(&hello, RELAY_HOST);
+        assert_eq!(
+            decision,
+            RouteDecision::DevicePassthrough {
+                subdomain: "test-cool-penguin".to_string(),
+                integration_secret: "brave-health".to_string(),
+            }
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Deduplicate HTTP retry logic** in `firestore_client.rs`: extracted `authenticated_request_with_retry` generic helper that takes a request-builder closure. `get_with_retry`, `patch_with_retry`, and `delete_with_retry` now delegate to it (~60 lines removed).
- **Add 13 unit tests for `router.rs`** covering SNI routing edge cases: garbage input, empty input, truncated headers, non-handshake record types, missing SNI extension, relay hostname routing, device passthrough with integration secrets, bare subdomains (rejected), unknown domains, too-many-subdomain-levels, bare base domain, hyphenated names, and test-prefixed subdomains (#438).
- **Replace `.lock().unwrap()` with `.lock().unwrap_or_else(|e| e.into_inner())`** across 14 sites in `InMemoryFirestore` (main.rs) so mutex poisoning degrades gracefully instead of panicking.

Closes #443

## Test plan

- [x] `cargo test` -- all tests pass (including 13 new router tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo fmt` -- no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)