### PR TITLE
Wire the dormant Connection settings cluster (#453)

### DIFF
--- a/app/src/main/java/com/rousecontext/app/di/AppModule.kt
+++ b/app/src/main/java/com/rousecontext/app/di/AppModule.kt
@@ -38,6 +38,7 @@ import com.rousecontext.app.state.PreferencesSnapshotHolder
 import com.rousecontext.app.state.SecurityAlertGate
 import com.rousecontext.app.state.ThemePreference
 import com.rousecontext.app.state.notificationPermissionFlow
+import com.rousecontext.app.support.BatteryOptimization
 import com.rousecontext.app.support.BugReportUriBuilder
 import com.rousecontext.app.support.FirebaseCrashReporter
 import com.rousecontext.app.token.RoomTokenStore
@@ -123,9 +124,6 @@ import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
-
-/** Idle timeout before disconnecting the tunnel after all streams close. */
-private const val IDLE_TIMEOUT_MS = 5 * 60 * 1000L
 
 /** How long to wait for graceful MCP session shutdown before forcing tunnel disconnect. */
 private const val GRACEFUL_SHUTDOWN_TIMEOUT_MS = 5_000L
@@ -585,8 +583,18 @@ val appModule = module {
         val tunnelClient: TunnelClient = get()
         val mcpSession: McpSession = get()
         val recorder: SpuriousWakeRecorder = get()
+        val appStatePreferences: AppStatePreferences = get()
         IdleTimeoutManager(
-            timeoutMillis = IDLE_TIMEOUT_MS,
+            // Read the user's idle-timeout setting fresh each wake cycle.
+            // Disabled => null => the timer never arms (the service then runs
+            // until the FGS dataSync budget or an FCM idle-stop intervenes).
+            timeoutProvider = {
+                if (appStatePreferences.idleTimeoutDisabled()) {
+                    null
+                } else {
+                    appStatePreferences.idleTimeoutMinutes() * 60_000L
+                }
+            },
             onTimeout = {
                 withTimeoutOrNull(GRACEFUL_SHUTDOWN_TIMEOUT_MS) { mcpSession.shutdown() }
                 tunnelClient.disconnect()
@@ -626,6 +634,7 @@ val appModule = module {
             integrations = get(),
             securityCheckPreferences = get(),
             appStatePreferences = get(),
+            batteryExemptProvider = { BatteryOptimization.isExempt(androidContext()) },
             spuriousWakesFlow = SettingsViewModel.spuriousWakeStatsFlow(get())
         )
     }

--- a/app/src/main/java/com/rousecontext/app/state/AppStatePreferences.kt
+++ b/app/src/main/java/com/rousecontext/app/state/AppStatePreferences.kt
@@ -37,6 +37,32 @@ class AppStatePreferences(private val context: Context) {
         }
     }
 
+    suspend fun idleTimeoutMinutes(): Int =
+        dataStore.data.first()[KEY_IDLE_TIMEOUT_MINUTES] ?: DEFAULT_IDLE_TIMEOUT_MINUTES
+
+    fun observeIdleTimeoutMinutes(): Flow<Int> = dataStore.data.map {
+        it[KEY_IDLE_TIMEOUT_MINUTES] ?: DEFAULT_IDLE_TIMEOUT_MINUTES
+    }
+
+    suspend fun setIdleTimeoutMinutes(value: Int) {
+        dataStore.edit { prefs ->
+            prefs[KEY_IDLE_TIMEOUT_MINUTES] = value
+        }
+    }
+
+    suspend fun idleTimeoutDisabled(): Boolean =
+        dataStore.data.first()[KEY_IDLE_TIMEOUT_DISABLED] ?: false
+
+    fun observeIdleTimeoutDisabled(): Flow<Boolean> = dataStore.data.map {
+        it[KEY_IDLE_TIMEOUT_DISABLED] ?: false
+    }
+
+    suspend fun setIdleTimeoutDisabled(value: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[KEY_IDLE_TIMEOUT_DISABLED] = value
+        }
+    }
+
     suspend fun hasLaunchedBefore(): Boolean =
         dataStore.data.first()[KEY_HAS_LAUNCHED_BEFORE] ?: false
 
@@ -53,14 +79,21 @@ class AppStatePreferences(private val context: Context) {
         dataStore.edit { prefs ->
             prefs.remove(KEY_SECURITY_CHECK_INTERVAL_HOURS)
             prefs.remove(KEY_HAS_LAUNCHED_BEFORE)
+            prefs.remove(KEY_IDLE_TIMEOUT_MINUTES)
+            prefs.remove(KEY_IDLE_TIMEOUT_DISABLED)
         }
     }
 
     companion object {
         const val DEFAULT_INTERVAL_HOURS = 12
 
+        /** Default idle timeout in minutes. Mirrors the historical `IDLE_TIMEOUT_MS` (5 min). */
+        const val DEFAULT_IDLE_TIMEOUT_MINUTES = 5
+
         private val KEY_SECURITY_CHECK_INTERVAL_HOURS =
             intPreferencesKey("security_check_interval_hours")
         private val KEY_HAS_LAUNCHED_BEFORE = booleanPreferencesKey("has_launched_before")
+        private val KEY_IDLE_TIMEOUT_MINUTES = intPreferencesKey("idle_timeout_minutes")
+        private val KEY_IDLE_TIMEOUT_DISABLED = booleanPreferencesKey("idle_timeout_disabled")
     }
 }

