### PR TITLE
Fix leaked Main dispatcher flake (#376)

### DIFF
--- a/app/src/test/java/com/rousecontext/app/testing/MainDispatcherRule.kt
+++ b/app/src/test/java/com/rousecontext/app/testing/MainDispatcherRule.kt
@@ -1,0 +1,48 @@
+package com.rousecontext.app.testing
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * JUnit rule that installs [dispatcher] as `Dispatchers.Main` for the duration
+ * of a test and unconditionally restores the original Main afterwards.
+ *
+ * Pairing `setMain`/`resetMain` in a rule (rather than ad-hoc `@Before`/`@After`
+ * methods) makes the reset bulletproof: the rule's teardown runs in a `finally`
+ * around the whole test even if the body throws, so the Main dispatcher can
+ * never be left overridden and leak into a subsequent test in the same JVM.
+ *
+ * Unit tests run in a single JVM (`testOptions.unitTests` sets no `forkEvery`),
+ * so a leaked Main override surfaces as an `IllegalStateException` from
+ * `kotlinx.coroutines.test`'s internal `TestMainDispatcher` in a *random later*
+ * test's `setMain` — the moving-target flake tracked in issue #376.
+ *
+ * The rule's teardown only resets Main; it does NOT join coroutines. A test that
+ * routes Main to a *real* (thread-backed) dispatcher must ensure its own
+ * coroutines are cancelled and drained to quiescence in its `@After` (which runs
+ * before this rule's teardown) so nothing is still dispatching on Main when the
+ * reset fires.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(private val dispatcher: CoroutineDispatcher = UnconfinedTestDispatcher()) :
+    TestRule {
+
+    override fun apply(base: Statement, description: Description): Statement =
+        object : Statement() {
+            override fun evaluate() {
+                Dispatchers.setMain(dispatcher)
+                try {
+                    base.evaluate()
+                } finally {
+                    Dispatchers.resetMain()
+                }
+            }
+        }
+}

--- a/app/src/test/java/com/rousecontext/app/ui/viewmodels/AuditHistoryViewModelRoomTest.kt
+++ b/app/src/test/java/com/rousecontext/app/ui/viewmodels/AuditHistoryViewModelRoomTest.kt
@@ -1,29 +1,30 @@
 package com.rousecontext.app.ui.viewmodels
 
 import android.content.Context
+import androidx.lifecycle.ViewModelStore
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
+import com.rousecontext.app.testing.MainDispatcherRule
 import com.rousecontext.notifications.audit.AuditDatabase
 import com.rousecontext.notifications.audit.AuditEntry
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withTimeout
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -49,21 +50,41 @@ import org.robolectric.RobolectricTestRunner
  *
  * Exercises a real in-memory Room database so the test pins the actual
  * `stateIn` lifecycle semantics rather than mocking `observeByDateRange`.
+ *
+ * ## Dispatcher discipline (issue #376)
+ *
+ * The VM's `viewModelScope` runs on `Dispatchers.Main.immediate`. This test
+ * points Main at a **dedicated single-thread dispatcher** ([mainExecutor]) so
+ * Room's reactive Flow and the VM share a real, thread-backed scheduler:
+ * the invalidation tracker fires on the DB executor threads and must deliver
+ * a genuine cross-thread wakeup to the `stateIn` collector, exactly as it does
+ * on-device. An `UnconfinedTestDispatcher` would trampoline emissions on the
+ * calling thread and miss those wakeups.
+ *
+ * Owning the executor (instead of sharing `Dispatchers.IO`, whose threads
+ * outlive the test) is what makes teardown deterministic: [tearDown] cancels
+ * the VM's `viewModelScope`, then drains the executor to quiescence before the
+ * [MainDispatcherRule] resets Main. Once the worker thread is dead no coroutine
+ * can still be dispatching on Main, so the reset cannot race a leftover
+ * coroutine — eliminating the leaked-Main flake from issue #376.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 class AuditHistoryViewModelRoomTest {
 
+    private val mainExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule(mainExecutor.asCoroutineDispatcher())
+
     private lateinit var database: AuditDatabase
-    private lateinit var testScope: CoroutineScope
+
+    // Owns the VM so tearDown can cancel its viewModelScope via clear().
+    private val viewModelStore = ViewModelStore()
+    private lateinit var vm: AuditHistoryViewModel
 
     @Before
     fun setUp() {
-        // ViewModel's viewModelScope uses Dispatchers.Main.immediate. Routing
-        // Main to the IO dispatcher lets Room's reactive Flow and the VM share
-        // a real scheduler; Unconfined would trampoline emissions on the
-        // calling thread and miss cross-thread invalidation-tracker wakeups.
-        Dispatchers.setMain(Dispatchers.IO)
         val context = ApplicationProvider.getApplicationContext<Context>()
         // Build the database directly so the query/transaction executor is a
         // real thread pool. Robolectric's default scheduling can leave Room's
@@ -73,21 +94,34 @@ class AuditHistoryViewModelRoomTest {
             .setQueryExecutor(Executors.newSingleThreadExecutor())
             .setTransactionExecutor(Executors.newSingleThreadExecutor())
             .build()
-        testScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        vm = AuditHistoryViewModel(auditDao = database.auditDao())
+        viewModelStore.put("audit", vm)
     }
 
     @After
     fun tearDown() {
-        testScope.coroutineContext[Job]?.cancel()
+        // 1. Cancel the VM's viewModelScope: stops the stateIn upstream and any
+        //    in-flight Room flow collectors. Their cancellation continuations
+        //    are dispatched onto mainExecutor.
+        viewModelStore.clear()
+        // 2. Drain Main to quiescence. shutdown() lets the already-queued
+        //    cancellation work finish while rejecting new tasks; awaitTermination
+        //    blocks until the single worker thread is idle and dead. After this,
+        //    nothing can dispatch on Main, so the rule's resetMain() (which runs
+        //    next) cannot race a leftover coroutine.
+        mainExecutor.shutdown()
+        check(mainExecutor.awaitTermination(DRAIN_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+            "Main dispatcher thread did not drain within ${DRAIN_TIMEOUT_MS}ms"
+        }
         database.close()
-        Dispatchers.resetMain()
+        // MainDispatcherRule.apply()'s finally runs Dispatchers.resetMain() here,
+        // on a now-dead dispatcher thread.
     }
 
     @Test
     fun `re-subscribing after a row insert reflects the new row without stale empty`() {
         runBlocking {
             val dao = database.auditDao()
-            val vm = AuditHistoryViewModel(auditDao = dao)
 
             // Phase 1: first subscriber lands on an empty DB and sees groups = [].
             val firstLoaded = withTimeout(TIMEOUT_MS) {
@@ -101,9 +135,10 @@ class AuditHistoryViewModelRoomTest {
             )
 
             // A no-op collector warms the shared flow so stateIn has seen at
-            // least one live subscriber. Cancelling it simulates the user
-            // leaving the audit screen.
-            val warmupJob: Job = vm.state.onEach { /* observe */ }.launchIn(testScope)
+            // least one live subscriber. Cancelling it (with join) simulates the
+            // user leaving the audit screen and guarantees the warmup coroutine
+            // is fully torn down before we proceed.
+            val warmupJob: Job = vm.state.onEach { /* observe */ }.launchIn(this)
             warmupJob.cancelAndJoin()
 
             // Phase 2: insert a row while the user is "away". This mirrors
@@ -141,5 +176,10 @@ class AuditHistoryViewModelRoomTest {
         // stuck grace window turns into a clear failure rather than a
         // flaky hang.
         const val TIMEOUT_MS = 10_000L
+
+        // Upper bound for cancelled viewModelScope work to drain off Main.
+        // Cancelled coroutines unwind near-instantly; this is a safety net,
+        // not an expected wait.
+        const val DRAIN_TIMEOUT_MS = 10_000L
     }
 }


### PR DESCRIPTION
## The flake (grounded in CI)

CI run **27476494784**, "Build & Test / Unit tests":

- **Attempt 1 (`:app`):**
  - `AuditHistoryViewModelRoomTest.kt:83` → `java.lang.IllegalStateException`, `Caused by: java.lang.Throwable at TestMainDispatcher.kt:76`. Line 83 is `Dispatchers.resetMain()`.
  - `OnboardingViewModelTest > startOnboarding handles auth exception gracefully` → `IllegalStateException at TestMainDispatcher.kt:72`, `Caused by: Throwable at TestMainDispatcher.kt:86`.
- **Attempt 2 was `BUILD SUCCESSFUL`.** The `SecurityCheckSchedulerTest.setUp:45` line cited earlier was a benign `CloseGuard` SQLite-leak *warning* logged via `System.logW` during a passing run — not a failure. No `:work` test calls `setMain`, so there is no Main-dispatcher leak in `:work`. This change is therefore scoped to `:app`.

## Mechanism: a leaked Main override, single JVM

`TestMainDispatcher.kt:72/76/86` is `kotlinx.coroutines.test`'s internal `NonConcurrentlyModifiable` guard. Its setter throws `IllegalStateException("Dispatchers.Main is used concurrently with setting it")` when a coroutine has *read* Main (recorded location = the `Caused by` Throwable) while another `setMain`/`resetMain` writes it. Because unit tests run in a **single JVM** (`testOptions.unitTests` sets no `forkEvery`), one test leaving a coroutine dispatching on Main pollutes a **random subsequent** test's `setMain` — hence moving-target victims and no single-class local repro (the two April audits found nothing locally).

## The leaking call site (confirmed)

`AuditHistoryViewModelRoomTest`:
- pointed Main at the **shared `Dispatchers.IO`** pool (threads outlive the test), and
- tore down with a fire-and-forget `testScope.coroutineContext[Job]?.cancel()` (**no join**) before `resetMain()`, and
- **never cancelled the VM's `viewModelScope`** at all.

The VM's `stateIn` upstream / Room flow collector runs on `viewModelScope` (= `Dispatchers.Main.immediate` = IO here). After the test body it could still be dispatching on Main when `resetMain()` ran — which is exactly the attempt-1 self-failure at `:83`, and which leaves a coroutine reading Main past the reset to poison the next class's `setMain` (the `OnboardingViewModelTest` victim).

## Fix (structural, deterministic)

- **`MainDispatcherRule`** (new): pairs `setMain`/`resetMain` in a `TestRule` so the reset always runs in a `finally` around the whole test — `setMain` can never be left dangling by an early return/throw.
- **Dedicated single-thread executor as Main** (not shared IO): preserves the real, thread-backed cross-thread scheduler Room's invalidation tracker needs (an `UnconfinedTestDispatcher` would trampoline emissions and miss wakeups), while making the dispatcher fully **drainable** because the test owns it.
- **VM owned in a `ViewModelStore`**; `tearDown`:
  1. `viewModelStore.clear()` → cancels `viewModelScope` (stops the `stateIn` upstream + Room collectors),
  2. `mainExecutor.shutdown()` + `awaitTermination(...)` → blocks until the single worker thread is **idle and dead**,
  3. then the rule's `resetMain()` fires.
- Warmup collector joined with `cancelAndJoin` on the `runBlocking` scope.

## Why this is correct (not just "ran green N times")

The flake is a data race between a coroutine reading Main and `resetMain` writing it. The fix **removes the race condition itself**: after `awaitTermination` returns, the only thread that could dispatch on the test's Main dispatcher has terminated, so when `resetMain()` runs there is provably no concurrent reader of Main, and no coroutine can outlive the reset into the next test. Using a single-thread executor we own (vs. the shared, never-terminating IO pool) is what makes that termination observable and deterministic. The repeated-green runs below corroborate; the argument above is the proof.

## Verification

- `:app:testGoogleDebugUnitTest --rerun-tasks` full suite: **7 consecutive green** runs (5 + 2 after `ktlintFormat`).
- `AuditHistoryViewModelRoomTest` alone: green (the #368 regression assertion still holds).
- `:work:testDebugUnitTest --rerun-tasks`: 2 green (unaffected, confirmed no `setMain`).
- `ktlintCheck detekt`: clean.

Fixes #376.

🤖 Generated with [Claude Code](https://claude.com/claude-code)