### PR TITLE
Stop FGS gracefully on dataSync run-time timeout (#450)

### DIFF
--- a/docs/ux-decisions.md
+++ b/docs/ux-decisions.md
@@ -14,6 +14,45 @@ Newest entries on top.
 
 ---
 
+## 2026-05-26 — Surface the FGS-budget notification on run-time timeout, not just at startup
+
+**Decision:** When Android calls `Service.onTimeout()` because the `dataSync`
+foreground-service budget is exhausted *while the service is running*,
+`TunnelForegroundService` posts the existing `FgsLimitNotifier` notification and
+stops cleanly — the same notification already shown when the budget is exhausted
+at startup.
+
+**Approved by:** Jason, in-session 2026-05-26 ("sure" — to implement the
+onTimeout handler reusing FgsLimitNotifier).
+
+**Context:** Crashes #450/#451 (`ForegroundServiceDidNotStopInTimeException`)
+were the service being force-killed when the cumulative 6h/24h dataSync FGS cap
+ran out mid-session. The start-time half of this was already handled
+(`ForegroundServiceStartNotAllowedException` → notify + stopSelf); the run-time
+half (`onTimeout`) was missing, so the budget exhausting mid-run produced a
+silent crash with no user-facing explanation.
+
+**Alternatives considered:**
+- **Stop silently on timeout, no notification** — fixes the crash but the user
+  gets no signal that wakes have paused until the 24h window frees budget;
+  inconsistent with the start-time path, which does notify.
+- **Distinct "ran out mid-session" copy** — more precise, but it's the same
+  underlying condition (budget exhausted, wakes paused, retries next window), so
+  a second message would be noise.
+
+**Trade-off accepted:** The same notification can now appear at a second moment
+in the lifecycle (mid-session, not only at wake start). Accepted because the
+user-facing meaning is identical — "FGS budget spent, wakes paused, will resume
+when the rolling window frees up" — and a shared id means the two paths replace
+rather than stack in the shade.
+
+**Relevant:**
+- Crashes: #450 (FcmReceiver.startTunnelService frame), #451 (system-generated
+  frame) — same root cause, one fix.
+- Mirrors the existing start-time handler in `TunnelForegroundService.startForegroundSafely`.
+
+---
+
 ## 2026-04-24 — Cert provisioning runs at Continue, not at first integration add
 
 **Decision:** Keep the post-#389 flow where relay subdomain registration and ACME cert provisioning fire immediately after the user taps Continue on NotificationPreferences, before Home loads.

--- a/work/src/main/kotlin/com/rousecontext/work/TunnelForegroundService.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/TunnelForegroundService.kt
@@ -289,6 +289,26 @@ class TunnelForegroundService : LifecycleService() {
         }
     }
 
