### PR TITLE
Add Certspotter fallback for CT-log checks

### DIFF
--- a/app/src/main/java/com/rousecontext/app/di/AppModule.kt
+++ b/app/src/main/java/com/rousecontext/app/di/AppModule.kt
@@ -83,6 +83,8 @@ import com.rousecontext.notifications.create
 import com.rousecontext.tunnel.CertProvisioningFlow
 import com.rousecontext.tunnel.CertRenewalFlow
 import com.rousecontext.tunnel.CertificateStore
+import com.rousecontext.tunnel.CertspotterCtLogFetcher
+import com.rousecontext.tunnel.CompositeCtLogFetcher
 import com.rousecontext.tunnel.CsrGenerator
 import com.rousecontext.tunnel.CtLogFetcher
 import com.rousecontext.tunnel.CtLogMonitor
@@ -414,7 +416,16 @@ val appModule = module {
     }
 
     // --- Security checks (SecurityCheckWorker dependencies) ---
-    single<CtLogFetcher> { HttpCtLogFetcher() }
+    // crt.sh (primary) flaps with 502/503 for minutes at a time, outlasting
+    // HttpCtLogFetcher's retry window. Certspotter is queried as a fallback so a
+    // crt.sh outage becomes a silent successful check instead of a false
+    // "Could not reach CT log service" warning. See CompositeCtLogFetcher.
+    single<CtLogFetcher> {
+        CompositeCtLogFetcher(
+            primary = HttpCtLogFetcher(),
+            fallback = CertspotterCtLogFetcher()
+        )
+    }
     single {
         CtLogMonitor(
             certificateStore = get(),

--- a/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/CertspotterCtLogFetcher.kt
+++ b/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/CertspotterCtLogFetcher.kt
@@ -1,0 +1,66 @@
+package com.rousecontext.tunnel
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.isSuccess
+import java.io.IOException
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Fallback [CtLogFetcher] that queries the Certspotter API for certificates
+ * issued to the device's subdomain. Used by [CompositeCtLogFetcher] only after
+ * the primary crt.sh source has already failed: crt.sh (community-run) returns
+ * 502/503 for minutes at a time, outlasting [HttpCtLogFetcher]'s retry window,
+ * which would otherwise surface a false "Could not reach CT log service" warning.
+ *
+ * Certspotter returns a JSON array of issuance objects, each with a nested
+ * `issuer.name` DN string. VERIFIED against live data: that string is
+ * byte-identical to crt.sh's `issuer_name` (same `C=US, O=..., CN=...` DN order
+ * and comma-space separators), so no normalization is needed -- we map each
+ * issuance's `issuer.name` straight into a crt.sh-shaped [CtLogEntry.issuerName].
+ * The translated JSON is then parsed by [CtLogMonitor] exactly as a crt.sh
+ * response would be, keeping the monitor and the crt.sh path 100% untouched.
+ *
+ * Error handling mirrors [HttpCtLogFetcher]: a non-2xx status throws an
+ * [IOException]; network errors propagate. No internal retry -- the composite
+ * only reaches this source after crt.sh failed, and we stay within the 30s
+ * security-check worker budget.
+ */
+class CertspotterCtLogFetcher(
+    private val httpClient: HttpClient = RelayApiClient.createDefaultClient(),
+    private val baseUrl: String = DEFAULT_CERTSPOTTER_URL
+) : CtLogFetcher {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun fetch(domain: String): String {
+        val response = httpClient.get(baseUrl) {
+            parameter("domain", domain)
+            parameter("include_subdomains", "true")
+            parameter("expand", "issuer")
+        }
+        if (!response.status.isSuccess()) {
+            throw IOException("certspotter returned HTTP ${response.status.value}")
+        }
+        val issuances = json.decodeFromString<List<CertspotterIssuance>>(response.bodyAsText())
+        // Map each issuance's issuer.name straight into a crt.sh-shaped entry.
+        // The monitor only reads issuer_name, so the other fields stay default.
+        val entries = issuances.map { CtLogEntry(issuerName = it.issuer.name) }
+        return json.encodeToString(entries)
+    }
+
+    @Serializable
+    private data class CertspotterIssuance(val issuer: CertspotterIssuer = CertspotterIssuer())
+
+    @Serializable
+    private data class CertspotterIssuer(@SerialName("name") val name: String = "")
+
+    companion object {
+        /** Public Certspotter issuances query endpoint. */
+        const val DEFAULT_CERTSPOTTER_URL = "https://api.certspotter.com/v1/issuances"
+    }
+}

--- a/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/CompositeCtLogFetcher.kt
+++ b/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/CompositeCtLogFetcher.kt
@@ -1,0 +1,36 @@
+package com.rousecontext.tunnel
+
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Composite [CtLogFetcher] that tries [primary] (crt.sh) first and falls back to
+ * [fallback] (Certspotter) on any failure. crt.sh frequently returns 502/503 for
+ * minutes at a time -- longer than [HttpCtLogFetcher]'s retry window -- which used
+ * to surface a false "Could not reach CT log service" warning even though the
+ * certificate set was unchanged. Querying a second, independent CT source on
+ * primary failure turns those crt.sh outages into silent successful checks while
+ * preserving real security coverage.
+ *
+ * If BOTH sources fail, the PRIMARY's exception is rethrown so the monitor's
+ * existing "Could not reach CT log service: <crt.sh message>" warning text stays
+ * meaningful. Coroutine cancellation is never swallowed.
+ */
+class CompositeCtLogFetcher(private val primary: CtLogFetcher, private val fallback: CtLogFetcher) :
+    CtLogFetcher {
+
+    override suspend fun fetch(domain: String): String = try {
+        primary.fetch(domain)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (primaryError: Exception) {
+        try {
+            fallback.fetch(domain)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // Both sources failed: surface the primary (crt.sh) error so the
+            // monitor's warning wording stays accurate.
+            throw primaryError
+        }
+    }
+}

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/CertspotterCtLogFetcherTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/CertspotterCtLogFetcherTest.kt
@@ -1,0 +1,109 @@
+package com.rousecontext.tunnel
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import java.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+
+/**
+ * Unit tests for [CertspotterCtLogFetcher], the fallback CT source used when
+ * crt.sh is unreachable. The critical guarantee these tests lock in: Certspotter's
+ * `issuer.name` string is byte-identical to crt.sh's `issuer_name` (same DN order +
+ * comma-space), so the translated crt.sh-shaped JSON parses to the exact same
+ * issuer set [CtLogMonitor] compares against -- zero normalization, zero false
+ * Alert risk.
+ */
+class CertspotterCtLogFetcherTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `fetch translates certspotter issuers into crt sh shaped json`(): Unit = runBlocking {
+        // A real-shaped Certspotter response: a JSON array of issuance objects,
+        // each with a nested issuer{name} whose value is the full DN string.
+        val certspotterJson = """
+            [
+              {
+                "id": "1",
+                "issuer": { "name": "C=US, O=Google Trust Services, CN=WR1" },
+                "dns_names": ["abc123.rousecontext.com"]
+              },
+              {
+                "id": "2",
+                "issuer": { "name": "C=US, O=Let's Encrypt, CN=R13" },
+                "dns_names": ["abc123.rousecontext.com"]
+              }
+            ]
+        """.trimIndent()
+        val httpClient = mockClient(certspotterJson, HttpStatusCode.OK)
+        val fetcher = CertspotterCtLogFetcher(httpClient = httpClient)
+
+        val result = fetcher.fetch("abc123.rousecontext.com")
+
+        // Parse the returned string exactly as CtLogMonitor does and assert the
+        // issuer_name set is byte-identical to the certspotter issuer.name values.
+        val entries = json.decodeFromString(ListSerializer(CtLogEntry.serializer()), result)
+        assertEquals(
+            setOf(
+                "C=US, O=Google Trust Services, CN=WR1",
+                "C=US, O=Let's Encrypt, CN=R13"
+            ),
+            entries.map { it.issuerName }.toSet()
+        )
+
+        httpClient.close()
+    }
+
+    @Test
+    fun `fetch returns empty array for empty certspotter response`(): Unit = runBlocking {
+        val httpClient = mockClient("[]", HttpStatusCode.OK)
+        val fetcher = CertspotterCtLogFetcher(httpClient = httpClient)
+
+        val result = fetcher.fetch("abc123.rousecontext.com")
+
+        val entries = json.decodeFromString(ListSerializer(CtLogEntry.serializer()), result)
+        assertTrue(entries.isEmpty(), "Empty certspotter array must parse to empty list")
+
+        httpClient.close()
+    }
+
+    @Test
+    fun `fetch throws IOException on non-2xx`(): Unit = runBlocking {
+        val httpClient = mockClient("upstream error", HttpStatusCode.BadGateway)
+        val fetcher = CertspotterCtLogFetcher(httpClient = httpClient)
+
+        val thrown = assertFailsWith<IOException> {
+            fetcher.fetch("abc123.rousecontext.com")
+        }
+        assertTrue(
+            thrown.message!!.contains("502"),
+            "Status code must appear in exception message, was: ${thrown.message}"
+        )
+
+        httpClient.close()
+    }
+
+    private fun mockClient(body: String, status: HttpStatusCode): HttpClient =
+        HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    respond(
+                        content = ByteReadChannel(body),
+                        status = status,
+                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                    )
+                }
+            }
+        }
+}

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/CompositeCtLogFetcherTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/CompositeCtLogFetcherTest.kt
@@ -1,0 +1,73 @@
+package com.rousecontext.tunnel
+
+import java.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Unit tests for [CompositeCtLogFetcher]: try primary (crt.sh); on ANY failure
+ * try the fallback (certspotter); if the fallback also fails, rethrow the PRIMARY's
+ * exception so [CtLogMonitor]'s "Could not reach CT log service: <crt.sh message>"
+ * warning stays meaningful.
+ */
+class CompositeCtLogFetcherTest {
+
+    private fun fetcher(block: suspend (String) -> String): CtLogFetcher = object : CtLogFetcher {
+        override suspend fun fetch(domain: String): String = block(domain)
+    }
+
+    @Test
+    fun `primary success does not invoke fallback`(): Unit = runBlocking {
+        var fallbackInvoked = false
+        val composite = CompositeCtLogFetcher(
+            primary = fetcher { "primary-result" },
+            fallback = fetcher {
+                fallbackInvoked = true
+                "fallback-result"
+            }
+        )
+
+        val result = composite.fetch("abc123.rousecontext.com")
+
+        assertEquals("primary-result", result)
+        assertFalse(fallbackInvoked, "Fallback must not be invoked when primary succeeds")
+    }
+
+    @Test
+    fun `primary failure invokes fallback and returns fallback value`(): Unit = runBlocking {
+        var fallbackInvoked = false
+        val composite = CompositeCtLogFetcher(
+            primary = fetcher { throw IOException("crt.sh returned HTTP 502") },
+            fallback = fetcher {
+                fallbackInvoked = true
+                "fallback-result"
+            }
+        )
+
+        val result = composite.fetch("abc123.rousecontext.com")
+
+        assertTrue(fallbackInvoked, "Fallback must be invoked when primary fails")
+        assertEquals("fallback-result", result)
+    }
+
+    @Test
+    fun `both fail rethrows primary exception`(): Unit = runBlocking {
+        val composite = CompositeCtLogFetcher(
+            primary = fetcher { throw IOException("crt.sh returned HTTP 502") },
+            fallback = fetcher { throw IOException("certspotter returned HTTP 503") }
+        )
+
+        val thrown = assertFailsWith<IOException> {
+            composite.fetch("abc123.rousecontext.com")
+        }
+        assertEquals(
+            "crt.sh returned HTTP 502",
+            thrown.message,
+            "When both sources fail, the PRIMARY (crt.sh) error must be surfaced"
+        )
+    }
+}


