### PR TITLE
Deduplicate graceful-shutdown sequence (#455)

### DIFF
--- a/app/src/main/java/com/rousecontext/app/di/AppModule.kt
+++ b/app/src/main/java/com/rousecontext/app/di/AppModule.kt
@@ -114,19 +114,16 @@ import com.rousecontext.work.SpuriousWakePreferences
 import com.rousecontext.work.SpuriousWakeRecorder
 import com.rousecontext.work.StoredCertVerifierSource
 import com.rousecontext.work.WakelockManager
+import com.rousecontext.work.gracefulTunnelShutdown
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
-
-/** How long to wait for graceful MCP session shutdown before forcing tunnel disconnect. */
-private const val GRACEFUL_SHUTDOWN_TIMEOUT_MS = 5_000L
 
 /**
  * crt.sh issuer names that are legitimate for Rouse Context certificates.
@@ -596,8 +593,7 @@ val appModule = module {
                 }
             },
             onTimeout = {
-                withTimeoutOrNull(GRACEFUL_SHUTDOWN_TIMEOUT_MS) { mcpSession.shutdown() }
-                tunnelClient.disconnect()
+                gracefulTunnelShutdown(mcpSession, tunnelClient)
             },
             recorder = recorder
         )

--- a/work/src/main/kotlin/com/rousecontext/work/GracefulTunnelShutdown.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/GracefulTunnelShutdown.kt
@@ -1,0 +1,26 @@
+package com.rousecontext.work
+
+import com.rousecontext.mcp.core.McpSession
+import com.rousecontext.tunnel.TunnelClient
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * How long to wait for graceful MCP session shutdown before forcing tunnel
+ * disconnect. Single source of truth for the #446 teardown contract.
+ */
+const val GRACEFUL_SHUTDOWN_TIMEOUT_MS = 5_000L
+
+/**
+ * Tears down the tunnel gracefully per the #446 contract: close MCP sessions
+ * cleanly (bounded by [GRACEFUL_SHUTDOWN_TIMEOUT_MS] so a wedged transport
+ * can't block teardown forever), then drop the tunnel.
+ *
+ * This is the single shared seam called from both the
+ * [TunnelForegroundService] `onDestroy` path and the `IdleTimeoutManager`
+ * `onTimeout` lambda (wired in the :app Koin module). It deliberately does NOT
+ * introduce its own coroutine scope — callers invoke it from their own scope.
+ */
+suspend fun gracefulTunnelShutdown(mcpSession: McpSession, tunnelClient: TunnelClient) {
+    withTimeoutOrNull(GRACEFUL_SHUTDOWN_TIMEOUT_MS) { mcpSession.shutdown() }
+    tunnelClient.disconnect()
+}

--- a/work/src/main/kotlin/com/rousecontext/work/TunnelForegroundService.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/TunnelForegroundService.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.withTimeoutOrNull
 import org.koin.android.ext.android.inject
 import org.koin.core.qualifier.named
 
@@ -315,8 +314,7 @@ class TunnelForegroundService : LifecycleService() {
         reconnectJob?.cancel()
         reconnectJob = null
         lifecycleScope.launch {
-            withTimeoutOrNull(GRACEFUL_SHUTDOWN_TIMEOUT_MS) { mcpSession.shutdown() }
-            tunnelClient.disconnect()
+            gracefulTunnelShutdown(mcpSession, tunnelClient)
         }
         super.onDestroy()
     }
@@ -374,7 +372,6 @@ class TunnelForegroundService : LifecycleService() {
         private const val TAG = "TunnelForegroundService"
         const val NOTIFICATION_ID = 1
 
-        private const val GRACEFUL_SHUTDOWN_TIMEOUT_MS = 5_000L
         private const val INITIAL_RECONNECT_DELAY_MS = 1_000L
         private const val MAX_RECONNECT_DELAY_MS = 30_000L
         private const val RECONNECT_GIVE_UP_MS = 5 * 60 * 1000L

--- a/work/src/test/kotlin/com/rousecontext/work/GracefulTunnelShutdownTest.kt
+++ b/work/src/test/kotlin/com/rousecontext/work/GracefulTunnelShutdownTest.kt
@@ -1,0 +1,54 @@
+package com.rousecontext.work
+
+import com.rousecontext.mcp.core.McpSession
+import com.rousecontext.tunnel.TunnelClient
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the shared [gracefulTunnelShutdown] seam (issue #455).
+ *
+ * This is the single source of truth for the #446 teardown contract:
+ * "close MCP sessions cleanly, bounded by a timeout, then drop the tunnel."
+ */
+class GracefulTunnelShutdownTest {
+
+    @Test
+    fun `calls shutdown then disconnect in order`() = kotlinx.coroutines.runBlocking {
+        val mcpSession = mockk<McpSession>(relaxed = true)
+        val tunnelClient = mockk<TunnelClient>(relaxed = true)
+
+        gracefulTunnelShutdown(mcpSession, tunnelClient)
+
+        coVerifyOrder {
+            mcpSession.shutdown()
+            tunnelClient.disconnect()
+        }
+    }
+
+    @Test
+    fun `disconnect still runs when shutdown hangs past the timeout`() =
+        kotlinx.coroutines.runBlocking {
+            val shutdownEntered = CompletableDeferred<Unit>()
+            val mcpSession = mockk<McpSession>(relaxed = true)
+            val tunnelClient = mockk<TunnelClient>(relaxed = true)
+
+            // shutdown() never completes — it must be bounded by the timeout so
+            // disconnect() still runs (withTimeoutOrNull contract).
+            coEvery { mcpSession.shutdown() } coAnswers {
+                shutdownEntered.complete(Unit)
+                delay(GRACEFUL_SHUTDOWN_TIMEOUT_MS * 10)
+            }
+
+            gracefulTunnelShutdown(mcpSession, tunnelClient)
+
+            assertTrue("shutdown should have been entered", shutdownEntered.isCompleted)
+            coVerify { tunnelClient.disconnect() }
+        }
+}


### PR DESCRIPTION
## Summary

The #446 graceful-teardown sequence was copied into two modules, each with its own `GRACEFUL_SHUTDOWN_TIMEOUT_MS = 5_000L`:

- `TunnelForegroundService.onDestroy` (`:work`)
- the `IdleTimeoutManager.onTimeout` lambda wired in `AppModule` (`:app`), with a top-level private constant

Both encode the same contract — "close MCP sessions cleanly, bounded by a timeout, then drop the tunnel." Tuning one (timeout, ordering, an added step) would silently drift the other, and they live in different modules.

## Change

Factored the sequence into a single shared seam:

```kotlin
suspend fun gracefulTunnelShutdown(mcpSession: McpSession, tunnelClient: TunnelClient) {
    withTimeoutOrNull(GRACEFUL_SHUTDOWN_TIMEOUT_MS) { mcpSession.shutdown() }
    tunnelClient.disconnect()
}
```

**Where it lives:** new `work/src/main/kotlin/com/rousecontext/work/GracefulTunnelShutdown.kt`, holding both the function and the single `GRACEFUL_SHUTDOWN_TIMEOUT_MS`. `:work` is the lowest module that already depends on both `:core:mcp` (`McpSession`) and `:core:tunnel` (`TunnelClient`), and `:app` depends on `:work` — so both call sites import it cleanly with no dependency-direction change. Confirmed it compiles in both modules.

Both call sites now invoke the shared function; the two duplicate constant declarations are removed.

## Pure refactor — no behavior change

- Ordering preserved: shutdown-bounded-by-timeout **then** disconnect.
- The 5s timeout value is unchanged.
- `onDestroy` keeps its exact `lifecycleScope.launch { ... }` structure (the body is just replaced by the call); scoping/launch behavior untouched.
- The function introduces no scope of its own — it's a plain `suspend fun` called from the existing scopes.

## Test

Added `GracefulTunnelShutdownTest` covering the #446 contract directly:
- calls `mcpSession.shutdown()` then `tunnelClient.disconnect()` in order, and
- a hanging `shutdown()` is bounded by the timeout while `disconnect()` still runs.

The existing `TunnelForegroundServiceLifecycleTest` (onDestroy/onTimeout coverage) passes unmodified.

## Verification

- `:work:testDebugUnitTest` — green
- `:app:testDebugUnitTest` — green
- `ktlintCheck detekt` — green

Fixes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)