+    /**
+     * Android 15+ enforces a cumulative ~6h-per-24h limit on `dataSync`
+     * foreground services. When that budget is exhausted *while the service is
+     * running*, the system calls this and requires us to stop within a couple
+     * seconds — otherwise it kills the process with
+     * `ForegroundServiceDidNotStopInTimeException` (#450, #451).
+     *
+     * This is the run-time mirror of the start-time
+     * `ForegroundServiceStartNotAllowedException` already handled in
+     * [startForegroundSafely]: post the same user-visible notification, suppress
+     * reconnect, and stop. The next FCM wake retries once the rolling window
+     * frees the budget back up.
+     */
+    override fun onTimeout(startId: Int, fgsType: Int) {
+        Log.w(TAG, "FGS dataSync time limit reached (fgsType=$fgsType); stopping service")
+        intentionalDisconnect = true
+        FgsLimitNotifier.postLimitReachedNotification(this)
+        stopSelf()
+    }
+
     override fun onDestroy() {
         Log.i(TAG, "TunnelForegroundService destroyed")
         intentionalDisconnect = true

--- a/work/src/test/kotlin/com/rousecontext/work/TunnelForegroundServiceLifecycleTest.kt
+++ b/work/src/test/kotlin/com/rousecontext/work/TunnelForegroundServiceLifecycleTest.kt
@@ -1,10 +1,13 @@
 package com.rousecontext.work
 
 import android.app.Notification
+import android.content.pm.ServiceInfo
+import android.os.Build
 import android.os.Looper
 import com.rousecontext.api.CrashReporter
 import com.rousecontext.bridge.SessionHandler
 import com.rousecontext.mcp.core.ProviderRegistry
+import com.rousecontext.notifications.FgsLimitNotifier
 import com.rousecontext.notifications.ForegroundNotifier
 import com.rousecontext.notifications.NotificationChannels
 import com.rousecontext.notifications.SessionSummaryNotifier
@@ -17,6 +20,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlin.time.Duration
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -36,6 +40,7 @@ import org.koin.dsl.module
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
 
 /**
  * Tests [TunnelForegroundService] lifecycle transitions using Robolectric.
@@ -280,6 +285,47 @@ class TunnelForegroundServiceLifecycleTest {
                 "before any coroutine or handler work runs (issue #325)",
             fgNotification
         )
+    }
+
+    // -- Test 7: onTimeout (run-time FGS budget exhaustion) stops the service (#450/#451) --
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.VANILLA_ICE_CREAM])
+    fun `onTimeout stops service and posts FGS limit notification`() {
+        // Android 15+ calls Service.onTimeout once the cumulative dataSync FGS
+        // budget is exhausted while the service is running. If we don't stop
+        // promptly the system kills us with ForegroundServiceDidNotStopInTime-
+        // Exception (#450/#451). This mirrors the start-time budget handler.
+        mockkObject(FgsLimitNotifier)
+        every { FgsLimitNotifier.postLimitReachedNotification(any()) } returns Unit
+        try {
+            fakeTunnelClient.stateFlow.value = TunnelState.DISCONNECTED
+
+            val controller = Robolectric.buildService(TunnelForegroundService::class.java)
+            val service = controller.get()
+            controller.create()
+            drainMain()
+            controller.startCommand(0, 1)
+            drainMain()
+            fakeTunnelClient.stateFlow.value = TunnelState.CONNECTED
+            drainMain()
+
+            // System signals the dataSync 6h budget is exhausted mid-run.
+            service.onTimeout(1, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+            drainMain()
+
+            assertTrue(
+                "Service must stop itself when the FGS run-time timeout fires",
+                shadowOf(service).isStoppedBySelf
+            )
+            assertTrue(
+                "intentionalDisconnect must be set so the stop doesn't trigger a reconnect",
+                service.intentionalDisconnect
+            )
+            verify { FgsLimitNotifier.postLimitReachedNotification(any()) }
+        } finally {
+            unmockkObject(FgsLimitNotifier)
+        }
     }
 
     // -- Helpers --


### PR DESCRIPTION
## Summary
Fixes the `ForegroundServiceDidNotStopInTimeException` crashes (#450, and #451 closed as a dup).

Android 15+ enforces a cumulative ~6h/24h limit on `dataSync` foreground services. When the budget is exhausted **while the service is running**, the system calls `Service.onTimeout()` and gives the service a couple seconds to stop — otherwise it force-kills the process with `ForegroundServiceDidNotStopInTimeException`.

`TunnelForegroundService` already handled the symmetric **start-time** case (`ForegroundServiceStartNotAllowedException` → post `FgsLimitNotifier` + `stopSelf`), but never overrode `onTimeout`, so a budget that ran out **mid-session** crashed silently. v1.0.2's keep-Ktor-alive-across-idle change makes the service stay foregrounded longer, accelerating accumulation toward the cap — an accelerant, not the root cause (the missing handler predates it).

## Change
- Override `onTimeout(startId, fgsType)` to mirror the start-time path: set `intentionalDisconnect`, post the existing `FgsLimitNotifier`, and `stopSelf()`.
- Robolectric test (`@Config sdk=35`) asserting `onTimeout(dataSync)` stops the service, suppresses reconnect, and posts the notification.
- `docs/ux-decisions.md` entry (per `.claude/rules/ux-changes.md`) for the new lifecycle moment at which the budget notification can appear. Approved in-session by Jason 2026-05-26.

## Test plan
- [x] `:work:testDebugUnitTest` green (new test fails without the override, passes with it)
- [x] `ktlintCheck` + `detekt` clean
- [x] Built + launched on a Pixel 6 Pro running Android 17 (SDK 37) — clean startup, no crash, confirms the code loads/runs on the OS that enforces the timeout
- [ ] Real 6h `dataSync` cap **not** synthetically reproducible (no adb fast-forward for the cumulative budget); handler is unit-verified

Fixes #450