### PR TITLE
Deduplicate 39 copy-paste health query methods via shared helper

### DIFF
--- a/integrations/src/main/java/com/rousecontext/integrations/health/query/ActivityQueries.kt
+++ b/integrations/src/main/java/com/rousecontext/integrations/health/query/ActivityQueries.kt
@@ -43,7 +43,7 @@ class ActivityQueries(private val reader: RecordReader) : CategoryQueries {
         "WheelchairPushes"
     )
 
-    @Suppress("CyclomaticComplexMethod")
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     override suspend fun query(
         recordType: String,
         from: Instant,
@@ -51,18 +51,176 @@ class ActivityQueries(private val reader: RecordReader) : CategoryQueries {
         limit: Int?
     ): List<JsonObject> = when (recordType) {
         "Steps" -> querySteps(from, to, limit)
-        "ActiveCaloriesBurned" -> queryActiveCalories(from, to, limit)
-        "TotalCaloriesBurned" -> queryTotalCalories(from, to, limit)
-        "BasalMetabolicRate" -> queryBasalMetabolicRate(from, to, limit)
-        "Distance" -> queryDistance(from, to, limit)
-        "ElevationGained" -> queryElevationGained(from, to, limit)
-        "FloorsClimbed" -> queryFloorsClimbed(from, to, limit)
-        "ExerciseSession" -> queryExercise(from, to, limit)
-        "Speed" -> querySpeed(from, to, limit)
-        "Power" -> queryPower(from, to, limit)
-        "CyclingPedalingCadence" -> queryCyclingPedalingCadence(from, to, limit)
-        "StepsCadence" -> queryStepsCadence(from, to, limit)
-        "WheelchairPushes" -> queryWheelchairPushes(from, to, limit)
+        "ActiveCaloriesBurned" -> reader.queryRecords(
+            ActiveCaloriesBurnedRecord::class,
+            from,
+            to,
+            limit
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("start_time", record.startTime.toString())
+                    put("end_time", record.endTime.toString())
+                    put("kcal", record.energy.inKilocalories)
+                }
+            )
+        }
+        "TotalCaloriesBurned" -> reader.queryRecords(
+            TotalCaloriesBurnedRecord::class,
+            from,
+            to,
+            limit
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("start_time", record.startTime.toString())
+                    put("end_time", record.endTime.toString())
+                    put("kcal", record.energy.inKilocalories)
+                }
+            )
+        }
+        "BasalMetabolicRate" -> reader.queryRecords(
+            BasalMetabolicRateRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("time", record.time.toString())
+                    put("watts", record.basalMetabolicRate.inWatts)
+                    put("kcal_per_day", record.basalMetabolicRate.inKilocaloriesPerDay)
+                }
+            )
+        }
+        "Distance" -> reader.queryRecords(
+            DistanceRecord::class,
+            from,
+            to,
+            limit
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("start_time", record.startTime.toString())
+                    put("end_time", record.endTime.toString())
+                    put("meters", record.distance.inMeters)
+                }
+            )
+        }
+        "ElevationGained" -> reader.queryRecords(
+            ElevationGainedRecord::class,
+            from,
+            to,
+            limit
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("start_time", record.startTime.toString())
+                    put("end_time", record.endTime.toString())
+                    put("meters", record.elevation.inMeters)
+                }
+            )
+        }
+        "FloorsClimbed" -> reader.queryRecords(
+            FloorsClimbedRecord::class,
+            from,
+            to,
+            limit
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("start_time", record.startTime.toString())
+                    put("end_time", record.endTime.toString())
+                    put("floors", record.floors)
+                }
+            )
+        }
+        "ExerciseSession" -> reader.queryRecords(
+            ExerciseSessionRecord::class,
+            from,
+            to,
+            limit
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("start_time", record.startTime.toString())
+                    put("end_time", record.endTime.toString())
+                    put("exercise_type", record.exerciseType)
+                    record.title?.let { put("title", it) }
+                }
+            )
+        }
+        "Speed" -> reader.queryRecords(
+            SpeedRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            record.samples.map { sample ->
+                buildJsonObject {
+                    put("time", sample.time.toString())
+                    put("meters_per_second", sample.speed.inMetersPerSecond)
+                }
+            }
+        }
+        "Power" -> reader.queryRecords(
+            PowerRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            record.samples.map { sample ->
+                buildJsonObject {
+                    put("time", sample.time.toString())
+                    put("watts", sample.power.inWatts)
+                }
+            }
+        }
+        "CyclingPedalingCadence" -> reader.queryRecords(
+            CyclingPedalingCadenceRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            record.samples.map { sample ->
+                buildJsonObject {
+                    put("time", sample.time.toString())
+                    put("rpm", sample.revolutionsPerMinute)
+                }
+            }
+        }
+        "StepsCadence" -> reader.queryRecords(
+            StepsCadenceRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            record.samples.map { sample ->
+                buildJsonObject {
+                    put("time", sample.time.toString())
+                    put("steps_per_minute", sample.rate)
+                }
+            }
+        }
+        "WheelchairPushes" -> reader.queryRecords(
+            WheelchairPushesRecord::class,
+            from,
+            to,
+            limit
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("start_time", record.startTime.toString())
+                    put("end_time", record.endTime.toString())
+                    put("count", record.count)
+                }
+            )
+        }
         else -> throw IllegalArgumentException("Unsupported record type: $recordType")
     }
 
