### PR TITLE
Extract shared ReadinessGate (#454)

### DIFF
--- a/app/src/main/java/com/rousecontext/app/registry/IntegrationProviderRegistry.kt
+++ b/app/src/main/java/com/rousecontext/app/registry/IntegrationProviderRegistry.kt
@@ -4,9 +4,7 @@ import com.rousecontext.api.IntegrationStateStore
 import com.rousecontext.api.McpIntegration
 import com.rousecontext.mcp.core.McpServerProvider
 import com.rousecontext.mcp.core.ProviderRegistry
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import kotlinx.coroutines.CompletableDeferred
+import com.rousecontext.mcp.core.ReadinessGate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -47,8 +45,7 @@ class IntegrationProviderRegistry(
     /** Live snapshot of enabled integration IDs. Exposed for tests and UI. */
     val enabledIds: StateFlow<Set<String>> = _enabledIds.asStateFlow()
 
-    private val readyDeferred = CompletableDeferred<Unit>()
-    private val readyLatch = CountDownLatch(1)
+    private val readinessGate = ReadinessGate()
 
     init {
         val flows = integrations.map { integration ->
@@ -73,11 +70,8 @@ class IntegrationProviderRegistry(
     }
 
     private fun signalReady() {
-        // Idempotent: subsequent emissions just no-op on the already-completed signals.
-        readyDeferred.complete(Unit)
-        if (readyLatch.count > 0) {
-            readyLatch.countDown()
-        }
+        // Idempotent: subsequent emissions just no-op on the already-ready gate.
+        readinessGate.signalReady()
     }
 
     override fun providerForPath(path: String): McpServerProvider? {
@@ -92,9 +86,9 @@ class IntegrationProviderRegistry(
         .toSet()
 
     override suspend fun awaitReady() {
-        readyDeferred.await()
+        readinessGate.awaitReady()
     }
 
     override fun awaitReadyBlocking(timeoutMs: Long): Boolean =
-        readyLatch.await(timeoutMs, TimeUnit.MILLISECONDS)
+        readinessGate.awaitReadyBlocking(timeoutMs)
 }

--- a/app/src/main/java/com/rousecontext/app/registry/OutreachIntegration.kt
+++ b/app/src/main/java/com/rousecontext/app/registry/OutreachIntegration.kt
@@ -8,9 +8,7 @@ import com.rousecontext.api.McpIntegration
 import com.rousecontext.app.state.IntegrationSettingsStore
 import com.rousecontext.integrations.outreach.OutreachMcpProvider
 import com.rousecontext.mcp.core.McpServerProvider
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import kotlinx.coroutines.CompletableDeferred
+import com.rousecontext.mcp.core.ReadinessGate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -31,7 +29,7 @@ import kotlinx.coroutines.launch
  * holds the `false` default — so a tool call that fired immediately after process
  * spawn would route through the notification fallback even when the user had
  * opted into direct launch. Tool callers go through [isDirectLaunchAllowed], which
- * suspends on [readyDeferred] until the first emission has been collected.
+ * suspends on [awaitReady] until the first emission has been collected.
  */
 class OutreachIntegration(
     private val context: Context,
@@ -55,8 +53,7 @@ class OutreachIntegration(
     private val _directLaunchEnabled = MutableStateFlow(false)
     val directLaunchEnabled: StateFlow<Boolean> = _directLaunchEnabled.asStateFlow()
 
-    private val readyDeferred = CompletableDeferred<Unit>()
-    private val readyLatch = CountDownLatch(1)
+    private val readinessGate = ReadinessGate()
 
     init {
         appScope.launch {
@@ -70,11 +67,8 @@ class OutreachIntegration(
     }
 
     private fun signalReady() {
-        // Idempotent: subsequent emissions just no-op on the already-completed signals.
-        readyDeferred.complete(Unit)
-        if (readyLatch.count > 0) {
-            readyLatch.countDown()
-        }
+        // Idempotent: subsequent emissions just no-op on the already-ready gate.
+        readinessGate.signalReady()
     }
 
     /**
@@ -83,7 +77,7 @@ class OutreachIntegration(
      * [com.rousecontext.mcp.core.ProviderRegistry.awaitReady] shape.
      */
     suspend fun awaitReady() {
-        readyDeferred.await()
+        readinessGate.awaitReady()
     }
 
     /**
@@ -91,8 +85,7 @@ class OutreachIntegration(
      * [com.rousecontext.mcp.core.ProviderRegistry.awaitReadyBlocking];
      * not currently exercised in production but provided for parity.
      */
-    fun awaitReadyBlocking(timeoutMs: Long): Boolean =
-        readyLatch.await(timeoutMs, TimeUnit.MILLISECONDS)
+    fun awaitReadyBlocking(timeoutMs: Long): Boolean = readinessGate.awaitReadyBlocking(timeoutMs)
 
     /**
      * Returns whether direct-activity launch is allowed right now. Suspends

--- a/app/src/main/java/com/rousecontext/app/state/DeviceRegistrationStatus.kt
+++ b/app/src/main/java/com/rousecontext/app/state/DeviceRegistrationStatus.kt
@@ -1,8 +1,6 @@
 package com.rousecontext.app.state
 
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import kotlinx.coroutines.CompletableDeferred
+import com.rousecontext.mcp.core.ReadinessGate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -50,8 +48,7 @@ class DeviceRegistrationStatus internal constructor(
     private val _complete = MutableStateFlow(initiallyRegistered)
     val complete: StateFlow<Boolean> = _complete.asStateFlow()
 
-    private val readyDeferred = CompletableDeferred<Unit>()
-    private val readyLatch = CountDownLatch(1)
+    private val readinessGate = ReadinessGate()
 
     init {
         if (initiallyReady) {
@@ -64,10 +61,7 @@ class DeviceRegistrationStatus internal constructor(
     }
 
     internal fun signalReady() {
-        readyDeferred.complete(Unit)
-        if (readyLatch.count > 0) {
-            readyLatch.countDown()
-        }
+        readinessGate.signalReady()
     }
 
     /**
@@ -89,15 +83,14 @@ class DeviceRegistrationStatus internal constructor(
      * authoritative on-disk answer (i.e. it is no longer the pre-load default).
      */
     suspend fun awaitReady() {
-        readyDeferred.await()
+        readinessGate.awaitReady()
     }
 
     /**
      * Thread-blocking variant of [awaitReady]. MUST NOT be called from the main
      * thread.
      */
-    fun awaitReadyBlocking(timeoutMs: Long): Boolean =
-        readyLatch.await(timeoutMs, TimeUnit.MILLISECONDS)
+    fun awaitReadyBlocking(timeoutMs: Long): Boolean = readinessGate.awaitReadyBlocking(timeoutMs)
 
     companion object {
         /**

--- a/app/src/main/java/com/rousecontext/app/state/SecurityAlertGate.kt
+++ b/app/src/main/java/com/rousecontext/app/state/SecurityAlertGate.kt
@@ -1,8 +1,6 @@
 package com.rousecontext.app.state
 
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import kotlinx.coroutines.CompletableDeferred
+import com.rousecontext.mcp.core.ReadinessGate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,8 +34,7 @@ import kotlinx.coroutines.launch
  */
 class SecurityAlertGate(source: Flow<Boolean>, scope: CoroutineScope) {
 
-    private val readyDeferred = CompletableDeferred<Unit>()
-    private val readyLatch = CountDownLatch(1)
+    private val readinessGate = ReadinessGate()
     private val flag = MutableStateFlow(false)
 
     init {
@@ -50,11 +47,8 @@ class SecurityAlertGate(source: Flow<Boolean>, scope: CoroutineScope) {
     }
 
     private fun signalReady() {
-        // Idempotent: subsequent emissions just no-op on the already-completed signals.
-        readyDeferred.complete(Unit)
-        if (readyLatch.count > 0) {
-            readyLatch.countDown()
-        }
+        // Idempotent: subsequent emissions just no-op on the already-ready gate.
+        readinessGate.signalReady()
     }
 
     /**
@@ -62,7 +56,7 @@ class SecurityAlertGate(source: Flow<Boolean>, scope: CoroutineScope) {
      * immediately. After this returns, [isAlerting] reflects the loaded state.
      */
     suspend fun awaitReady() {
-        readyDeferred.await()
+        readinessGate.awaitReady()
     }
 
     /**
@@ -70,8 +64,7 @@ class SecurityAlertGate(source: Flow<Boolean>, scope: CoroutineScope) {
      * signalled within [timeoutMs], `false` otherwise. MUST NOT be called from
      * the main thread.
      */
-    fun awaitReadyBlocking(timeoutMs: Long): Boolean =
-        readyLatch.await(timeoutMs, TimeUnit.MILLISECONDS)
+    fun awaitReadyBlocking(timeoutMs: Long): Boolean = readinessGate.awaitReadyBlocking(timeoutMs)
 
     /**
      * Returns the current alert verdict. Suspends until the first emission of

--- a/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/ReadinessGate.kt
+++ b/core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/ReadinessGate.kt
@@ -1,0 +1,53 @@
+package com.rousecontext.mcp.core
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * One-shot "first emission has landed" gate.
+ *
+ * Several DataStore-backed holders need to suspend (or block) until their backing
+ * flow has emitted at least once, so that the very first request after a cold-start
+ * FCM wake cannot read a pre-load default. This gate owns the paired
+ * [CompletableDeferred] (for suspending callers) and [CountDownLatch] (for callers
+ * that cannot suspend, e.g. the FCM service's background worker thread) and keeps
+ * the two in sync.
+ *
+ * Mirrors the [ProviderRegistry.awaitReady] / [ProviderRegistry.awaitReadyBlocking]
+ * contract; see issue #414 / #416 for why this primitive is load-bearing on the
+ * cold-start path.
+ *
+ * Signalling is idempotent: [signalReady] may be called any number of times (e.g.
+ * once per flow emission) and only the first call has effect.
+ */
+class ReadinessGate {
+
+    private val readyDeferred = CompletableDeferred<Unit>()
+    private val readyLatch = CountDownLatch(1)
+
+    /**
+     * Marks the gate ready, unblocking any current and future [awaitReady] /
+     * [awaitReadyBlocking] callers. Idempotent: subsequent calls no-op on the
+     * already-completed signals.
+     */
+    fun signalReady() {
+        readyDeferred.complete(Unit)
+        if (readyLatch.count > 0) {
+            readyLatch.countDown()
+        }
+    }
+
+    /** Suspends until [signalReady] has been called. Returns immediately once ready. */
+    suspend fun awaitReady() {
+        readyDeferred.await()
+    }
+
+    /**
+     * Thread-blocking variant of [awaitReady]. Returns `true` if the gate became
+     * ready within [timeoutMs], `false` otherwise. MUST NOT be called from the
+     * main thread.
+     */
+    fun awaitReadyBlocking(timeoutMs: Long): Boolean =
+        readyLatch.await(timeoutMs, TimeUnit.MILLISECONDS)
+}

--- a/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/core/ReadinessGateTest.kt
+++ b/core/mcp/src/jvmTest/kotlin/com/rousecontext/mcp/core/ReadinessGateTest.kt
@@ -1,0 +1,63 @@
+package com.rousecontext.mcp.core
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReadinessGateTest {
+
+    @Test
+    fun `awaitReadyBlocking returns false before signal`() {
+        val gate = ReadinessGate()
+        assertFalse(gate.awaitReadyBlocking(timeoutMs = 20))
+    }
+
+    @Test
+    fun `awaitReadyBlocking returns true after signal`() {
+        val gate = ReadinessGate()
+        gate.signalReady()
+        assertTrue(gate.awaitReadyBlocking(timeoutMs = 20))
+    }
+
+    @Test
+    fun `awaitReady suspends until signalled then resumes`() = runBlocking {
+        val gate = ReadinessGate()
+        val resumed = CompletableDeferred<Unit>()
+        val waiter = launch {
+            gate.awaitReady()
+            resumed.complete(Unit)
+        }
+
+        // Not signalled yet: the waiter must still be suspended.
+        assertFalse(resumed.isCompleted)
+
+        gate.signalReady()
+
+        withTimeout(1_000) { resumed.await() }
+        assertTrue(resumed.isCompleted)
+        waiter.cancelAndJoin()
+    }
+
+    @Test
+    fun `awaitReady returns immediately when already signalled`() = runBlocking {
+        val gate = ReadinessGate()
+        gate.signalReady()
+        withTimeout(1_000) { gate.awaitReady() }
+    }
+
+    @Test
+    fun `double signal is safe and idempotent`() = runBlocking {
+        val gate = ReadinessGate()
+        gate.signalReady()
+        gate.signalReady()
+        gate.signalReady()
+
+        assertTrue(gate.awaitReadyBlocking(timeoutMs = 20))
+        withTimeout(1_000) { gate.awaitReady() }
+    }
+}


### PR DESCRIPTION
## What

Four classes independently hand-rolled the identical "suspend/block until the backing flow has emitted at least once" primitive — a `CompletableDeferred<Unit>` + `CountDownLatch(1)` pair with byte-for-byte identical `signalReady()` / `awaitReady()` / `awaitReadyBlocking(timeoutMs)` bodies. This change extracts a single tested `ReadinessGate` helper and has all four classes delegate to it.

## Where the helper lives + why

`core/mcp/src/jvmMain/kotlin/com/rousecontext/mcp/core/ReadinessGate.kt`, alongside the `ProviderRegistry` interface that already documents this exact `awaitReady` / `awaitReadyBlocking` contract (issue #414/#416). All four consumers are `:app`-only and `:app` already depends on `:core:mcp`, so this introduces no new dependency edge — it's the lowest-friction home that all four can import. `CompletableDeferred` is already used elsewhere in `:core:mcp/jvmMain`; `CountDownLatch` is JVM stdlib.

## Pure refactor — no behavior change

Each class's observable behavior is identical. The gate preserves the existing semantics exactly: idempotent signal, deferred + latch kept in sync, blocking variant timing out via `CountDownLatch.await(timeoutMs, MILLISECONDS)`. When `signalReady` fires and the `signalReady` bodies are unchanged in timing/placement — only the storage of the primitive moved. All pre-existing tests (`IntegrationProviderRegistryTest`, `OutreachIntegrationTest`, `SecurityAlertGateTest`, `DeviceRegistrationStatusTest`) pass unmodified.

## Test added

`core/mcp/src/jvmTest/.../ReadinessGateTest.kt` — covers: `awaitReadyBlocking` false before signal / true after; `awaitReady` suspends until signalled then resumes; `awaitReady` returns immediately when already signalled; double/triple signal is safe and idempotent.

## Note on the OutreachIntegration "parity" method

The issue suggested `OutreachIntegration.awaitReadyBlocking` ("not currently exercised in production but provided for parity") could disappear. It does NOT fall away naturally — the existing `OutreachIntegrationTest` directly exercises `integration.awaitReadyBlocking(...)`. Removing it would require modifying an existing test, which the refactor rules forbid. It's kept and now delegates to the gate (one-liner, no longer a copy-pasted body).

## Migrated
- `IntegrationProviderRegistry`
- `DeviceRegistrationStatus`
- `SecurityAlertGate`
- `OutreachIntegration`

## Verification
- `:core:mcp:jvmTest` + `:app:testDebugUnitTest` — pass
- `ktlintCheck` + `detekt` — clean (ktlintFormat applied to collapse the now-shorter delegating one-liners)

Fixes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)