--- a/app/src/main/java/com/rousecontext/app/support/BatteryOptimization.kt
+++ b/app/src/main/java/com/rousecontext/app/support/BatteryOptimization.kt
@@ -1,0 +1,37 @@
+package com.rousecontext.app.support
+
+import android.content.Context
+import android.content.Intent
+import android.os.PowerManager
+import android.provider.Settings
+
+/**
+ * Battery-optimization status and the user-facing flow to change it.
+ *
+ * Reliable FCM wake-ups depend on the app being exempt from Doze battery
+ * optimization. We surface the current status in Settings (a warning + the
+ * idle-timeout "Disable" switch both gate on it) and offer a "Fix this" button
+ * that sends the user to the system screen where they can grant the exemption.
+ *
+ * We deliberately use [Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS]
+ * (the optimization list the user picks the app from) rather than
+ * `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` (the direct allow/deny dialog):
+ * the direct request needs the `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`
+ * permission, which Google Play restricts to apps whose core function requires
+ * it. The settings-list route needs no special permission.
+ */
+object BatteryOptimization {
+
+    /** True if this app is currently exempt from Doze battery optimization. */
+    fun isExempt(context: Context): Boolean {
+        val pm = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
+            ?: return false
+        return pm.isIgnoringBatteryOptimizations(context.packageName)
+    }
+
+    /**
+     * Intent that opens the system battery-optimization settings list, where the
+     * user can mark this app "Don't optimize". Launch from an Activity context.
+     */
+    fun settingsIntent(): Intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+}

--- a/app/src/main/java/com/rousecontext/app/support/BugReportUriBuilder.kt
+++ b/app/src/main/java/com/rousecontext/app/support/BugReportUriBuilder.kt
@@ -3,7 +3,6 @@ package com.rousecontext.app.support
 import android.content.Context
 import android.net.Uri
 import android.os.Build
-import android.os.PowerManager
 import com.rousecontext.app.BuildConfig
 
 /**
@@ -44,13 +43,7 @@ class BugReportUriBuilder(private val context: Context) {
         append("- App version: ${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})\n")
         append("- Android: ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT})\n")
         append("- Device: ${Build.MANUFACTURER} ${Build.MODEL}\n")
-        append("- Battery optimization exempt: ${isIgnoringBatteryOptimizations()}\n")
-    }
-
-    private fun isIgnoringBatteryOptimizations(): Boolean {
-        val pm = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
-            ?: return false
-        return pm.isIgnoringBatteryOptimizations(context.packageName)
+        append("- Battery optimization exempt: ${BatteryOptimization.isExempt(context)}\n")
     }
 
     private fun assemble(title: String, body: String): String = ISSUE_URL_BASE +

--- a/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/SettingsDestination.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/SettingsDestination.kt
@@ -9,14 +9,19 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.rousecontext.app.R
+import com.rousecontext.app.support.BatteryOptimization
 import com.rousecontext.app.support.BugReportUriBuilder
 import com.rousecontext.app.ui.navigation.ConfigureNavBar
 import com.rousecontext.app.ui.navigation.Routes
@@ -74,9 +79,25 @@ private fun SettingsDestinationContent() {
     val showAll by viewModel.showAllMcpMessages.collectAsState()
     val bugReportUriBuilder: BugReportUriBuilder = koinInject()
     val settingsContext = LocalContext.current
+    // Re-read battery-optimization status when returning from the system
+    // settings screen the "Fix this" button opens (#453).
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner.lifecycle) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.refresh()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
     SettingsContent(
         state = state.copy(showAllMcpMessages = showAll),
         onIdleTimeoutChanged = viewModel::setIdleTimeout,
+        onDisableTimeoutToggled = viewModel::setDisableTimeout,
+        onFixBatteryOptimization = {
+            startActivitySafely(settingsContext, BatteryOptimization.settingsIntent())
+        },
         onPostSessionModeChanged = viewModel::setPostSessionMode,
         onShowAllMcpMessagesChanged = viewModel::setShowAllMcpMessages,
         onThemeModeChanged = viewModel::setThemeMode,
@@ -105,5 +126,18 @@ private fun openUriSafely(context: Context, uri: Uri) {
         context.startActivity(intent)
     } catch (_: ActivityNotFoundException) {
         // No browser available; silently ignore.
+    }
+}
+
+/**
+ * Launch an arbitrary system [Intent], swallowing [ActivityNotFoundException]
+ * for the rare device/ROM that doesn't expose the target screen. Used for the
+ * battery-optimization settings deep-link behind "Fix this".
+ */
+private fun startActivitySafely(context: Context, intent: Intent) {
+    try {
+        context.startActivity(intent.apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) })
+    } catch (_: ActivityNotFoundException) {
+        // Settings screen not available on this device; silently ignore.
     }
 }