@@ -88,204 +246,6 @@ class ActivityQueries(private val reader: RecordReader) : CategoryQueries {
                 }
             }
             .sortedBy { it["date"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryActiveCalories(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(ActiveCaloriesBurnedRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("start_time", record.startTime.toString())
-                    put("end_time", record.endTime.toString())
-                    put("kcal", record.energy.inKilocalories)
-                }
-            }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryTotalCalories(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(TotalCaloriesBurnedRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("start_time", record.startTime.toString())
-                    put("end_time", record.endTime.toString())
-                    put("kcal", record.energy.inKilocalories)
-                }
-            }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryBasalMetabolicRate(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(BasalMetabolicRateRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("time", record.time.toString())
-                    put("watts", record.basalMetabolicRate.inWatts)
-                    put("kcal_per_day", record.basalMetabolicRate.inKilocaloriesPerDay)
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryDistance(from: Instant, to: Instant, limit: Int?): List<JsonObject> {
-        val records = reader.read(DistanceRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("start_time", record.startTime.toString())
-                    put("end_time", record.endTime.toString())
-                    put("meters", record.distance.inMeters)
-                }
-            }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryElevationGained(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(ElevationGainedRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("start_time", record.startTime.toString())
-                    put("end_time", record.endTime.toString())
-                    put("meters", record.elevation.inMeters)
-                }
-            }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryFloorsClimbed(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(FloorsClimbedRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("start_time", record.startTime.toString())
-                    put("end_time", record.endTime.toString())
-                    put("floors", record.floors)
-                }
-            }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryExercise(from: Instant, to: Instant, limit: Int?): List<JsonObject> {
-        val records = reader.read(ExerciseSessionRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("start_time", record.startTime.toString())
-                    put("end_time", record.endTime.toString())
-                    put("exercise_type", record.exerciseType)
-                    record.title?.let { put("title", it) }
-                }
-            }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun querySpeed(from: Instant, to: Instant, limit: Int?): List<JsonObject> {
-        val records = reader.read(SpeedRecord::class, from, to)
-        return records
-            .flatMap { record ->
-                record.samples.map { sample ->
-                    buildJsonObject {
-                        put("time", sample.time.toString())
-                        put("meters_per_second", sample.speed.inMetersPerSecond)
-                    }
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryPower(from: Instant, to: Instant, limit: Int?): List<JsonObject> {
-        val records = reader.read(PowerRecord::class, from, to)
-        return records
-            .flatMap { record ->
-                record.samples.map { sample ->
-                    buildJsonObject {
-                        put("time", sample.time.toString())
-                        put("watts", sample.power.inWatts)
-                    }
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryCyclingPedalingCadence(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(CyclingPedalingCadenceRecord::class, from, to)
-        return records
-            .flatMap { record ->
-                record.samples.map { sample ->
-                    buildJsonObject {
-                        put("time", sample.time.toString())
-                        put("rpm", sample.revolutionsPerMinute)
-                    }
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryStepsCadence(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(StepsCadenceRecord::class, from, to)
-        return records
-            .flatMap { record ->
-                record.samples.map { sample ->
-                    buildJsonObject {
-                        put("time", sample.time.toString())
-                        put("steps_per_minute", sample.rate)
-                    }
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryWheelchairPushes(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(WheelchairPushesRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("start_time", record.startTime.toString())
-                    put("end_time", record.endTime.toString())
-                    put("count", record.count)
-                }
-            }
             .let { if (limit != null) it.take(limit) else it }
     }
 }

--- a/integrations/src/main/java/com/rousecontext/integrations/health/query/BodyQueries.kt
+++ b/integrations/src/main/java/com/rousecontext/integrations/health/query/BodyQueries.kt
@@ -25,25 +25,105 @@ class BodyQueries(private val reader: RecordReader) : CategoryQueries {
         "Vo2Max"
     )
 
+    @Suppress("LongMethod")
     override suspend fun query(
         recordType: String,
         from: Instant,
         to: Instant,
         limit: Int?
     ): List<JsonObject> = when (recordType) {
-        "Weight" -> queryWeight(from, to, limit)
-        "Height" -> queryHeight(from, to, limit)
-        "BodyFat" -> queryBodyFat(from, to, limit)
-        "BoneMass" -> queryBoneMass(from, to, limit)
-        "LeanBodyMass" -> queryLeanBodyMass(from, to, limit)
-        "Vo2Max" -> queryVo2Max(from, to, limit)
+        "Weight" -> reader.queryRecords(
+            WeightRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("time", record.time.toString())
+                    put("kg", record.weight.inKilograms)
+                }
+            )
+        }
+        "Height" -> reader.queryRecords(
+            HeightRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("time", record.time.toString())
+                    put("meters", record.height.inMeters)
+                }
+            )
+        }
+        "BodyFat" -> reader.queryRecords(
+            BodyFatRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("time", record.time.toString())
+                    put("percentage", record.percentage.value)
+                }
+            )
+        }
+        "BoneMass" -> reader.queryRecords(
+            BoneMassRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("time", record.time.toString())
+                    put("kg", record.mass.inKilograms)
+                }
+            )
+        }
+        "LeanBodyMass" -> reader.queryRecords(
+            LeanBodyMassRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("time", record.time.toString())
+                    put("kg", record.mass.inKilograms)
+                }
+            )
+        }
+        "Vo2Max" -> reader.queryRecords(
+            Vo2MaxRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("time", record.time.toString())
+                    put("ml_per_min_per_kg", record.vo2MillilitersPerMinuteKilogram)
+                    put("measurement_method", record.measurementMethod)
+                }
+            )
+        }
         else -> throw IllegalArgumentException("Unsupported record type: $recordType")
     }
 
     override suspend fun summary(from: Instant, to: Instant, granted: Set<String>): JsonObject =
         buildJsonObject {
             if ("Weight" in granted) {
-                val weights = queryWeight(from, to, null)
+                val weights = query("Weight", from, to, null)
                 val latest = weights.lastOrNull()
                 if (latest != null) {
                     val kg = latest["kg"]?.toString()?.toDoubleOrNull()
@@ -51,87 +131,4 @@ class BodyQueries(private val reader: RecordReader) : CategoryQueries {
                 }
             }
         }
-
-    private suspend fun queryWeight(from: Instant, to: Instant, limit: Int?): List<JsonObject> {
-        val records = reader.read(WeightRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("time", record.time.toString())
-                    put("kg", record.weight.inKilograms)
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryHeight(from: Instant, to: Instant, limit: Int?): List<JsonObject> {
-        val records = reader.read(HeightRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("time", record.time.toString())
-                    put("meters", record.height.inMeters)
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryBodyFat(from: Instant, to: Instant, limit: Int?): List<JsonObject> {
-        val records = reader.read(BodyFatRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("time", record.time.toString())
-                    put("percentage", record.percentage.value)
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryBoneMass(from: Instant, to: Instant, limit: Int?): List<JsonObject> {
-        val records = reader.read(BoneMassRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("time", record.time.toString())
-                    put("kg", record.mass.inKilograms)
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryLeanBodyMass(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(LeanBodyMassRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("time", record.time.toString())
-                    put("kg", record.mass.inKilograms)
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryVo2Max(from: Instant, to: Instant, limit: Int?): List<JsonObject> {
-        val records = reader.read(Vo2MaxRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("time", record.time.toString())
-                    put("ml_per_min_per_kg", record.vo2MillilitersPerMinuteKilogram)
-                    put("measurement_method", record.measurementMethod)
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
 }

--- a/integrations/src/main/java/com/rousecontext/integrations/health/query/MindfulnessQueries.kt
+++ b/integrations/src/main/java/com/rousecontext/integrations/health/query/MindfulnessQueries.kt
@@ -21,21 +21,13 @@ class MindfulnessQueries(private val reader: RecordReader) : CategoryQueries {
         to: Instant,
         limit: Int?
     ): List<JsonObject> = when (recordType) {
-        "MindfulnessSession" -> queryMindfulnessSession(from, to, limit)
-        else -> throw IllegalArgumentException("Unsupported record type: $recordType")
-    }
-
-    override suspend fun summary(from: Instant, to: Instant, granted: Set<String>): JsonObject =
-        JsonObject(emptyMap())
-
-    private suspend fun queryMindfulnessSession(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(MindfulnessSessionRecord::class, from, to)
-        return records
-            .map { record ->
+        "MindfulnessSession" -> reader.queryRecords(
+            MindfulnessSessionRecord::class,
+            from,
+            to,
+            limit
+        ) { record ->
+            listOf(
                 buildJsonObject {
                     put("start_time", record.startTime.toString())
                     put("end_time", record.endTime.toString())
@@ -43,7 +35,11 @@ class MindfulnessQueries(private val reader: RecordReader) : CategoryQueries {
                     record.title?.let { put("title", it) }
                     record.notes?.let { put("notes", it) }
                 }
-            }
-            .let { if (limit != null) it.take(limit) else it }
+            )
+        }
+        else -> throw IllegalArgumentException("Unsupported record type: $recordType")
     }
+
+    override suspend fun summary(from: Instant, to: Instant, granted: Set<String>): JsonObject =
+        JsonObject(emptyMap())
 }

--- a/integrations/src/main/java/com/rousecontext/integrations/health/query/NutritionQueries.kt
+++ b/integrations/src/main/java/com/rousecontext/integrations/health/query/NutritionQueries.kt
@@ -20,31 +20,27 @@ class NutritionQueries(private val reader: RecordReader) : CategoryQueries {
         to: Instant,
         limit: Int?
     ): List<JsonObject> = when (recordType) {
-        "Hydration" -> queryHydration(from, to, limit)
-        "Nutrition" -> queryNutrition(from, to, limit)
-        else -> throw IllegalArgumentException("Unsupported record type: $recordType")
-    }
-
-    override suspend fun summary(from: Instant, to: Instant, granted: Set<String>): JsonObject =
-        JsonObject(emptyMap())
-
-    private suspend fun queryHydration(from: Instant, to: Instant, limit: Int?): List<JsonObject> {
-        val records = reader.read(HydrationRecord::class, from, to)
-        return records
-            .map { record ->
+        "Hydration" -> reader.queryRecords(
+            HydrationRecord::class,
+            from,
+            to,
+            limit
+        ) { record ->
+            listOf(
                 buildJsonObject {
                     put("start_time", record.startTime.toString())
                     put("end_time", record.endTime.toString())
                     put("liters", record.volume.inLiters)
                 }
-            }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryNutrition(from: Instant, to: Instant, limit: Int?): List<JsonObject> {
-        val records = reader.read(NutritionRecord::class, from, to)
-        return records
-            .map { record ->
+            )
+        }
+        "Nutrition" -> reader.queryRecords(
+            NutritionRecord::class,
+            from,
+            to,
+            limit
+        ) { record ->
+            listOf(
                 buildJsonObject {
                     put("start_time", record.startTime.toString())
                     put("end_time", record.endTime.toString())
@@ -54,7 +50,11 @@ class NutritionQueries(private val reader: RecordReader) : CategoryQueries {
                     record.totalFat?.let { put("fat_g", it.inGrams) }
                     record.totalCarbohydrate?.let { put("carbs_g", it.inGrams) }
                 }
-            }
-            .let { if (limit != null) it.take(limit) else it }
+            )
+        }
+        else -> throw IllegalArgumentException("Unsupported record type: $recordType")
     }
+
+    override suspend fun summary(from: Instant, to: Instant, granted: Set<String>): JsonObject =
+        JsonObject(emptyMap())
 }

--- a/integrations/src/main/java/com/rousecontext/integrations/health/query/RecordReader.kt
+++ b/integrations/src/main/java/com/rousecontext/integrations/health/query/RecordReader.kt
@@ -3,6 +3,7 @@ package com.rousecontext.integrations.health.query
 import androidx.health.connect.client.records.Record
 import java.time.Instant
 import kotlin.reflect.KClass
+import kotlinx.serialization.json.JsonObject
 
 /**
  * Seam for reading Health Connect records.
@@ -12,4 +13,25 @@ import kotlin.reflect.KClass
  */
 interface RecordReader {
     suspend fun <T : Record> read(type: KClass<T>, from: Instant, to: Instant): List<T>
+}
+
+/**
+ * Shared query helper that eliminates per-record-type boilerplate.
+ *
+ * Reads records of [type] in the given time range, applies [mapper] to produce
+ * JSON objects (one-to-many, supporting both map and flatMap use cases), optionally
+ * sorts by the `"time"` key when [sortByTime] is true, and applies [limit].
+ */
+internal suspend fun <T : Record> RecordReader.queryRecords(
+    type: KClass<T>,
+    from: Instant,
+    to: Instant,
+    limit: Int?,
+    sortByTime: Boolean = false,
+    mapper: (T) -> List<JsonObject>
+): List<JsonObject> {
+    val records = read(type, from, to)
+    val mapped = records.flatMap(mapper)
+    val sorted = if (sortByTime) mapped.sortedBy { it["time"].toString() } else mapped
+    return if (limit != null) sorted.take(limit) else sorted
 }

--- a/integrations/src/main/java/com/rousecontext/integrations/health/query/ReproductiveQueries.kt
+++ b/integrations/src/main/java/com/rousecontext/integrations/health/query/ReproductiveQueries.kt
@@ -25,122 +25,99 @@ class ReproductiveQueries(private val reader: RecordReader) : CategoryQueries {
         "SexualActivity"
     )
 
+    @Suppress("LongMethod")
     override suspend fun query(
         recordType: String,
         from: Instant,
         to: Instant,
         limit: Int?
     ): List<JsonObject> = when (recordType) {
-        "MenstruationFlow" -> queryMenstruationFlow(from, to, limit)
-        "MenstruationPeriod" -> queryMenstruationPeriod(from, to, limit)
-        "CervicalMucus" -> queryCervicalMucus(from, to, limit)
-        "OvulationTest" -> queryOvulationTest(from, to, limit)
-        "IntermenstrualBleeding" -> queryIntermenstrualBleeding(from, to, limit)
-        "SexualActivity" -> querySexualActivity(from, to, limit)
-        else -> throw IllegalArgumentException("Unsupported record type: $recordType")
-    }
-
-    override suspend fun summary(from: Instant, to: Instant, granted: Set<String>): JsonObject =
-        JsonObject(emptyMap())
-
-    private suspend fun queryMenstruationFlow(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(MenstruationFlowRecord::class, from, to)
-        return records
-            .map { record ->
+        "MenstruationFlow" -> reader.queryRecords(
+            MenstruationFlowRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
                 buildJsonObject {
                     put("time", record.time.toString())
                     put("flow", record.flow)
                 }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryMenstruationPeriod(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(MenstruationPeriodRecord::class, from, to)
-        return records
-            .map { record ->
+            )
+        }
+        "MenstruationPeriod" -> reader.queryRecords(
+            MenstruationPeriodRecord::class,
+            from,
+            to,
+            limit
+        ) { record ->
+            listOf(
                 buildJsonObject {
                     put("start_time", record.startTime.toString())
                     put("end_time", record.endTime.toString())
                 }
-            }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryCervicalMucus(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(CervicalMucusRecord::class, from, to)
-        return records
-            .map { record ->
+            )
+        }
+        "CervicalMucus" -> reader.queryRecords(
+            CervicalMucusRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
                 buildJsonObject {
                     put("time", record.time.toString())
                     put("appearance", record.appearance)
                     put("sensation", record.sensation)
                 }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryOvulationTest(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(OvulationTestRecord::class, from, to)
-        return records
-            .map { record ->
+            )
+        }
+        "OvulationTest" -> reader.queryRecords(
+            OvulationTestRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
                 buildJsonObject {
                     put("time", record.time.toString())
                     put("result", record.result)
                 }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryIntermenstrualBleeding(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(IntermenstrualBleedingRecord::class, from, to)
-        return records
-            .map { record ->
+            )
+        }
+        "IntermenstrualBleeding" -> reader.queryRecords(
+            IntermenstrualBleedingRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
                 buildJsonObject {
                     put("time", record.time.toString())
                 }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun querySexualActivity(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(SexualActivityRecord::class, from, to)
-        return records
-            .map { record ->
+            )
+        }
+        "SexualActivity" -> reader.queryRecords(
+            SexualActivityRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
                 buildJsonObject {
                     put("time", record.time.toString())
                     put("protection_used", record.protectionUsed)
                 }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
+            )
+        }
+        else -> throw IllegalArgumentException("Unsupported record type: $recordType")
     }
+
+    override suspend fun summary(from: Instant, to: Instant, granted: Set<String>): JsonObject =
+        JsonObject(emptyMap())
 }

--- a/integrations/src/main/java/com/rousecontext/integrations/health/query/SleepQueries.kt
+++ b/integrations/src/main/java/com/rousecontext/integrations/health/query/SleepQueries.kt
@@ -21,14 +21,38 @@ class SleepQueries(private val reader: RecordReader) : CategoryQueries {
         to: Instant,
         limit: Int?
     ): List<JsonObject> = when (recordType) {
-        "SleepSession" -> querySleep(from, to, limit)
+        "SleepSession" -> reader.queryRecords(
+            SleepSessionRecord::class,
+            from,
+            to,
+            limit
+        ) { record ->
+            val stagesArray = buildJsonArray {
+                record.stages.forEach { stage ->
+                    add(
+                        buildJsonObject {
+                            put("stage", mapSleepStage(stage.stage))
+                            put("start", stage.startTime.toString())
+                            put("end", stage.endTime.toString())
+                        }
+                    )
+                }
+            }
+            listOf(
+                buildJsonObject {
+                    put("start_time", record.startTime.toString())
+                    put("end_time", record.endTime.toString())
+                    put("stages", stagesArray.toString())
+                }
+            )
+        }
         else -> throw IllegalArgumentException("Unsupported record type: $recordType")
     }
 
     override suspend fun summary(from: Instant, to: Instant, granted: Set<String>): JsonObject =
         buildJsonObject {
             if ("SleepSession" in granted) {
-                val sessions = querySleep(from, to, null)
+                val sessions = query("SleepSession", from, to, null)
                 val totalMinutes = sessions.sumOf { session ->
                     val start = session["start_time"]?.toString()?.trim('"')
                     val end = session["end_time"]?.toString()?.trim('"')
@@ -45,35 +69,6 @@ class SleepQueries(private val reader: RecordReader) : CategoryQueries {
                 put("sleep_hours", totalMinutes / MINUTES_PER_HOUR)
             }
         }
-
-    private suspend fun querySleep(from: Instant, to: Instant, limit: Int?): List<JsonObject> {
-        val records = reader.read(SleepSessionRecord::class, from, to)
-        return records
-            .map { record ->
-                // The legacy wire shape stored stages as a string-encoded JSON
-                // array (`"stages":"[{...},{...}]"`). Preserve that exact shape:
-                // build the array using kotlinx.serialization for proper escaping
-                // of `start`/`end`, then put its `toString()` representation as
-                // a string field.
-                val stagesArray = buildJsonArray {
-                    record.stages.forEach { stage ->
-                        add(
-                            buildJsonObject {
-                                put("stage", mapSleepStage(stage.stage))
-                                put("start", stage.startTime.toString())
-                                put("end", stage.endTime.toString())
-                            }
-                        )
-                    }
-                }
-                buildJsonObject {
-                    put("start_time", record.startTime.toString())
-                    put("end_time", record.endTime.toString())
-                    put("stages", stagesArray.toString())
-                }
-            }
-            .let { if (limit != null) it.take(limit) else it }
-    }
 
     private fun mapSleepStage(stage: Int): String = when (stage) {
         SleepSessionRecord.STAGE_TYPE_AWAKE -> "awake"

--- a/integrations/src/main/java/com/rousecontext/integrations/health/query/VitalsQueries.kt
+++ b/integrations/src/main/java/com/rousecontext/integrations/health/query/VitalsQueries.kt
@@ -34,30 +34,175 @@ class VitalsQueries(private val reader: RecordReader) : CategoryQueries {
         "SkinTemperature"
     )
 
-    @Suppress("CyclomaticComplexMethod")
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     override suspend fun query(
         recordType: String,
         from: Instant,
         to: Instant,
         limit: Int?
     ): List<JsonObject> = when (recordType) {
-        "HeartRate" -> queryHeartRate(from, to, limit)
-        "RestingHeartRate" -> queryRestingHeartRate(from, to, limit)
-        "HeartRateVariabilityRmssd" -> queryHeartRateVariability(from, to, limit)
-        "BloodPressure" -> queryBloodPressure(from, to, limit)
-        "BloodGlucose" -> queryBloodGlucose(from, to, limit)
-        "OxygenSaturation" -> queryOxygenSaturation(from, to, limit)
-        "RespiratoryRate" -> queryRespiratoryRate(from, to, limit)
-        "BodyTemperature" -> queryBodyTemperature(from, to, limit)
-        "BasalBodyTemperature" -> queryBasalBodyTemperature(from, to, limit)
-        "SkinTemperature" -> querySkinTemperature(from, to, limit)
+        "HeartRate" -> reader.queryRecords(
+            HeartRateRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            record.samples.map { sample ->
+                buildJsonObject {
+                    put("time", sample.time.toString())
+                    put("bpm", sample.beatsPerMinute)
+                }
+            }
+        }
+        "RestingHeartRate" -> reader.queryRecords(
+            RestingHeartRateRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("time", record.time.toString())
+                    put("bpm", record.beatsPerMinute)
+                }
+            )
+        }
+        "HeartRateVariabilityRmssd" -> reader.queryRecords(
+            HeartRateVariabilityRmssdRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("time", record.time.toString())
+                    put("rmssd_ms", record.heartRateVariabilityMillis)
+                }
+            )
+        }
+        "BloodPressure" -> reader.queryRecords(
+            BloodPressureRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("time", record.time.toString())
+                    put("systolic", record.systolic.inMillimetersOfMercury)
+                    put("diastolic", record.diastolic.inMillimetersOfMercury)
+                }
+            )
+        }
+        "BloodGlucose" -> reader.queryRecords(
+            BloodGlucoseRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("time", record.time.toString())
+                    put("mmol_per_l", record.level.inMillimolesPerLiter)
+                }
+            )
+        }
+        "OxygenSaturation" -> reader.queryRecords(
+            OxygenSaturationRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("time", record.time.toString())
+                    put("percentage", record.percentage.value)
+                }
+            )
+        }
+        "RespiratoryRate" -> reader.queryRecords(
+            RespiratoryRateRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("time", record.time.toString())
+                    put("breaths_per_minute", record.rate)
+                }
+            )
+        }
+        "BodyTemperature" -> reader.queryRecords(
+            BodyTemperatureRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("time", record.time.toString())
+                    put("celsius", record.temperature.inCelsius)
+                    put("measurement_location", record.measurementLocation)
+                }
+            )
+        }
+        "BasalBodyTemperature" -> reader.queryRecords(
+            BasalBodyTemperatureRecord::class,
+            from,
+            to,
+            limit,
+            sortByTime = true
+        ) { record ->
+            listOf(
+                buildJsonObject {
+                    put("time", record.time.toString())
+                    put("celsius", record.temperature.inCelsius)
+                    put("measurement_location", record.measurementLocation)
+                }
+            )
+        }
+        "SkinTemperature" -> reader.queryRecords(
+            SkinTemperatureRecord::class,
+            from,
+            to,
+            limit
+        ) { record ->
+            val deltasArray = buildJsonArray {
+                record.deltas.forEach { delta ->
+                    add(
+                        buildJsonObject {
+                            put("time", delta.time.toString())
+                            put("delta_celsius", delta.delta.inCelsius)
+                        }
+                    )
+                }
+            }
+            listOf(
+                buildJsonObject {
+                    put("start_time", record.startTime.toString())
+                    put("end_time", record.endTime.toString())
+                    record.baseline?.let { put("baseline_celsius", it.inCelsius) }
+                    put("measurement_location", record.measurementLocation)
+                    put("deltas", deltasArray.toString())
+                }
+            )
+        }
         else -> throw IllegalArgumentException("Unsupported record type: $recordType")
     }
 
     override suspend fun summary(from: Instant, to: Instant, granted: Set<String>): JsonObject =
         buildJsonObject {
             if ("HeartRate" in granted) {
-                val samples = queryHeartRate(from, to, null)
+                val samples = query("HeartRate", from, to, null)
                 if (samples.isNotEmpty()) {
                     val avg = samples.mapNotNull {
                         it["bpm"]?.toString()?.toLongOrNull()
@@ -66,192 +211,4 @@ class VitalsQueries(private val reader: RecordReader) : CategoryQueries {
                 }
             }
         }
-
-    private suspend fun queryHeartRate(from: Instant, to: Instant, limit: Int?): List<JsonObject> {
-        val records = reader.read(HeartRateRecord::class, from, to)
-        return records
-            .flatMap { record ->
-                record.samples.map { sample ->
-                    buildJsonObject {
-                        put("time", sample.time.toString())
-                        put("bpm", sample.beatsPerMinute)
-                    }
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryRestingHeartRate(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(RestingHeartRateRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("time", record.time.toString())
-                    put("bpm", record.beatsPerMinute)
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryHeartRateVariability(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(HeartRateVariabilityRmssdRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("time", record.time.toString())
-                    put("rmssd_ms", record.heartRateVariabilityMillis)
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryBloodPressure(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(BloodPressureRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("time", record.time.toString())
-                    put("systolic", record.systolic.inMillimetersOfMercury)
-                    put("diastolic", record.diastolic.inMillimetersOfMercury)
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryBloodGlucose(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(BloodGlucoseRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("time", record.time.toString())
-                    put("mmol_per_l", record.level.inMillimolesPerLiter)
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryOxygenSaturation(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(OxygenSaturationRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("time", record.time.toString())
-                    put("percentage", record.percentage.value)
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryRespiratoryRate(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(RespiratoryRateRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("time", record.time.toString())
-                    put("breaths_per_minute", record.rate)
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryBodyTemperature(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(BodyTemperatureRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("time", record.time.toString())
-                    put("celsius", record.temperature.inCelsius)
-                    put("measurement_location", record.measurementLocation)
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun queryBasalBodyTemperature(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(BasalBodyTemperatureRecord::class, from, to)
-        return records
-            .map { record ->
-                buildJsonObject {
-                    put("time", record.time.toString())
-                    put("celsius", record.temperature.inCelsius)
-                    put("measurement_location", record.measurementLocation)
-                }
-            }
-            .sortedBy { it["time"].toString() }
-            .let { if (limit != null) it.take(limit) else it }
-    }
-
-    private suspend fun querySkinTemperature(
-        from: Instant,
-        to: Instant,
-        limit: Int?
-    ): List<JsonObject> {
-        val records = reader.read(SkinTemperatureRecord::class, from, to)
-        return records
-            .map { record ->
-                // The legacy wire shape stored deltas as a string-encoded JSON
-                // array (`"deltas":"[{...},{...}]"`). Preserve that exact shape:
-                // build the array using kotlinx.serialization for proper escaping
-                // of `time` (and any future string fields), then put its
-                // `toString()` representation as a string field.
-                val deltasArray = buildJsonArray {
-                    record.deltas.forEach { delta ->
-                        add(
-                            buildJsonObject {
-                                put("time", delta.time.toString())
-                                put("delta_celsius", delta.delta.inCelsius)
-                            }
-                        )
-                    }
-                }
-                buildJsonObject {
-                    put("start_time", record.startTime.toString())
-                    put("end_time", record.endTime.toString())
-                    record.baseline?.let { put("baseline_celsius", it.inCelsius) }
-                    put("measurement_location", record.measurementLocation)
-                    put("deltas", deltasArray.toString())
-                }
-            }
-            .let { if (limit != null) it.take(limit) else it }
-    }
 }


### PR DESCRIPTION
## Summary
- Extract `RecordReader.queryRecords()` extension function that handles the read-map-sort-limit boilerplate shared by all 39 private `query*()` methods
- Replace each private method with an inline lambda at its `when` branch call site across 7 category files (VitalsQueries, ActivityQueries, BodyQueries, ReproductiveQueries, SleepQueries, NutritionQueries, MindfulnessQueries)
- Net reduction of ~96 LOC (586 deletions, 490 insertions) with zero behavior change -- Steps (groupBy) and Sleep/SkinTemperature (complex nested arrays) retain their custom logic

Closes #442

## Test plan
- [x] All existing `integrations:testDebugUnitTest` tests pass (7 test files, unchanged)
- [x] `ktlintCheck` clean
- [x] `detekt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)