### PR DESCRIPTION
## Problem

The Certificate Transparency security check (`CtLogMonitor`) queries crt.sh via `HttpCtLogFetcher`. crt.sh (community-run, maintained by Sectigo) frequently returns 502/503 for minutes at a time. The existing per-request retry (1s/3s/9s, #256) plus cross-run debounce (3 consecutive failures, #256/#429) reduce but don't eliminate user-facing "Could not reach CT log service" warnings, because crt.sh outages outlast the retry window. Those residual warnings are crt.sh being down, not a real reachability problem.

There is no GitHub issue for this — it's a direct user-requested reliability fix.

## Fix

Add a second, independent CT source (Certspotter) consulted **only after** crt.sh has already failed, so a crt.sh outage becomes a silent successful check instead of a warning — while preserving real security coverage.

- **`CompositeCtLogFetcher(primary, fallback)`** — `fetch` tries crt.sh; on any failure tries certspotter; if **both** fail, rethrows the **primary** (crt.sh) error so the monitor's "Could not reach CT log service: \<crt.sh message\>" wording stays accurate. `CancellationException` is rethrown explicitly (structured-concurrency rule).
- **`CertspotterCtLogFetcher`** — GET `api.certspotter.com/v1/issuances` (`domain`, `include_subdomains=true`, `expand=issuer`), then translates the certspotter issuance array into crt.sh-shaped JSON (`List<CtLogEntry>`) that `CtLogMonitor` already parses. Non-2xx throws `IOException`; network errors propagate; no internal retry (the composite only reaches it after crt.sh failed, staying within the 30s worker budget).
- Wire `AppModule`'s `CtLogFetcher` to `CompositeCtLogFetcher(primary = HttpCtLogFetcher(), fallback = CertspotterCtLogFetcher())`.

## Key correctness point (security path)

Certspotter's `issuer.name` string is **byte-identical** to crt.sh's `issuer_name` — same `C=US, O=..., CN=...` DN order and comma-space separators — verified against live data. So each issuance's `issuer.name` maps **straight** into the issuer field the monitor compares, with **no normalization** and **zero false-Alert risk**. A test parses the translated JSON with the same `Json` the monitor uses and asserts the issuer set is exactly the certspotter `issuer.name` values.

## Unchanged (no UX/error-surface change)

`CtLogMonitor` (classification), `HttpCtLogFetcher`, `SecurityCheckWorker`, the debounce, and the notification/warning copy are all untouched. This only makes the underlying fetch succeed more often, so there's no UX-surface change and no `docs/ux-decisions.md` entry is needed.

## Tests (new)

- `CertspotterCtLogFetcherTest`: canned certspotter response → translated JSON's parsed `issuer_name`s equal the exact certspotter `issuer.name` strings; empty array → `[]` (empty list); 502 → `IOException`.
- `CompositeCtLogFetcherTest`: primary success → fallback not invoked; primary fails → fallback used; both fail → primary's exception (message) rethrown.

## Verification

- `:core:tunnel:jvmTest` — green (existing `CtLogMonitorTest` + `HttpCtLogFetcherTest` pass unmodified)
- `:app:testDebugUnitTest` — green
- `ktlintCheck` + `detekt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)