--- a/app/src/main/java/com/rousecontext/app/ui/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/viewmodels/SettingsViewModel.kt
@@ -56,6 +56,13 @@ class SettingsViewModel(
     private val integrations: List<McpIntegration> = emptyList(),
     private val securityCheckPreferences: SecurityCheckPreferences? = null,
     private val appStatePreferences: AppStatePreferences? = null,
+    /**
+     * Reports whether the app is currently exempt from battery optimization.
+     * Read on each refresh so returning from the system battery-settings screen
+     * (which triggers a refresh on resume) reflects the new state. Defaults to a
+     * conservative "not exempt" when absent (tests only).
+     */
+    private val batteryExemptProvider: () -> Boolean = { false },
     spuriousWakesFlow: Flow<SpuriousWakeStats> = flowOf(SpuriousWakeStats.EMPTY)
 ) : ViewModel() {
 
@@ -94,6 +101,14 @@ class SettingsViewModel(
         ?.observeSecurityCheckIntervalHours()
         ?: flowOf(AppStatePreferences.DEFAULT_INTERVAL_HOURS)
 
+    /** (idle-timeout minutes, idle-timeout disabled) from DataStore, with defaults. */
+    private val idleTimeoutFlow: Flow<Pair<Int, Boolean>> = appStatePreferences?.let { prefs ->
+        combine(
+            prefs.observeIdleTimeoutMinutes(),
+            prefs.observeIdleTimeoutDisabled()
+        ) { minutes, disabled -> minutes to disabled }
+    } ?: flowOf(AppStatePreferences.DEFAULT_IDLE_TIMEOUT_MINUTES to false)
+
     val state: StateFlow<SettingsState> = combine(
         combine(
             refreshTrigger,
@@ -102,17 +117,27 @@ class SettingsViewModel(
             rotateError,
             spuriousWakesFlow
         ) { _, themeMode, rotating, rotateErr, spurious ->
-            Quint(themeMode, rotating, rotateErr, spurious, Unit)
+            // Battery-exempt is a point-in-time PowerManager read; re-evaluate it
+            // whenever the refresh trigger (or any of these flows) emits, so a
+            // resume-driven refresh() picks up a change made in system settings.
+            Quint(themeMode, rotating, rotateErr, spurious, batteryExemptProvider())
         },
         notificationSettingsProvider.observeSettings(),
         trustStatusFlow,
-        intervalFlow
-    ) { tuple, settings, trust, intervalHours ->
+        intervalFlow,
+        idleTimeoutFlow
+    ) { tuple, settings, trust, intervalHours, idle ->
         val themeMode = tuple.a
         val rotating = tuple.b
         val rotateErr = tuple.c
         val spurious = tuple.d
+        val batteryExempt = tuple.e
+        val (idleMinutes, idleDisabled) = idle
         SettingsState(
+            idleTimeoutMinutes = idleMinutes,
+            idleTimeoutDisabled = idleDisabled,
+            batteryOptimizationExempt = batteryExempt,
+            showBatteryWarning = !batteryExempt,
             postSessionMode = settings.postSessionMode.toOption(),
             themeMode = themeMode.toOption(),
             securityCheckInterval = SecurityCheckIntervalOption.forHours(intervalHours),
@@ -159,8 +184,17 @@ class SettingsViewModel(
     }
 
     fun setIdleTimeout(minutes: Int) {
-        // TODO: persist to DataStore when idle timeout DataStore is added
-        refresh()
+        viewModelScope.launch {
+            appStatePreferences?.setIdleTimeoutMinutes(minutes)
+            refresh()
+        }
+    }
+
+    fun setDisableTimeout(disabled: Boolean) {
+        viewModelScope.launch {
+            appStatePreferences?.setIdleTimeoutDisabled(disabled)
+            refresh()
+        }
     }
 
     fun setPostSessionMode(mode: PostSessionModeOption) {

--- a/app/src/test/java/com/rousecontext/app/state/AppStatePreferencesTest.kt
+++ b/app/src/test/java/com/rousecontext/app/state/AppStatePreferencesTest.kt
@@ -52,4 +52,46 @@ class AppStatePreferencesTest {
             cancelAndIgnoreRemainingEvents()
         }
     }
+
+    @Test
+    fun `idle timeout minutes defaults to constant`() = runTest {
+        assertEquals(AppStatePreferences.DEFAULT_IDLE_TIMEOUT_MINUTES, prefs.idleTimeoutMinutes())
+    }
+
+    @Test
+    fun `setIdleTimeoutMinutes persists value`() = runTest {
+        prefs.setIdleTimeoutMinutes(10)
+        assertEquals(10, prefs.idleTimeoutMinutes())
+    }
+
+    @Test
+    fun `observeIdleTimeoutMinutes emits updates`() = runTest {
+        prefs.observeIdleTimeoutMinutes().test {
+            assertEquals(AppStatePreferences.DEFAULT_IDLE_TIMEOUT_MINUTES, awaitItem())
+            prefs.setIdleTimeoutMinutes(2)
+            assertEquals(2, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `idle timeout disabled defaults to false`() = runTest {
+        assertFalse(prefs.idleTimeoutDisabled())
+    }
+
+    @Test
+    fun `setIdleTimeoutDisabled persists value`() = runTest {
+        prefs.setIdleTimeoutDisabled(true)
+        assertTrue(prefs.idleTimeoutDisabled())
+    }
+
+    @Test
+    fun `observeIdleTimeoutDisabled emits updates`() = runTest {
+        prefs.observeIdleTimeoutDisabled().test {
+            assertFalse(awaitItem())
+            prefs.setIdleTimeoutDisabled(true)
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
 }

--- a/app/src/test/java/com/rousecontext/app/support/BatteryOptimizationTest.kt
+++ b/app/src/test/java/com/rousecontext/app/support/BatteryOptimizationTest.kt
@@ -1,0 +1,37 @@
+package com.rousecontext.app.support
+
+import android.content.Context
+import android.os.PowerManager
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class BatteryOptimizationTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `isExempt reflects PowerManager state`() {
+        val pm = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        val shadow = shadowOf(pm)
+
+        shadow.setIgnoringBatteryOptimizations(context.packageName, true)
+        assertTrue(BatteryOptimization.isExempt(context))
+
+        shadow.setIgnoringBatteryOptimizations(context.packageName, false)
+        assertFalse(BatteryOptimization.isExempt(context))
+    }
+
+    @Test
+    fun `settingsIntent targets the battery-optimization settings screen`() {
+        val intent = BatteryOptimization.settingsIntent()
+        assertEquals(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS, intent.action)
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/ui/viewmodels/SettingsViewModelTest.kt
+++ b/app/src/test/java/com/rousecontext/app/ui/viewmodels/SettingsViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.rousecontext.app.ui.viewmodels
 
 import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
 import com.rousecontext.api.NotificationSettings
 import com.rousecontext.api.NotificationSettingsProvider
@@ -9,6 +10,7 @@ import com.rousecontext.app.state.AppStatePreferences
 import com.rousecontext.app.state.ThemeMode
 import com.rousecontext.app.state.ThemePreference
 import com.rousecontext.app.ui.screens.PostSessionModeOption
+import com.rousecontext.app.ui.screens.SettingsState
 import com.rousecontext.app.ui.screens.TrustOverallStatus
 import com.rousecontext.work.SecurityCheckPreferences
 import io.mockk.coEvery
@@ -294,6 +296,68 @@ class SettingsViewModelTest {
     }
 
     @Test
+    fun `setIdleTimeout persists the selected minutes`() = runTest(testDispatcher) {
+        val prefs = mockAppStatePrefs()
+        val vm = createViewModel(PostSessionMode.SUMMARY, appStatePrefs = prefs)
+        vm.setIdleTimeout(10)
+        testDispatcher.scheduler.advanceUntilIdle()
+        coVerify { prefs.setIdleTimeoutMinutes(10) }
+    }
+
+    @Test
+    fun `state reflects the stored idle timeout minutes`() = runTest(testDispatcher) {
+        val prefs = mockAppStatePrefs(idleMinutes = 10)
+        val vm = createViewModel(PostSessionMode.SUMMARY, appStatePrefs = prefs)
+        vm.state.test {
+            val state = awaitLoaded()
+            assertEquals(10, state.idleTimeoutMinutes)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setDisableTimeout persists the flag`() = runTest(testDispatcher) {
+        val prefs = mockAppStatePrefs()
+        val vm = createViewModel(PostSessionMode.SUMMARY, appStatePrefs = prefs)
+        vm.setDisableTimeout(true)
+        testDispatcher.scheduler.advanceUntilIdle()
+        coVerify { prefs.setIdleTimeoutDisabled(true) }
+    }
+
+    @Test
+    fun `state reflects the stored disable-timeout flag`() = runTest(testDispatcher) {
+        val prefs = mockAppStatePrefs(idleDisabled = true)
+        val vm = createViewModel(PostSessionMode.SUMMARY, appStatePrefs = prefs)
+        vm.state.test {
+            val state = awaitLoaded()
+            assertTrue(state.idleTimeoutDisabled)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `battery exempt hides the warning`() = runTest(testDispatcher) {
+        val vm = createViewModel(PostSessionMode.SUMMARY, batteryExempt = true)
+        vm.state.test {
+            val state = awaitLoaded()
+            assertTrue(state.batteryOptimizationExempt)
+            assertFalse("warning hidden when exempt", state.showBatteryWarning)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `not battery exempt shows the warning`() = runTest(testDispatcher) {
+        val vm = createViewModel(PostSessionMode.SUMMARY, batteryExempt = false)
+        vm.state.test {
+            val state = awaitLoaded()
+            assertFalse(state.batteryOptimizationExempt)
+            assertTrue("warning shown when not exempt", state.showBatteryWarning)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `spurious wake stats default to zero`() = runTest(testDispatcher) {
         val vm = createViewModel(PostSessionMode.SUMMARY)
         vm.state.test {
@@ -332,6 +396,13 @@ class SettingsViewModelTest {
         )
     }
 
+    /** Drain the initial loading emission(s) and return the first loaded state. */
+    private suspend fun ReceiveTurbine<SettingsState>.awaitLoaded(): SettingsState {
+        var item = awaitItem()
+        while (item.isLoading) item = awaitItem()
+        return item
+    }
+
     private fun freshSecurityPrefs(): SecurityCheckPreferences {
         val prefs = SecurityCheckPreferences(ApplicationProvider.getApplicationContext())
         runBlocking {
@@ -342,16 +413,41 @@ class SettingsViewModelTest {
         return prefs
     }
 
+    /**
+     * Mock [AppStatePreferences] with controllable idle-timeout reads. Avoids the
+     * real process-singleton DataStore, whose async writes would bleed between
+     * tests sharing this Robolectric VM.
+     */
+    private fun mockAppStatePrefs(
+        idleMinutes: Int = AppStatePreferences.DEFAULT_IDLE_TIMEOUT_MINUTES,
+        idleDisabled: Boolean = false
+    ): AppStatePreferences = mockk(relaxed = true) {
+        every { observeIdleTimeoutMinutes() } returns flowOf(idleMinutes)
+        every { observeIdleTimeoutDisabled() } returns flowOf(idleDisabled)
+        every { observeSecurityCheckIntervalHours() } returns
+            flowOf(AppStatePreferences.DEFAULT_INTERVAL_HOURS)
+    }
+
     private fun createViewModel(
         mode: PostSessionMode,
-        securityPrefs: SecurityCheckPreferences? = null
-    ): SettingsViewModel = createViewModel(mode, securityPrefs, provider = null)
+        securityPrefs: SecurityCheckPreferences? = null,
+        appStatePrefs: AppStatePreferences? = null,
+        batteryExempt: Boolean = false
+    ): SettingsViewModel = createViewModel(
+        mode,
+        securityPrefs,
+        provider = null,
+        appStatePrefs = appStatePrefs,
+        batteryExempt = batteryExempt
+    )
 
     private fun createViewModel(
         mode: PostSessionMode,
         securityPrefs: SecurityCheckPreferences?,
         provider: NotificationSettingsProvider?,
-        spuriousWakesFlow: Flow<SpuriousWakeStats> = flowOf(SpuriousWakeStats.EMPTY)
+        spuriousWakesFlow: Flow<SpuriousWakeStats> = flowOf(SpuriousWakeStats.EMPTY),
+        appStatePrefs: AppStatePreferences? = null,
+        batteryExempt: Boolean = false
     ): SettingsViewModel {
         val resolvedProvider = provider ?: mockk {
             val s = NotificationSettings(
@@ -366,7 +462,6 @@ class SettingsViewModelTest {
         val themePref = mockk<ThemePreference> {
             every { themeMode } returns MutableStateFlow(ThemeMode.AUTO)
         }
-        val appStatePrefs: AppStatePreferences? = null
         return SettingsViewModel(
             resolvedProvider,
             themePref,
@@ -375,6 +470,7 @@ class SettingsViewModelTest {
             emptyList(),
             securityPrefs,
             appStatePrefs,
+            batteryExemptProvider = { batteryExempt },
             spuriousWakesFlow = spuriousWakesFlow
         )
     }

--- a/docs/ux-decisions.md
+++ b/docs/ux-decisions.md
@@ -14,6 +14,51 @@ Newest entries on top.
 
 ---
 
+## 2026-06-02 — Wire the dormant Connection settings; "Fix this" opens battery-optimization settings
+
+**Decision:** Make the previously-inert "Connection" settings cluster functional
+(#453): the idle-timeout dropdown now persists and changes the real timeout, the
+"Disable timeout" switch persists and means "no idle timer," the battery-
+optimization warning shows based on real status (not always-on), and its "Fix
+this" button launches the system battery-optimization settings screen
+(`ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS`).
+
+**Approved by:** Jason, in-session 2026-06-02 — declared #453 a bug (these
+controls were always meant to work), approved rolling the whole cluster into one
+fix ("you can roll this all into one fix on the existing ticket").
+
+**Context:** The entire Connection settings group was built as UI but never wired
+to the ViewModel/destination: `setIdleTimeout` discarded its argument, the
+disable switch's callback was unwired and gated on a `batteryOptimizationExempt`
+flag that was hardcoded `false`, the battery warning's `showBatteryWarning` was
+hardcoded `true` (so every user saw a permanent, non-actionable warning), and the
+"Fix this" button did nothing. This is restoring intended behavior of shipped
+controls, not adding new surfaces — but it does newly *activate* a system screen,
+hence this entry.
+
+**Alternatives considered:**
+- **Direct exemption dialog** (`ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`) —
+  one-tap allow/deny, but requires the `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`
+  permission, which Google Play restricts to apps whose core function needs it.
+  Rejected to avoid Play-policy risk; the settings-list route needs no permission.
+- **Fix only the dropdown, defer the switch/warning** — smaller, but leaves the
+  permanent false battery warning and a second dead control in place; the cluster
+  is one tangled knot, so splitting it ships a still-broken screen.
+
+**Trade-off accepted:** "Fix this" lands the user on the system battery-
+optimization *list* (they pick the app) rather than a one-tap dialog — an extra
+step, accepted in exchange for needing no Play-restricted permission. Also: with
+the idle timeout disabled, the tunnel stays foregrounded until the 6h `dataSync`
+FGS cap stops it (the #452 path) — the intended semantics of the control.
+
+**Relevant:**
+- Filed by the nightly code-health pass as #453; scope expanded in-session.
+- Battery-opt status read shared via `BatteryOptimization` (lifted from
+  `BugReportUriBuilder`). Idle timeout persisted in `AppStatePreferences`, read
+  dynamically by `IdleTimeoutManager` each wake cycle.
+
+---
+
 ## 2026-05-26 — Surface the FGS-budget notification on run-time timeout, not just at startup
 
 **Decision:** When Android calls `Service.onTimeout()` because the `dataSync`

--- a/work/src/main/kotlin/com/rousecontext/work/IdleTimeoutManager.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/IdleTimeoutManager.kt
@@ -19,12 +19,15 @@ import kotlinx.coroutines.launch
  * optional [recorder] is notified so the app can track spurious wakes (wake
  * cycles that never reached ACTIVE).
  *
- * @param timeoutMillis How long to wait in CONNECTED state before triggering disconnect.
+ * @param timeoutProvider Supplies the idle timeout in milliseconds, read each
+ *   time the timer arms (on entering CONNECTED) so a user setting change takes
+ *   effect on the next wake cycle without restarting the service. Returning
+ *   `null` means the idle timeout is disabled — the timer is not armed at all.
  * @param onTimeout Called when the idle timeout fires.
  * @param recorder Optional sink for wake-cycle observability.
  */
 class IdleTimeoutManager(
-    private val timeoutMillis: Long,
+    private val timeoutProvider: suspend () -> Long?,
     private val onTimeout: suspend () -> Unit,
     private val recorder: SpuriousWakeRecorder? = null
 ) {
@@ -60,10 +63,16 @@ class IdleTimeoutManager(
                 when (state) {
                     TunnelState.CONNECTED -> {
                         cycleStarted = true
-                        timerJob = launch {
-                            delay(timeoutMillis)
-                            timeoutFired = true
-                            onTimeout()
+                        // Read the timeout fresh each cycle. null = disabled:
+                        // leave the timer unarmed so the tunnel stays up until
+                        // some other stop (FCM idle, FGS budget) intervenes.
+                        val timeoutMillis = timeoutProvider()
+                        if (timeoutMillis != null) {
+                            timerJob = launch {
+                                delay(timeoutMillis)
+                                timeoutFired = true
+                                onTimeout()
+                            }
                         }
                     }
                     TunnelState.ACTIVE -> {

--- a/work/src/test/kotlin/com/rousecontext/work/IdleTimeoutTest.kt
+++ b/work/src/test/kotlin/com/rousecontext/work/IdleTimeoutTest.kt
@@ -21,7 +21,7 @@ class IdleTimeoutTest {
     fun `CONNECTED without prior ACTIVE fires timeout`() = runTest {
         val disconnected = CompletableDeferred<Unit>()
         val manager = IdleTimeoutManager(
-            timeoutMillis = 30_000L,
+            timeoutProvider = { 30_000L },
             onTimeout = { disconnected.complete(Unit) }
         )
 
@@ -42,7 +42,7 @@ class IdleTimeoutTest {
     fun `timer starts on ACTIVE to CONNECTED transition`() = runTest {
         val disconnected = CompletableDeferred<Unit>()
         val manager = IdleTimeoutManager(
-            timeoutMillis = 30_000L,
+            timeoutProvider = { 30_000L },
             onTimeout = { disconnected.complete(Unit) }
         )
 
@@ -63,7 +63,7 @@ class IdleTimeoutTest {
     fun `stream arrival cancels timer`() = runTest {
         val disconnected = CompletableDeferred<Unit>()
         val manager = IdleTimeoutManager(
-            timeoutMillis = 30_000L,
+            timeoutProvider = { 30_000L },
             onTimeout = { disconnected.complete(Unit) }
         )
 
@@ -87,7 +87,7 @@ class IdleTimeoutTest {
     fun `timer restarts when returning to CONNECTED from ACTIVE`() = runTest {
         val disconnected = CompletableDeferred<Unit>()
         val manager = IdleTimeoutManager(
-            timeoutMillis = 30_000L,
+            timeoutProvider = { 30_000L },
             onTimeout = { disconnected.complete(Unit) }
         )
 
@@ -111,7 +111,7 @@ class IdleTimeoutTest {
     fun `DISCONNECTED cancels timer and resets hasBeenActive`() = runTest {
         val disconnected = CompletableDeferred<Unit>()
         val manager = IdleTimeoutManager(
-            timeoutMillis = 30_000L,
+            timeoutProvider = { 30_000L },
             onTimeout = { disconnected.complete(Unit) }
         )
 
@@ -139,7 +139,7 @@ class IdleTimeoutTest {
     fun `spurious wake recorded when timeout fires without ACTIVE`() = runTest {
         val recorder = FakeSpuriousWakeRecorder()
         val manager = IdleTimeoutManager(
-            timeoutMillis = 30_000L,
+            timeoutProvider = { 30_000L },
             onTimeout = { },
             recorder = recorder
         )
@@ -162,7 +162,7 @@ class IdleTimeoutTest {
     fun `non-spurious wake only increments total`() = runTest {
         val recorder = FakeSpuriousWakeRecorder()
         val manager = IdleTimeoutManager(
-            timeoutMillis = 30_000L,
+            timeoutProvider = { 30_000L },
             onTimeout = { },
             recorder = recorder
         )
@@ -185,7 +185,7 @@ class IdleTimeoutTest {
     fun `multiple wake cycles accumulate correctly`() = runTest {
         val recorder = FakeSpuriousWakeRecorder()
         val manager = IdleTimeoutManager(
-            timeoutMillis = 30_000L,
+            timeoutProvider = { 30_000L },
             onTimeout = { },
             recorder = recorder
         )
@@ -216,6 +216,57 @@ class IdleTimeoutTest {
 
         assertEquals(2, recorder.spuriousCount)
         assertEquals(3, recorder.totalCount)
+        job.cancel()
+    }
+
+    @Test
+    fun `disabled provider never arms the timer`() = runTest {
+        val disconnected = CompletableDeferred<Unit>()
+        val manager = IdleTimeoutManager(
+            // null = idle timeout disabled by the user
+            timeoutProvider = { null },
+            onTimeout = { disconnected.complete(Unit) }
+        )
+
+        val job = launch { manager.observe(stateFlow) }
+
+        stateFlow.value = TunnelState.CONNECTED
+        advanceTimeBy(60 * 60 * 1000L)
+
+        assertFalse(
+            "Timeout must NOT fire when the provider reports disabled (null)",
+            disconnected.isCompleted
+        )
+        assertFalse("timeoutFired flag should stay false", manager.timeoutFired)
+        job.cancel()
+    }
+
+    @Test
+    fun `provider is re-read each cycle so a changed value takes effect`() = runTest {
+        val disconnected = CompletableDeferred<Unit>()
+        var current = 30_000L
+        val manager = IdleTimeoutManager(
+            timeoutProvider = { current },
+            onTimeout = { disconnected.complete(Unit) }
+        )
+
+        val job = launch { manager.observe(stateFlow) }
+
+        // First cycle uses 30s; complete it without firing by going ACTIVE.
+        stateFlow.value = TunnelState.CONNECTED
+        stateFlow.value = TunnelState.ACTIVE
+        stateFlow.value = TunnelState.DISCONNECTED
+        advanceTimeBy(10L)
+
+        // User shortens the timeout; the next CONNECTED cycle must honor it.
+        current = 2_000L
+        stateFlow.value = TunnelState.CONNECTED
+        advanceTimeBy(2_001L)
+
+        assertTrue(
+            "A value changed between cycles must take effect on the next arm",
+            disconnected.isCompleted
+        )
         job.cancel()
     }
 

--- a/work/src/test/kotlin/com/rousecontext/work/TunnelForegroundServiceLifecycleTest.kt
+++ b/work/src/test/kotlin/com/rousecontext/work/TunnelForegroundServiceLifecycleTest.kt
@@ -72,7 +72,7 @@ class TunnelForegroundServiceLifecycleTest {
             every { awaitReadyBlocking(any()) } returns true
         }
         idleTimeoutManager = IdleTimeoutManager(
-            timeoutMillis = Long.MAX_VALUE,
+            timeoutProvider = { Long.MAX_VALUE },
             onTimeout = { /* no-op for tests */ }
         )
 


### PR DESCRIPTION
## Summary
Fixes #453. The whole "Connection" settings cluster was built as UI but never wired to the ViewModel/destination — four inert controls:

| Control | Was |
|---|---|
| Idle-timeout dropdown | `setIdleTimeout` discarded its arg; value hardcoded 5 |
| "Disable timeout" switch | callback unwired; gated on `batteryOptimizationExempt` hardcoded `false` |
| Battery-optimization warning | `showBatteryWarning` hardcoded `true` → shown to every user, always |
| "Fix this" button | callback unwired |

## Changes
- **Persist** idle-timeout minutes + disable flag in `AppStatePreferences` (mirrors the existing `securityCheckIntervalHours` int-pref).
- **`IdleTimeoutManager`** now takes a `suspend () -> Long?` provider, read each CONNECTED cycle (`null` = disabled → timer never arms), so a settings change takes effect on the next wake with no service restart. `AppModule` supplies it from `AppStatePreferences`; the old fixed `IDLE_TIMEOUT_MS` constant is removed.
- **Battery status**: `batteryOptimizationExempt` + `showBatteryWarning` now derive from the real `PowerManager` state via a new shared `BatteryOptimization` helper (lifted from `BugReportUriBuilder`, which now reuses it). Re-read on Settings `ON_RESUME`.
- **"Fix this"** opens `ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS` (no Play-restricted permission, unlike the direct-request intent).

## Tests
- `AppStatePreferencesTest`: idle-minutes + disable round-trip.
- `IdleTimeoutTest`: dynamic provider value, disabled-never-arms, value re-read per cycle.
- `BatteryOptimizationTest`: status read + intent action.
- `SettingsViewModelTest`: persist calls + state reflection for minutes/disable/battery.

## Verification
- [x] `:app` + `:work` `testDebugUnitTest`, `ktlintCheck`, `detekt` all green
- [x] Built + ran on a Pixel 6 Pro (Android 17): selecting **10 min** updates the dropdown live **and survives a force-stop + relaunch** (DataStore round-trip on cold start); Settings renders with no crash
- Note: the FCM-wake → `IdleTimeoutManager` path itself isn't exercisable in CI; the manager logic is unit-tested and the persist/read round-trip is device-verified

## UX
`docs/ux-decisions.md` entry added — the one rule-touching bit is activating the battery-opt **system screen** via the (already-present) "Fix this" button. Scope approved in-session.

Behavior note: with the idle timeout disabled the tunnel stays foregrounded until the 6h `dataSync` FGS cap stops it (the #452 path) — intended semantics.

Fixes #453