### PR TITLE
FOSS #464: ACRA crash reporting (foss) + relay /crash → GitHub issues

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -253,6 +253,15 @@ dependencies {
     // flavor-agnostic BackgroundDelivery seam.
     "fossImplementation"(libs.unifiedpush.connector)
 
+    // ACRA — scoped to the `foss` flavor only (issue #464). Crashlytics is not
+    // FOSS, so the foss flavor reports crashes via ACRA's HttpSender, which
+    // POSTs JSON crash reports to the relay's `POST /crash` endpoint. The relay
+    // sanitizes/dedups them into GitHub issues (mirroring the Crashlytics→issue
+    // convention). The google flavor never links ACRA — it keeps Crashlytics
+    // behind the same flavor-agnostic CrashReporter seam.
+    "fossImplementation"(libs.acra.core)
+    "fossImplementation"(libs.acra.http)
+
     // Health Connect (for HealthConnectIntegration availability check)
     implementation(libs.health.connect)
 

--- a/app/src/foss/java/com/rousecontext/app/di/DistributionModule.kt
+++ b/app/src/foss/java/com/rousecontext/app/di/DistributionModule.kt
@@ -9,6 +9,7 @@ import com.rousecontext.app.auth.NoOpFcmTokenProvider
 import com.rousecontext.app.delivery.BackgroundDelivery
 import com.rousecontext.app.delivery.UnifiedPushBackgroundDelivery
 import com.rousecontext.app.state.DeviceRegistrationStatus
+import com.rousecontext.app.support.AcraCrashReporter
 import com.rousecontext.tunnel.CertificateStore
 import com.rousecontext.tunnel.OnboardingFlow
 import com.rousecontext.tunnel.TunnelClient
@@ -26,11 +27,14 @@ import org.koin.dsl.module
  * registration and provisioning go through [KeypairDeviceCredentialProvider]
  * (signed registration proof, no Firebase), and expired-cert renewal goes
  * through [KeypairRenewalAuthProvider] (keypair-signed timestamp proof). Crash
- * reporting (#464) and push (#463) remain stubbed until their tickets land.
+ * reporting is ACRA-backed (issue #464); push (#463) remains stubbed until its
+ * ticket lands.
  */
 val distributionModule = module {
-    // Crash reporting — no-op until a FOSS crash backend lands (#464).
-    single { CrashReporter.NoOp }
+    // Crash reporting — ACRA, the FOSS Crashlytics replacement (#464). ACRA is
+    // initialized in CrashReporterInitializer (attachBaseContext); this binding
+    // forwards caught-exception logging / collection toggling to it.
+    single<CrashReporter> { AcraCrashReporter() }
 
     // Push-token retrieval — foss has no FCM token; its push target is the
     // UnifiedPush endpoint (reported via BackgroundDelivery), so the FCM-token

--- a/app/src/foss/java/com/rousecontext/app/support/AcraCrashReporter.kt
+++ b/app/src/foss/java/com/rousecontext/app/support/AcraCrashReporter.kt
@@ -1,0 +1,40 @@
+package com.rousecontext.app.support
+
+import com.rousecontext.api.CrashReporter
+import java.util.concurrent.atomic.AtomicLong
+import org.acra.ACRA
+
+/**
+ * [CrashReporter] backed by ACRA (the FOSS Crashlytics replacement), used by
+ * the `foss` flavor. The parallel `google` flavor binds
+ * [com.rousecontext.app.support.FirebaseCrashReporter]; both sit behind the
+ * same Koin seam. Issue #464.
+ *
+ * ACRA is initialized in [CrashReporterInitializer] from
+ * `Application.attachBaseContext`. Before that runs (or if init is skipped,
+ * e.g. in the ACRA sender process), [ACRA.errorReporter] returns a safe no-op
+ * stub, so every method here degrades gracefully rather than throwing.
+ */
+class AcraCrashReporter : CrashReporter {
+
+    /** Monotonic counter so breadcrumb custom-data keys never collide. */
+    private val breadcrumbSeq = AtomicLong(0)
+
+    override fun logCaughtException(throwable: Throwable) {
+        // Non-fatal: report without killing the process, mirroring
+        // Crashlytics.recordException.
+        ACRA.errorReporter.handleSilentException(throwable)
+    }
+
+    override fun log(message: String) {
+        // Attach as custom data so it rides along with the next crash report,
+        // the closest ACRA analogue to a Crashlytics breadcrumb. Keys are
+        // sequenced so successive breadcrumbs don't overwrite each other.
+        val key = "breadcrumb_${breadcrumbSeq.incrementAndGet()}"
+        ACRA.errorReporter.putCustomData(key, message)
+    }
+
+    override fun setCollectionEnabled(enabled: Boolean) {
+        ACRA.errorReporter.setEnabled(enabled)
+    }
+}

--- a/app/src/foss/java/com/rousecontext/app/support/CrashReporterInitializer.kt
+++ b/app/src/foss/java/com/rousecontext/app/support/CrashReporterInitializer.kt
@@ -1,0 +1,69 @@
+package com.rousecontext.app.support
+
+import android.app.Application
+import com.rousecontext.app.BuildConfig
+import org.acra.ACRA
+import org.acra.config.CoreConfigurationBuilder
+import org.acra.config.HttpSenderConfigurationBuilder
+import org.acra.data.StringFormat
+import org.acra.sender.HttpSender
+
+/**
+ * `foss`-flavor crash-reporting initializer (issue #464).
+ *
+ * Initializes ACRA, the FOSS replacement for Firebase Crashlytics. ACRA hooks
+ * the process-wide uncaught-exception handler and forks a dedicated sender
+ * process, so it MUST be initialized from [Application.attachBaseContext] (the
+ * shared [com.rousecontext.app.RouseApplication] calls this).
+ *
+ * Reports are POSTed as JSON to the relay's `POST /crash` endpoint, where they
+ * are sanitized, deduped, and turned into GitHub issues (mirroring the
+ * Crashlytics→issue convention). The endpoint URL derives from the same
+ * `BuildConfig` relay host the tunnel uses, over HTTPS.
+ *
+ * Collection is gated to release builds here (debug builds never phone home, so
+ * local repros don't open spurious issues). The runtime toggle is also exposed
+ * via [AcraCrashReporter.setCollectionEnabled], wired through the shared
+ * `RouseApplication.configureCrashReporting` path so a future Settings opt-out
+ * can flip it at runtime.
+ */
+object CrashReporterInitializer {
+    fun initialize(application: Application) {
+        if (ACRA.isInitialised) return
+
+        val builder = CoreConfigurationBuilder()
+            .withBuildConfigClass(BuildConfig::class.java)
+            .withReportFormat(StringFormat.JSON)
+            // Don't collect logcat: it can contain data from other apps and
+            // PII. The relay also sanitizes, but minimizing at the source is
+            // cheaper and safer. Stack trace + app/OS version is enough to
+            // triage a crash into a GitHub issue.
+            .withLogcatArguments(emptyList())
+            .withPluginConfigurations(
+                HttpSenderConfigurationBuilder()
+                    .withUri(crashReportUri())
+                    .withHttpMethod(HttpSender.Method.POST)
+                    .build()
+            )
+
+        ACRA.init(application, builder)
+
+        // Mirror the google flavor's debug/release gate (Crashlytics is
+        // collection-disabled in debug). Release builds collect by default
+        // until a user opts out. The shared configureCrashReporting() hook
+        // reaffirms this shortly after onCreate.
+        ACRA.errorReporter.setEnabled(!BuildConfig.DEBUG)
+    }
+
+    /**
+     * Build the relay crash-ingest URL from the same relay host the tunnel
+     * uses. Always HTTPS; includes an explicit port only when it isn't the
+     * standard 443 (e.g. a self-hosting fork or a dev relay).
+     */
+    private fun crashReportUri(): String {
+        val host = BuildConfig.RELAY_HOST
+        val port = BuildConfig.RELAY_PORT
+        val authority = if (port == 443) host else "$host:$port"
+        return "https://$authority/crash"
+    }
+}

--- a/app/src/google/java/com/rousecontext/app/support/CrashReporterInitializer.kt
+++ b/app/src/google/java/com/rousecontext/app/support/CrashReporterInitializer.kt
@@ -1,0 +1,24 @@
+package com.rousecontext.app.support
+
+import android.app.Application
+
+/**
+ * `google`-flavor crash-reporting initializer (issue #464).
+ *
+ * Firebase Crashlytics self-initializes via the `firebase-crashlytics` Gradle
+ * plugin's ContentProvider (`CrashlyticsInitProvider`) before
+ * [Application.onCreate], so there is nothing to wire up in
+ * [Application.attachBaseContext]. This no-op exists purely so the shared
+ * [com.rousecontext.app.RouseApplication.attachBaseContext] can call a
+ * flavor-agnostic entry point; the `foss` source set provides an ACRA-backed
+ * counterpart.
+ */
+object CrashReporterInitializer {
+    // `application` is unused in the google flavor — Crashlytics self-initializes
+    // via its plugin ContentProvider — but the parameter is part of the shared,
+    // flavor-agnostic entry point the foss flavor uses to call ACRA.init().
+    @Suppress("UnusedParameter")
+    fun initialize(application: Application) {
+        // No-op: Crashlytics initializes itself via its plugin ContentProvider.
+    }
+}

--- a/app/src/main/java/com/rousecontext/app/RouseApplication.kt
+++ b/app/src/main/java/com/rousecontext/app/RouseApplication.kt
@@ -1,6 +1,7 @@
 package com.rousecontext.app
 
 import android.app.Application
+import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import androidx.work.Configuration
@@ -9,6 +10,7 @@ import com.rousecontext.app.debug.debugModules
 import com.rousecontext.app.di.appModule
 import com.rousecontext.app.di.distributionModule
 import com.rousecontext.app.state.AppStatePreferences
+import com.rousecontext.app.support.CrashReporterInitializer
 import com.rousecontext.notifications.NotificationChannels
 import com.rousecontext.tunnel.CertificateStore
 import com.rousecontext.work.CertRenewalScheduler
@@ -46,6 +48,20 @@ class RouseApplication :
         get() = Configuration.Builder()
             .setWorkerFactory(KoinWorkerFactory(GlobalContext.get()))
             .build()
+
+    /**
+     * Crash-reporting backends that hook the process-wide uncaught-exception
+     * handler MUST install before any other init runs, and ACRA specifically
+     * requires [attachBaseContext] (it inspects the base context and forks a
+     * dedicated sender process). [CrashReporterInitializer] is flavor-specific:
+     * the `foss` source set initializes ACRA here; the `google` source set is a
+     * no-op (Crashlytics self-initializes via its Gradle-plugin ContentProvider).
+     * Issue #464.
+     */
+    override fun attachBaseContext(base: Context) {
+        super.attachBaseContext(base)
+        CrashReporterInitializer.initialize(this)
+    }
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/testFoss/java/com/rousecontext/app/support/AcraCrashReporterTest.kt
+++ b/app/src/testFoss/java/com/rousecontext/app/support/AcraCrashReporterTest.kt
@@ -1,0 +1,42 @@
+package com.rousecontext.app.support
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Smoke tests for the `foss`-flavor [AcraCrashReporter] (issue #464).
+ *
+ * These assert the contract that matters in practice: the reporter forwards to
+ * ACRA's static [org.acra.ACRA.errorReporter] without ever throwing, even when
+ * ACRA has NOT been initialized (the unit-test process never calls
+ * `ACRA.init`). ACRA returns a safe no-op `ErrorReporter` stub before init, so
+ * a caught-exception report, a breadcrumb, or a collection-toggle from app code
+ * degrades gracefully rather than crashing the very flows it's meant to observe.
+ *
+ * Full end-to-end report delivery (ACRA init in attachBaseContext → HttpSender
+ * → relay `/crash`) is exercised by the relay's crash-endpoint tests; here we
+ * only guard the device-side binding.
+ */
+@RunWith(RobolectricTestRunner::class)
+class AcraCrashReporterTest {
+
+    private val reporter = AcraCrashReporter()
+
+    @Test
+    fun `logCaughtException does not throw when ACRA is uninitialized`() {
+        reporter.logCaughtException(IllegalStateException("boom"))
+    }
+
+    @Test
+    fun `log breadcrumb does not throw when ACRA is uninitialized`() {
+        reporter.log("reached checkpoint A")
+        reporter.log("reached checkpoint B")
+    }
+
+    @Test
+    fun `setCollectionEnabled does not throw when ACRA is uninitialized`() {
+        reporter.setCollectionEnabled(true)
+        reporter.setCollectionEnabled(false)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ activity = "1.13.0"
 lifecycle = "2.10.0"
 firebase-bom = "34.12.0"
 unifiedpush-connector = "2.5.0"
+acra = "5.13.1"
 health-connect = "1.1.0"
 mcp-sdk = "0.11.1"
 kotlinx-serialization-json = "1.11.0"
@@ -50,6 +51,8 @@ firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.r
 firebase-auth = { group = "com.google.firebase", name = "firebase-auth" }
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 unifiedpush-connector = { group = "org.unifiedpush.android", name = "connector", version.ref = "unifiedpush-connector" }
+acra-core = { group = "ch.acra", name = "acra-core", version.ref = "acra" }
+acra-http = { group = "ch.acra", name = "acra-http", version.ref = "acra" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
 firebase-firestore = { group = "com.google.firebase", name = "firebase-firestore" }
 health-connect = { group = "androidx.health.connect", name = "connect-client", version.ref = "health-connect" }

--- a/relay/Cargo.lock
+++ b/relay/Cargo.lock
@@ -1688,6 +1688,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1815,7 @@ dependencies = [
  "pem",
  "rand 0.8.5",
  "rcgen",
+ "regex",
  "reqwest",
  "rustls",
  "rustls-pemfile",

--- a/relay/Cargo.toml
+++ b/relay/Cargo.toml
@@ -49,6 +49,7 @@ hickory-resolver = { version = "0.24", features = ["tokio-runtime"] }
 rcgen = { version = "0.13", features = ["x509-parser"] }
 time = "0.3"
 pem = "3"
+regex = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/relay/README.md
+++ b/relay/README.md
@@ -26,6 +26,44 @@ overrides (see `src/config.rs::apply_env_overrides`).
 
 ## Operational notes
 
+### Crash reporting (`POST /crash`, foss flavor)
+
+`foss`-flavor app builds report crashes via ACRA's `HttpSender`, which POSTs a
+JSON crash report to `POST /crash`. The relay **sanitizes** it (allowlists a few
+non-identifying fields, redacts emails/IPs/on-device paths/tokens from the stack
+trace), **dedups** by stack-trace fingerprint, **spike-caps** crash loops, and
+files/append a GitHub issue labeled `crash` (mirroring the Crashlytics→issue
+convention; Crashlytics has no server-side ingestion API).
+
+**Abuse surface.** The endpoint takes unauthenticated external POSTs and files
+GitHub issues, so it is rate-limited rather than open: a per-IP token bucket
+(429 on flood), a per-fingerprint spike-cap, and a **global new-issue cap** that
+bounds how many issues can be opened per window even under fingerprint/IP
+rotation. Device mTLS auth is intentionally NOT required — ACRA can't present
+the device client cert and crashes must be reportable before a device is
+provisioned.
+
+**Ops dependency — GitHub token.** Filing needs a GitHub token with
+`issues:write` on the target repo (a fine-grained PAT scoped to Issues, or a
+GitHub App token). Configure:
+
+```toml
+[github]
+crash_repo = "Monkopedia/rouse-context"
+token_env  = "GITHUB_CRASH_TOKEN"   # name of the env var holding the token
+```
+
+Set the token in `/etc/rouse-relay/env` (loaded like `CF_API_TOKEN`):
+
+```
+GITHUB_CRASH_TOKEN=github_pat_...
+```
+
+If `crash_repo` is empty or the token env var is unset, `/crash` still
+sanitizes + dedups + logs and returns `202` — it just skips the GitHub filing
+(no crash, graceful no-op). The repo and env-var name can also be overridden via
+`RELAY_GITHUB_CRASH_REPO` / `RELAY_GITHUB_TOKEN_ENV`.
+
 ### ACME provider
 
 The relay uses Google Trust Services (GTS) as its default ACME provider

--- a/relay/relay.example.toml
+++ b/relay/relay.example.toml
@@ -18,6 +18,21 @@ service_account_path = "/etc/relay/firebase-sa.json"
 zone_id = "your-cloudflare-zone-id"
 api_token_env = "CF_API_TOKEN"
 
+[github]
+# Crash-report sink for `foss`-flavor devices (issue #464). ACRA POSTs JSON
+# crash reports to `POST /crash`; the relay sanitizes/dedups them into GitHub
+# issues labeled `crash`. Leave `crash_repo` empty to disable filing — the
+# endpoint then still sanitizes + dedups + logs and returns 202 (no-op filing).
+#
+# OPS DEPENDENCY: filing needs a GitHub token with `issues:write` on the repo
+# (a fine-grained PAT scoped to Issues, or a GitHub App token). The token is
+# NOT stored here — only the NAME of the env var that holds it (set it in
+# /etc/rouse-relay/env alongside CF_API_TOKEN). Default env var:
+# GITHUB_CRASH_TOKEN.
+# crash_repo = "Monkopedia/rouse-context"
+token_env = "GITHUB_CRASH_TOKEN"
+# api_base_url = "https://api.github.com"   # override only for testing
+
 [acme]
 # ACME provider directory URL. Default (when omitted) is Google Trust Services
 # production: https://dv.acme-v02.api.pki.goog/directory — 100 new orders/hour

--- a/relay/src/api/crash.rs
+++ b/relay/src/api/crash.rs
@@ -1,0 +1,88 @@
+//! POST /crash -- Crash-report ingestion for `foss`-flavor devices (#464).
+//!
+//! `foss` builds use ACRA's `HttpSender` to POST a JSON crash report here. The
+//! relay sanitizes it, dedups by stack-trace fingerprint, spike-caps crash
+//! loops, and files/append a GitHub issue labeled `crash`. See [`crate::crash`]
+//! for the pipeline and its security/abuse-surface rationale.
+//!
+//! Protection (no device auth — ACRA can't present the device mTLS cert, and
+//! crashes must be reportable pre-provisioning): per-IP rate limit (429) +
+//! per-fingerprint spike-cap + global new-issue cap, all in [`crate::crash`].
+//!
+//! Responses are intentionally coarse so a caller can't probe the dedup/cap
+//! state: `202 Accepted` for anything ingested (filed, appended, deduped,
+//! capped, or no-sink), `400` for a body with no usable stack trace, `429`
+//! when the per-IP limit trips, `413` when the body is too large.
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::{Extension, Json};
+use serde_json::Value;
+use std::sync::Arc;
+use tracing::{debug, warn};
+
+use crate::api::{ApiError, AppState, ClientIp};
+
+/// Hard cap on the crash payload we'll buffer/parse. ACRA reports with a
+/// stack trace + a little metadata are a few KB; 512 KB is generous while
+/// bounding memory on the constrained VPS.
+const MAX_CRASH_BODY_BYTES: usize = 512 * 1024;
+
+pub async fn handle_crash(
+    State(state): State<Arc<AppState>>,
+    client_ip: Option<Extension<ClientIp>>,
+    body: Bytes,
+) -> Response {
+    // Per-IP admission BEFORE any parsing work. Fall back to a single shared
+    // key when the source IP isn't plumbed (in-process test router), so the
+    // limiter still functions deterministically there.
+    let ip_key = client_ip
+        .map(|Extension(ClientIp(ip))| ip.to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+    if let Err(retry_after) = state.crash.allow_ip(&ip_key) {
+        debug!(ip = %ip_key, "crash report rate limited (per-IP)");
+        return ApiError::rate_limited("Too many crash reports", retry_after).into_response();
+    }
+
+    if body.len() > MAX_CRASH_BODY_BYTES {
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(serde_json::json!({ "status": "too_large" })),
+        )
+            .into_response();
+    }
+
+    let raw: Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            debug!(error = %e, "crash report JSON parse failed");
+            return ApiError::bad_request("Invalid crash report JSON").into_response();
+        }
+    };
+
+    let outcome = state.crash.process(&raw).await;
+    use crate::crash::CrashIngestOutcome::*;
+    match outcome {
+        InvalidReport => ApiError::bad_request("Crash report missing stack trace").into_response(),
+        FilingFailed => {
+            // Don't leak filing internals to the device; it already crashed.
+            warn!("crash report accepted but GitHub filing failed");
+            accepted("accepted")
+        }
+        Filed(_) => accepted("filed"),
+        Appended(_) => accepted("appended"),
+        DroppedDuplicate => accepted("deduplicated"),
+        DroppedCapped => accepted("rate_capped"),
+        NoSink => accepted("accepted"),
+    }
+}
+
+fn accepted(status: &str) -> Response {
+    (
+        StatusCode::ACCEPTED,
+        Json(serde_json::json!({ "status": status })),
+    )
+        .into_response()
+}

--- a/relay/src/api/mod.rs
+++ b/relay/src/api/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! All endpoints are served over HTTPS on `relay.rousecontext.com`.
 
+pub mod crash;
 pub mod register;
 pub mod renew;
 pub mod request_subdomain;
@@ -189,6 +190,10 @@ pub struct AppState {
     /// window still triggers a fresh FCM push. Wrapped in `Arc` because the
     /// passthrough connection handlers also hold a clone.
     pub fcm_wake_throttle: std::sync::Arc<crate::rate_limit::FcmWakeThrottle>,
+    /// Crash-report ingestion for `foss`-flavor devices (`POST /crash`, #464).
+    /// Owns the per-IP limiter, dedup/spike-cap registry, and (optional) GitHub
+    /// issue filer.
+    pub crash: std::sync::Arc<crate::crash::CrashService>,
     pub config: crate::config::RelayConfig,
     pub device_ca: Option<crate::device_ca::DeviceCa>,
     /// Optional test-mode instrumentation. `None` in production. When `Some`,
@@ -199,6 +204,12 @@ pub struct AppState {
     #[cfg(feature = "test-mode")]
     pub test_metrics: Option<std::sync::Arc<crate::test_mode::TestMetrics>>,
 }
+
+/// Source IP of an inbound relay-API request, injected as a request extension
+/// by the connection handler. Used by `POST /crash` for per-IP rate limiting.
+/// Optional at the handler (the in-process test router doesn't set it).
+#[derive(Debug, Clone, Copy)]
+pub struct ClientIp(pub std::net::IpAddr);
 
 /// Tower middleware that rejects requests without a `DeviceIdentity`
 /// extension (i.e. without a valid mTLS client certificate) before the
@@ -249,6 +260,7 @@ pub fn build_router(state: std::sync::Arc<AppState>) -> axum::Router {
             axum::routing::post(request_subdomain::handle_request_subdomain),
         )
         .route("/renew", axum::routing::post(renew::handle_renew))
+        .route("/crash", axum::routing::post(crash::handle_crash))
         .route("/status", axum::routing::get(status::handle_status));
 
     let authed_router = axum::Router::new()

--- a/relay/src/api/ws.rs
+++ b/relay/src/api/ws.rs
@@ -833,6 +833,7 @@ mod tests {
             fcm_wake_throttle: Arc::new(crate::rate_limit::FcmWakeThrottle::new(
                 Duration::from_secs(10),
             )),
+            crash: Arc::new(crate::crash::CrashService::disabled()),
             config: RelayConfig::default(),
             device_ca: None,
             #[cfg(feature = "test-mode")]
@@ -945,6 +946,7 @@ mod tests {
             fcm_wake_throttle: Arc::new(crate::rate_limit::FcmWakeThrottle::new(
                 Duration::from_secs(10),
             )),
+            crash: Arc::new(crate::crash::CrashService::disabled()),
             config,
             device_ca: None,
             #[cfg(feature = "test-mode")]

--- a/relay/src/config.rs
+++ b/relay/src/config.rs
@@ -24,6 +24,7 @@ pub struct RelayConfig {
     pub limits: LimitsConfig,
     pub acme: AcmeConfig,
     pub device_ca: DeviceCaConfig,
+    pub github: GitHubConfig,
     /// Known integration names. Each device gets a per-integration secret
     /// in the format `{adjective}-{integration}`.
     pub integrations: Vec<String>,
@@ -39,7 +40,52 @@ impl Default for RelayConfig {
             limits: LimitsConfig::default(),
             acme: AcmeConfig::default(),
             device_ca: DeviceCaConfig::default(),
+            github: GitHubConfig::default(),
             integrations: default_integrations(),
+        }
+    }
+}
+
+/// GitHub configuration for the `POST /crash` endpoint (issue #464).
+///
+/// Crash reports from `foss`-flavor devices are filed as GitHub issues. This
+/// needs a GitHub token with `issues:write` on the target repo — an OPS
+/// DEPENDENCY the operator provisions (a fine-grained PAT or app token), stored
+/// in the env var named by `token_env`. When `crash_repo` is empty OR the token
+/// env var is unset, the endpoint still runs (sanitize + dedup + log) but
+/// gracefully no-ops the GitHub filing instead of crashing.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct GitHubConfig {
+    /// `owner/repo` that crash issues are filed against (e.g.
+    /// `Monkopedia/rouse-context`). Empty disables filing.
+    pub crash_repo: String,
+    /// Name of the environment variable holding the GitHub token. Default
+    /// `GITHUB_CRASH_TOKEN`. The token itself is NEVER stored in the config
+    /// file — only the name of the env var that holds it (mirrors the
+    /// Cloudflare `api_token_env` pattern).
+    pub token_env: String,
+    /// GitHub REST API base URL. Override only for testing against a fake API.
+    pub api_base_url: String,
+}
+
+impl Default for GitHubConfig {
+    fn default() -> Self {
+        Self {
+            crash_repo: String::new(),
+            token_env: "GITHUB_CRASH_TOKEN".to_string(),
+            api_base_url: "https://api.github.com".to_string(),
+        }
+    }
+}
+
+impl GitHubConfig {
+    /// Resolve the GitHub token from the configured env var. Returns `None`
+    /// when the var is unset or empty (filing is then a graceful no-op).
+    pub fn resolve_token(&self) -> Option<String> {
+        match std::env::var(&self.token_env) {
+            Ok(v) if !v.is_empty() => Some(v),
+            _ => None,
         }
     }
 }
@@ -438,6 +484,15 @@ impl RelayConfig {
         }
         if let Ok(val) = std::env::var("DEVICE_CA_CERT_PATH") {
             self.device_ca.ca_cert_path = val;
+        }
+        if let Ok(val) = std::env::var("RELAY_GITHUB_CRASH_REPO") {
+            self.github.crash_repo = val;
+        }
+        if let Ok(val) = std::env::var("RELAY_GITHUB_TOKEN_ENV") {
+            self.github.token_env = val;
+        }
+        if let Ok(val) = std::env::var("RELAY_GITHUB_API_BASE_URL") {
+            self.github.api_base_url = val;
         }
     }
 }

--- a/relay/src/crash.rs
+++ b/relay/src/crash.rs
@@ -1,0 +1,944 @@
+//! Crash-report ingestion for `foss`-flavor devices (issue #464).
+//!
+//! `foss` builds report crashes via ACRA's `HttpSender`, which POSTs a JSON
+//! object keyed by ACRA `ReportField` names to `POST /crash`. Crashlytics has
+//! no server-side ingestion API, so both flavors converge on GitHub issues:
+//! the relay turns an ACRA report into a sanitized, deduped issue labeled
+//! `crash`, mirroring the existing Crashlytics→issue automation.
+//!
+//! Pipeline (see [`CrashService::process`]):
+//!   1. **sanitize** — allowlist a handful of non-identifying fields and redact
+//!      emails / IPs / on-device paths / long tokens from the stack trace.
+//!   2. **dedup** — fingerprint the stack trace; the same fingerprint appends a
+//!      comment to its existing issue instead of opening a new one.
+//!   3. **spike-cap** — cap reports-per-fingerprint per time window so one
+//!      crash loop can't append forever; a global cap bounds *new* issues per
+//!      window so fingerprint-varying abuse can't open unlimited issues.
+//!   4. **file** — create/append a GitHub issue, if a token is configured.
+//!
+//! ## Security / abuse surface
+//!
+//! `/crash` accepts unauthenticated external POSTs and (indirectly) files
+//! GitHub issues, so it is an abuse vector (cf. the #472 SSRF lesson). It is
+//! protected WITHOUT requiring device auth — ACRA's `HttpSender` cannot present
+//! the device mTLS client cert, and crashes must be reportable before a device
+//! is even provisioned. Instead the endpoint layers:
+//!   * a **per-IP token-bucket rate limit** (rejects raw flooding from one
+//!     source with 429),
+//!   * the **per-fingerprint spike-cap** (one crash loop ⇒ at most N
+//!     touches/window), and
+//!   * a **global new-issue cap** (the real backstop: even an attacker rotating
+//!     source IPs and fingerprints cannot create more than N issues/window).
+//!
+//! All three are in-memory and reset on restart; the global cap means the
+//! worst case after a restart is a bounded re-burst, not unbounded filing.
+
+use crate::rate_limit::{RateLimitConfig, RateLimiter};
+use async_trait::async_trait;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+use thiserror::Error;
+use tracing::{info, warn};
+
+/// ACRA `ReportField` names retained in the issue. Dropping everything else is
+/// the core of sanitization: identifying fields (`INSTALLATION_ID`,
+/// `DEVICE_ID`, `USER_EMAIL`, `USER_IP`, `LOGCAT`, `SHARED_PREFERENCES`, …) are
+/// never echoed into a public GitHub issue.
+const ALLOWLISTED_FIELDS: &[(&str, &str)] = &[
+    ("APP_VERSION_NAME", "App version"),
+    ("APP_VERSION_CODE", "App version code"),
+    ("ANDROID_VERSION", "Android version"),
+    ("PHONE_MODEL", "Device model"),
+    ("BRAND", "Device brand"),
+    ("PACKAGE_NAME", "Package"),
+];
+
+/// Maximum stack-trace characters embedded in an issue body. Bounds memory and
+/// issue size if a device sends a pathologically long trace.
+const MAX_STACK_TRACE_CHARS: usize = 16_000;
+
+// ---------------------------------------------------------------------------
+// Sanitization
+// ---------------------------------------------------------------------------
+
+fn email_re() -> &'static regex::Regex {
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        regex::Regex::new(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}").unwrap()
+    })
+}
+
+fn ipv4_re() -> &'static regex::Regex {
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    RE.get_or_init(|| regex::Regex::new(r"\b\d{1,3}(?:\.\d{1,3}){3}\b").unwrap())
+}
+
+/// On-device storage paths whose later components can embed a user/profile
+/// identifier. We keep the well-known prefix (useful signal) and redact the
+/// trailing path so an account name in e.g. `/storage/emulated/0/Android/...`
+/// never lands in a public issue.
+fn user_path_re() -> &'static regex::Regex {
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        regex::Regex::new(
+            r"(/data/user/\d+|/data/data|/storage/emulated/\d+|/sdcard|/home/[^/\s]+|/Users/[^/\s]+)(/\S*)?",
+        )
+        .unwrap()
+    })
+}
+
+/// Long opaque runs (>= 32 chars of token-ish characters with no separators)
+/// look like bearer tokens / keys rather than code identifiers (which contain
+/// dots). Redact them defensively.
+fn long_token_re() -> &'static regex::Regex {
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    RE.get_or_init(|| regex::Regex::new(r"[A-Za-z0-9_\-]{32,}").unwrap())
+}
+
+/// Redact anything resembling private user data from free text (stack traces).
+/// The field allowlist already drops identifying ACRA fields; this scrubs the
+/// one free-form field we DO keep.
+pub fn sanitize_text(input: &str) -> String {
+    let s = email_re().replace_all(input, "[redacted-email]");
+    let s = ipv4_re().replace_all(&s, "[redacted-ip]");
+    let s = user_path_re().replace_all(&s, "$1/[redacted-path]");
+    let s = long_token_re().replace_all(&s, "[redacted-token]");
+    s.into_owned()
+}
+
+// ---------------------------------------------------------------------------
+// Fingerprinting
+// ---------------------------------------------------------------------------
+
+/// Compute a stable fingerprint for a stack trace.
+///
+/// Stability across app versions matters: we key on the exception class plus
+/// the top frames with their *line numbers stripped* (`Foo.kt:42` → `Foo.kt`),
+/// and drop the exception message (it often embeds variable data). Two reports
+/// of the same logical crash fingerprint identically so they dedup onto one
+/// issue.
+pub fn fingerprint(stack_trace: &str) -> String {
+    let mut normalized = String::new();
+    let mut frames = 0usize;
+    for (i, raw_line) in stack_trace.lines().enumerate() {
+        let line = raw_line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            // Header: keep the exception class, drop the message after ':'.
+            let class = line.split(':').next().unwrap_or(line).trim();
+            normalized.push_str(class);
+            normalized.push('\n');
+            continue;
+        }
+        if let Some(frame) = line.strip_prefix("at ") {
+            // Strip the "(File.kt:NN)" location so line-number churn doesn't
+            // change the fingerprint; keep the qualified method.
+            let method = frame.split('(').next().unwrap_or(frame).trim();
+            normalized.push_str(method);
+            normalized.push('\n');
+            frames += 1;
+            if frames >= 8 {
+                break;
+            }
+        }
+    }
+    if normalized.is_empty() {
+        normalized.push_str(stack_trace.trim());
+    }
+    let digest = Sha256::digest(normalized.as_bytes());
+    hex_lower(&digest[..8])
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+// ---------------------------------------------------------------------------
+// Report → sanitized issue
+// ---------------------------------------------------------------------------
+
+/// A sanitized crash report ready to become a GitHub issue.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SanitizedReport {
+    pub fingerprint: String,
+    pub title: String,
+    pub body: String,
+}
+
+fn json_str(raw: &Value, key: &str) -> Option<String> {
+    match raw.get(key) {
+        Some(Value::String(s)) if !s.is_empty() => Some(s.clone()),
+        Some(Value::Number(n)) => Some(n.to_string()),
+        _ => None,
+    }
+}
+
+/// Build a sanitized report from an ACRA JSON payload, or `None` if it carries
+/// no usable stack trace (an empty/garbage POST we refuse to file).
+pub fn build_sanitized_report(raw: &Value) -> Option<SanitizedReport> {
+    let stack_raw = json_str(raw, "STACK_TRACE")?;
+    let mut stack = sanitize_text(stack_raw.trim());
+    if stack.is_empty() {
+        return None;
+    }
+    if stack.chars().count() > MAX_STACK_TRACE_CHARS {
+        let truncated: String = stack.chars().take(MAX_STACK_TRACE_CHARS).collect();
+        stack = format!("{truncated}\n… [truncated]");
+    }
+
+    let fp = fingerprint(&stack);
+    let title = build_title(&stack, &fp);
+
+    let mut body = String::new();
+    body.push_str("Automated crash report from a `foss`-flavor build (ACRA → relay `/crash`).\n\n");
+    for (field, label) in ALLOWLISTED_FIELDS {
+        if let Some(val) = json_str(raw, field) {
+            // Allowlisted fields are non-identifying, but sanitize defensively.
+            body.push_str(&format!("- **{label}:** {}\n", sanitize_text(&val)));
+        }
+    }
+    body.push_str("\n```\n");
+    body.push_str(&stack);
+    body.push_str("\n```\n\n");
+    // Machine-readable marker so dedup can survive a relay restart via a GitHub
+    // search if we ever want it (not required for the in-memory fast path).
+    body.push_str(&format!("<!-- crash-fingerprint: {fp} -->\n"));
+
+    Some(SanitizedReport {
+        fingerprint: fp,
+        title,
+        body,
+    })
+}
+
+fn build_title(stack: &str, fp: &str) -> String {
+    let first = stack.lines().next().unwrap_or("").trim();
+    let class = first.split(':').next().unwrap_or(first).trim();
+    // Short, leading-package-stripped exception name for readability.
+    let short = class.rsplit('.').next().unwrap_or(class);
+    let short = if short.is_empty() { "Crash" } else { short };
+    format!("[crash] {short} ({fp})")
+}
+
+// ---------------------------------------------------------------------------
+// Dedup + spike-cap + global cap
+// ---------------------------------------------------------------------------
+
+/// Tunables for the dedup / capping logic.
+#[derive(Debug, Clone)]
+pub struct CrashLimitsConfig {
+    /// Sliding window for the per-fingerprint spike-cap.
+    pub per_fingerprint_window: Duration,
+    /// Max reports (create + appends) accepted per fingerprint per window.
+    pub per_fingerprint_max_reports: u32,
+    /// Sliding window for the global new-issue cap.
+    pub global_window: Duration,
+    /// Max NEW issues created across all fingerprints per global window.
+    pub global_max_new_issues: u32,
+}
+
+impl Default for CrashLimitsConfig {
+    fn default() -> Self {
+        Self {
+            per_fingerprint_window: Duration::from_secs(3600),
+            per_fingerprint_max_reports: 5,
+            global_window: Duration::from_secs(3600),
+            global_max_new_issues: 20,
+        }
+    }
+}
+
+/// What to do with a freshly-fingerprinted report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CrashDecision {
+    /// First sighting (this window) — open a new issue.
+    CreateIssue,
+    /// Known fingerprint — append to its existing issue.
+    AppendToIssue(u64),
+    /// Spike-capped: too many reports for this fingerprint this window.
+    DropSpikeCapped,
+    /// Global cap reached: refuse to open another new issue this window.
+    DropGlobalCapped,
+}
+
+struct FingerprintState {
+    issue_number: Option<u64>,
+    window_start: Instant,
+    reports_in_window: u32,
+    last_seen: Instant,
+}
+
+struct DedupInner {
+    fingerprints: HashMap<String, FingerprintState>,
+    global_window_start: Instant,
+    global_new_issues: u32,
+}
+
+/// In-memory dedup / spike-cap / global-cap registry. Thread-safe; resets on
+/// relay restart. Time is injectable (`*_at`) for deterministic tests.
+pub struct CrashDedup {
+    cfg: CrashLimitsConfig,
+    inner: Mutex<DedupInner>,
+}
+
+impl CrashDedup {
+    pub fn new(cfg: CrashLimitsConfig) -> Self {
+        Self {
+            cfg,
+            inner: Mutex::new(DedupInner {
+                fingerprints: HashMap::new(),
+                global_window_start: Instant::now(),
+                global_new_issues: 0,
+            }),
+        }
+    }
+
+    pub fn decide(&self, fp: &str) -> CrashDecision {
+        self.decide_at(fp, Instant::now())
+    }
+
+    pub fn decide_at(&self, fp: &str, now: Instant) -> CrashDecision {
+        let mut inner = self.inner.lock().unwrap();
+
+        // Roll the global window.
+        if now.duration_since(inner.global_window_start) >= self.cfg.global_window {
+            inner.global_window_start = now;
+            inner.global_new_issues = 0;
+        }
+
+        let entry = inner
+            .fingerprints
+            .entry(fp.to_string())
+            .or_insert_with(|| FingerprintState {
+                issue_number: None,
+                window_start: now,
+                reports_in_window: 0,
+                last_seen: now,
+            });
+        entry.last_seen = now;
+
+        // Roll the per-fingerprint window (keep the known issue number so a
+        // recurring crash keeps appending to the same issue across windows).
+        if now.duration_since(entry.window_start) >= self.cfg.per_fingerprint_window {
+            entry.window_start = now;
+            entry.reports_in_window = 0;
+        }
+
+        entry.reports_in_window += 1;
+        if entry.reports_in_window > self.cfg.per_fingerprint_max_reports {
+            return CrashDecision::DropSpikeCapped;
+        }
+
+        if let Some(number) = entry.issue_number {
+            return CrashDecision::AppendToIssue(number);
+        }
+
+        // Needs a new issue — check the global backstop.
+        if inner.global_new_issues >= self.cfg.global_max_new_issues {
+            return CrashDecision::DropGlobalCapped;
+        }
+        inner.global_new_issues += 1;
+        CrashDecision::CreateIssue
+    }
+
+    /// Record the issue number after a successful create, so subsequent reports
+    /// for this fingerprint append instead of opening duplicates.
+    pub fn record_issue_number(&self, fp: &str, number: u64) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(entry) = inner.fingerprints.get_mut(fp) {
+            entry.issue_number = Some(number);
+        }
+    }
+
+    /// Evict fingerprint entries not seen within 2× the per-fingerprint window
+    /// so the map can't grow without bound. Dropping an idle entry only loses
+    /// dedup for a crash that hasn't recurred in a long time (it would open a
+    /// fresh issue next time, which is fine).
+    pub fn sweep_expired(&self) {
+        self.sweep_expired_at(Instant::now());
+    }
+
+    pub fn sweep_expired_at(&self, now: Instant) {
+        let ttl = self.cfg.per_fingerprint_window.saturating_mul(2);
+        let mut inner = self.inner.lock().unwrap();
+        inner
+            .fingerprints
+            .retain(|_, st| now.duration_since(st.last_seen) < ttl);
+    }
+
+    pub fn tracked_fingerprints(&self) -> usize {
+        self.inner.lock().unwrap().fingerprints.len()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GitHub issue filing
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Error)]
+pub enum GitHubError {
+    #[error("http error: {0}")]
+    Http(String),
+    #[error("github api error: status {0}: {1}")]
+    Api(u16, String),
+}
+
+/// Files / appends GitHub issues. Behind a trait so tests substitute a fake
+/// and the relay never needs network access to exercise the pipeline.
+#[async_trait]
+pub trait GitHubIssueFiler: Send + Sync {
+    async fn create_issue(
+        &self,
+        title: &str,
+        body: &str,
+        labels: &[&str],
+    ) -> Result<u64, GitHubError>;
+    async fn comment_issue(&self, number: u64, body: &str) -> Result<(), GitHubError>;
+}
+
+/// Real filer talking to the GitHub REST API.
+pub struct RealGitHubIssueFiler {
+    http: reqwest::Client,
+    api_base: String,
+    repo: String,
+    token: String,
+}
+
+impl RealGitHubIssueFiler {
+    pub fn new(api_base: String, repo: String, token: String) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            api_base: api_base.trim_end_matches('/').to_string(),
+            repo,
+            token,
+        }
+    }
+}
+
+#[async_trait]
+impl GitHubIssueFiler for RealGitHubIssueFiler {
+    async fn create_issue(
+        &self,
+        title: &str,
+        body: &str,
+        labels: &[&str],
+    ) -> Result<u64, GitHubError> {
+        let url = format!("{}/repos/{}/issues", self.api_base, self.repo);
+        let payload = serde_json::json!({
+            "title": title,
+            "body": body,
+            "labels": labels,
+        });
+        let resp = self
+            .http
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.token))
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", "rouse-relay")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| GitHubError::Http(e.to_string()))?;
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(GitHubError::Api(status.as_u16(), text));
+        }
+        let parsed: Value =
+            serde_json::from_str(&text).map_err(|e| GitHubError::Http(e.to_string()))?;
+        parsed
+            .get("number")
+            .and_then(|n| n.as_u64())
+            .ok_or_else(|| GitHubError::Api(status.as_u16(), "missing issue number".to_string()))
+    }
+
+    async fn comment_issue(&self, number: u64, body: &str) -> Result<(), GitHubError> {
+        let url = format!(
+            "{}/repos/{}/issues/{}/comments",
+            self.api_base, self.repo, number
+        );
+        let payload = serde_json::json!({ "body": body });
+        let resp = self
+            .http
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.token))
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", "rouse-relay")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|e| GitHubError::Http(e.to_string()))?;
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(GitHubError::Api(status.as_u16(), text));
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CrashService — ties the pipeline together
+// ---------------------------------------------------------------------------
+
+/// Outcome of ingesting one crash report (returned for logging/tests).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CrashIngestOutcome {
+    /// New GitHub issue opened.
+    Filed(u64),
+    /// Appended a comment to an existing issue.
+    Appended(u64),
+    /// Spike-capped duplicate (same fingerprint, over the per-window cap).
+    DroppedDuplicate,
+    /// Global new-issue cap reached this window.
+    DroppedCapped,
+    /// GitHub token not configured: sanitized + logged, nothing filed.
+    NoSink,
+    /// Report carried no usable stack trace.
+    InvalidReport,
+    /// GitHub API call failed (logged; the device is not told).
+    FilingFailed,
+}
+
+/// Per-IP rate-limit defaults for `/crash`: ~10 accepted POSTs/min per source
+/// IP, burst 20. A crash loop on one device is further bounded by the
+/// spike-cap; this just stops raw flooding before any work is done.
+fn default_ip_rate_config() -> RateLimitConfig {
+    RateLimitConfig {
+        max_tokens: 20,
+        refill_interval: Duration::from_secs(6),
+    }
+}
+
+/// Owns the crash pipeline: per-IP limiter, dedup/cap registry, and the
+/// (optional) GitHub filer. Lives in [`crate::api::AppState`].
+pub struct CrashService {
+    filer: Option<Arc<dyn GitHubIssueFiler>>,
+    ip_limiter: RateLimiter,
+    dedup: CrashDedup,
+}
+
+impl CrashService {
+    pub fn new(
+        filer: Option<Arc<dyn GitHubIssueFiler>>,
+        ip_rate: RateLimitConfig,
+        limits: CrashLimitsConfig,
+    ) -> Self {
+        Self {
+            filer,
+            ip_limiter: RateLimiter::new(ip_rate),
+            dedup: CrashDedup::new(limits),
+        }
+    }
+
+    /// A service with no GitHub sink and default limits — used by tests and as
+    /// the production default when no token/repo is configured.
+    pub fn disabled() -> Self {
+        Self::new(None, default_ip_rate_config(), CrashLimitsConfig::default())
+    }
+
+    /// Convenience constructor mirroring the production wiring.
+    pub fn with_filer(filer: Option<Arc<dyn GitHubIssueFiler>>) -> Self {
+        Self::new(
+            filer,
+            default_ip_rate_config(),
+            CrashLimitsConfig::default(),
+        )
+    }
+
+    /// Per-IP admission check. `Ok(())` if allowed, `Err(retry_after_secs)` if
+    /// rate-limited. Call before doing any parsing work.
+    pub fn allow_ip(&self, ip: &str) -> Result<(), u64> {
+        self.ip_limiter.try_acquire(ip)
+    }
+
+    /// Whether GitHub filing is configured.
+    pub fn has_sink(&self) -> bool {
+        self.filer.is_some()
+    }
+
+    pub fn dedup(&self) -> &CrashDedup {
+        &self.dedup
+    }
+
+    /// Evict expired per-IP limiter buckets and idle fingerprint entries so the
+    /// in-memory maps can't grow without bound. Called from the shared
+    /// rate-limit sweep loop.
+    pub fn sweep_expired(&self) {
+        self.ip_limiter.sweep_expired();
+        self.dedup.sweep_expired();
+    }
+
+    /// Sanitize → dedup/cap → file. Returns the outcome for logging.
+    pub async fn process(&self, raw: &Value) -> CrashIngestOutcome {
+        let report = match build_sanitized_report(raw) {
+            Some(r) => r,
+            None => return CrashIngestOutcome::InvalidReport,
+        };
+
+        match self.dedup.decide(&report.fingerprint) {
+            CrashDecision::DropSpikeCapped => {
+                info!(fingerprint = %report.fingerprint, "crash report spike-capped");
+                CrashIngestOutcome::DroppedDuplicate
+            }
+            CrashDecision::DropGlobalCapped => {
+                warn!(fingerprint = %report.fingerprint, "crash global new-issue cap reached");
+                CrashIngestOutcome::DroppedCapped
+            }
+            CrashDecision::CreateIssue => self.create(&report).await,
+            CrashDecision::AppendToIssue(number) => self.append(&report, number).await,
+        }
+    }
+
+    async fn create(&self, report: &SanitizedReport) -> CrashIngestOutcome {
+        let Some(filer) = &self.filer else {
+            info!(
+                fingerprint = %report.fingerprint,
+                title = %report.title,
+                "crash report sanitized but GitHub filing not configured (no-op)"
+            );
+            return CrashIngestOutcome::NoSink;
+        };
+        match filer
+            .create_issue(&report.title, &report.body, &["crash"])
+            .await
+        {
+            Ok(number) => {
+                self.dedup.record_issue_number(&report.fingerprint, number);
+                info!(fingerprint = %report.fingerprint, issue = number, "filed crash issue");
+                CrashIngestOutcome::Filed(number)
+            }
+            Err(e) => {
+                warn!(fingerprint = %report.fingerprint, error = %e, "failed to file crash issue");
+                CrashIngestOutcome::FilingFailed
+            }
+        }
+    }
+
+    async fn append(&self, report: &SanitizedReport, number: u64) -> CrashIngestOutcome {
+        let Some(filer) = &self.filer else {
+            return CrashIngestOutcome::NoSink;
+        };
+        let comment = format!("Recurrence of this crash.\n\n```\n{}\n```\n", report.body);
+        match filer.comment_issue(number, &comment).await {
+            Ok(()) => {
+                info!(fingerprint = %report.fingerprint, issue = number, "appended crash recurrence");
+                CrashIngestOutcome::Appended(number)
+            }
+            Err(e) => {
+                warn!(fingerprint = %report.fingerprint, error = %e, "failed to append crash recurrence");
+                CrashIngestOutcome::FilingFailed
+            }
+        }
+    }
+}
+
+/// Build the production GitHub filer from config, or `None` when filing is not
+/// configured (no `crash_repo` or the token env var is unset/empty). When
+/// `None`, the endpoint still sanitizes + dedups + logs and returns 202.
+pub fn build_filer_from_config(
+    cfg: &crate::config::GitHubConfig,
+) -> Option<Arc<dyn GitHubIssueFiler>> {
+    if cfg.crash_repo.is_empty() {
+        info!("[github] crash_repo not configured; /crash will sanitize+log only");
+        return None;
+    }
+    match cfg.resolve_token() {
+        Some(token) => {
+            info!(repo = %cfg.crash_repo, "[github] crash issue filing enabled");
+            Some(Arc::new(RealGitHubIssueFiler::new(
+                cfg.api_base_url.clone(),
+                cfg.crash_repo.clone(),
+                token,
+            )))
+        }
+        None => {
+            warn!(
+                env = %cfg.token_env,
+                repo = %cfg.crash_repo,
+                "[github] crash_repo set but token env var unset; /crash will sanitize+log only"
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_STACK: &str = "java.lang.IllegalStateException: widget 42 not ready\n\tat com.rousecontext.app.Foo.bar(Foo.kt:42)\n\tat com.rousecontext.app.Baz.qux(Baz.kt:13)";
+
+    #[test]
+    fn sanitize_redacts_email_ip_path_token() {
+        let input =
+            "user alice@example.com from 192.168.1.7 at /storage/emulated/0/Android/data/secret \
+             token ABCDEFGHIJKLMNOPQRSTUVWXYZ012345678";
+        let out = sanitize_text(input);
+        assert!(out.contains("[redacted-email]"), "{out}");
+        assert!(out.contains("[redacted-ip]"), "{out}");
+        assert!(out.contains("/storage/emulated/0/[redacted-path]"), "{out}");
+        assert!(out.contains("[redacted-token]"), "{out}");
+        assert!(!out.contains("alice@example.com"));
+        assert!(!out.contains("192.168.1.7"));
+        assert!(!out.contains("secret"));
+    }
+
+    #[test]
+    fn sanitize_keeps_normal_stack_frames() {
+        let out = sanitize_text(SAMPLE_STACK);
+        assert!(out.contains("com.rousecontext.app.Foo.bar"));
+        assert!(out.contains("IllegalStateException"));
+    }
+
+    #[test]
+    fn fingerprint_is_stable_across_messages_and_line_numbers() {
+        let a =
+            "java.lang.IllegalStateException: widget 42 not ready\n\tat com.x.Foo.bar(Foo.kt:42)";
+        let b =
+            "java.lang.IllegalStateException: widget 99 not ready\n\tat com.x.Foo.bar(Foo.kt:77)";
+        assert_eq!(fingerprint(a), fingerprint(b));
+    }
+
+    #[test]
+    fn fingerprint_differs_for_different_crashes() {
+        let a = "java.lang.IllegalStateException: x\n\tat com.x.Foo.bar(Foo.kt:42)";
+        let b = "java.lang.NullPointerException: y\n\tat com.x.Other.baz(Other.kt:1)";
+        assert_ne!(fingerprint(a), fingerprint(b));
+    }
+
+    #[test]
+    fn build_sanitized_report_requires_stack_trace() {
+        let raw = serde_json::json!({ "APP_VERSION_NAME": "1.0.3" });
+        assert!(build_sanitized_report(&raw).is_none());
+    }
+
+    #[test]
+    fn build_sanitized_report_drops_identifying_fields() {
+        let raw = serde_json::json!({
+            "STACK_TRACE": SAMPLE_STACK,
+            "APP_VERSION_NAME": "1.0.3",
+            "ANDROID_VERSION": "14",
+            "INSTALLATION_ID": "11111111-2222-3333-4444-555555555555",
+            "USER_EMAIL": "alice@example.com",
+            "LOGCAT": "private logs here",
+        });
+        let report = build_sanitized_report(&raw).unwrap();
+        assert!(report.body.contains("1.0.3"));
+        assert!(report.body.contains("Android version"));
+        assert!(!report.body.contains("11111111-2222"));
+        assert!(!report.body.contains("alice@example.com"));
+        assert!(!report.body.contains("private logs here"));
+        assert!(report.title.starts_with("[crash] IllegalStateException ("));
+    }
+
+    #[test]
+    fn dedup_first_creates_then_appends() {
+        let dedup = CrashDedup::new(CrashLimitsConfig::default());
+        let now = Instant::now();
+        assert_eq!(dedup.decide_at("fp1", now), CrashDecision::CreateIssue);
+        // Before the issue number is recorded, a second report still wants the
+        // issue created (idempotent create intent) — but once recorded it
+        // appends.
+        dedup.record_issue_number("fp1", 7);
+        assert_eq!(dedup.decide_at("fp1", now), CrashDecision::AppendToIssue(7));
+    }
+
+    #[test]
+    fn dedup_spike_caps_per_fingerprint() {
+        let cfg = CrashLimitsConfig {
+            per_fingerprint_max_reports: 3,
+            ..CrashLimitsConfig::default()
+        };
+        let dedup = CrashDedup::new(cfg);
+        let now = Instant::now();
+        assert_eq!(dedup.decide_at("fp", now), CrashDecision::CreateIssue);
+        dedup.record_issue_number("fp", 1);
+        assert_eq!(dedup.decide_at("fp", now), CrashDecision::AppendToIssue(1));
+        assert_eq!(dedup.decide_at("fp", now), CrashDecision::AppendToIssue(1));
+        // 4th report in the window is spike-capped.
+        assert_eq!(dedup.decide_at("fp", now), CrashDecision::DropSpikeCapped);
+    }
+
+    #[test]
+    fn dedup_resets_after_window() {
+        let cfg = CrashLimitsConfig {
+            per_fingerprint_max_reports: 1,
+            per_fingerprint_window: Duration::from_secs(60),
+            ..CrashLimitsConfig::default()
+        };
+        let dedup = CrashDedup::new(cfg);
+        let now = Instant::now();
+        assert_eq!(dedup.decide_at("fp", now), CrashDecision::CreateIssue);
+        dedup.record_issue_number("fp", 5);
+        assert_eq!(dedup.decide_at("fp", now), CrashDecision::DropSpikeCapped);
+        // After the window, counting resets; the known issue number is kept so
+        // it appends rather than opening a duplicate.
+        let later = now + Duration::from_secs(61);
+        assert_eq!(
+            dedup.decide_at("fp", later),
+            CrashDecision::AppendToIssue(5)
+        );
+    }
+
+    #[test]
+    fn dedup_global_cap_blocks_new_issues_across_fingerprints() {
+        let cfg = CrashLimitsConfig {
+            global_max_new_issues: 2,
+            per_fingerprint_max_reports: 10,
+            ..CrashLimitsConfig::default()
+        };
+        let dedup = CrashDedup::new(cfg);
+        let now = Instant::now();
+        assert_eq!(dedup.decide_at("a", now), CrashDecision::CreateIssue);
+        assert_eq!(dedup.decide_at("b", now), CrashDecision::CreateIssue);
+        // Third distinct fingerprint can't open a new issue this window.
+        assert_eq!(dedup.decide_at("c", now), CrashDecision::DropGlobalCapped);
+    }
+
+    #[test]
+    fn dedup_sweep_evicts_idle_fingerprints() {
+        let cfg = CrashLimitsConfig {
+            per_fingerprint_window: Duration::from_secs(60),
+            ..CrashLimitsConfig::default()
+        };
+        let dedup = CrashDedup::new(cfg);
+        let now = Instant::now();
+        dedup.decide_at("fp", now);
+        assert_eq!(dedup.tracked_fingerprints(), 1);
+        dedup.sweep_expired_at(now + Duration::from_secs(59));
+        assert_eq!(dedup.tracked_fingerprints(), 1);
+        dedup.sweep_expired_at(now + Duration::from_secs(121));
+        assert_eq!(dedup.tracked_fingerprints(), 0);
+    }
+
+    // --- CrashService orchestration via a fake filer ---
+
+    struct FakeFiler {
+        creates: Mutex<Vec<(String, String)>>,
+        comments: Mutex<Vec<(u64, String)>>,
+        next_number: Mutex<u64>,
+        fail: bool,
+    }
+
+    impl FakeFiler {
+        fn new() -> Self {
+            Self {
+                creates: Mutex::new(Vec::new()),
+                comments: Mutex::new(Vec::new()),
+                next_number: Mutex::new(100),
+                fail: false,
+            }
+        }
+        fn failing() -> Self {
+            Self {
+                fail: true,
+                ..Self::new()
+            }
+        }
+    }
+
+    #[async_trait]
+    impl GitHubIssueFiler for FakeFiler {
+        async fn create_issue(
+            &self,
+            title: &str,
+            body: &str,
+            _labels: &[&str],
+        ) -> Result<u64, GitHubError> {
+            if self.fail {
+                return Err(GitHubError::Http("boom".into()));
+            }
+            self.creates
+                .lock()
+                .unwrap()
+                .push((title.to_string(), body.to_string()));
+            let mut n = self.next_number.lock().unwrap();
+            let number = *n;
+            *n += 1;
+            Ok(number)
+        }
+        async fn comment_issue(&self, number: u64, body: &str) -> Result<(), GitHubError> {
+            if self.fail {
+                return Err(GitHubError::Http("boom".into()));
+            }
+            self.comments
+                .lock()
+                .unwrap()
+                .push((number, body.to_string()));
+            Ok(())
+        }
+    }
+
+    fn sample_report() -> Value {
+        serde_json::json!({
+            "STACK_TRACE": SAMPLE_STACK,
+            "APP_VERSION_NAME": "1.0.3",
+        })
+    }
+
+    #[tokio::test]
+    async fn process_files_then_appends_same_fingerprint() {
+        let filer = Arc::new(FakeFiler::new());
+        let svc = CrashService::with_filer(Some(filer.clone()));
+        let first = svc.process(&sample_report()).await;
+        assert!(matches!(first, CrashIngestOutcome::Filed(_)));
+        let second = svc.process(&sample_report()).await;
+        assert!(matches!(second, CrashIngestOutcome::Appended(_)));
+        assert_eq!(filer.creates.lock().unwrap().len(), 1);
+        assert_eq!(filer.comments.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn process_no_sink_when_filer_absent() {
+        let svc = CrashService::disabled();
+        assert_eq!(
+            svc.process(&sample_report()).await,
+            CrashIngestOutcome::NoSink
+        );
+    }
+
+    #[tokio::test]
+    async fn process_invalid_report_without_stack() {
+        let svc = CrashService::disabled();
+        let raw = serde_json::json!({ "APP_VERSION_NAME": "1.0.3" });
+        assert_eq!(svc.process(&raw).await, CrashIngestOutcome::InvalidReport);
+    }
+
+    #[tokio::test]
+    async fn process_filing_failure_is_reported_not_panicked() {
+        let svc = CrashService::with_filer(Some(Arc::new(FakeFiler::failing())));
+        assert_eq!(
+            svc.process(&sample_report()).await,
+            CrashIngestOutcome::FilingFailed
+        );
+    }
+
+    #[test]
+    fn ip_rate_limit_rejects_after_burst() {
+        let svc = CrashService::new(
+            None,
+            RateLimitConfig {
+                max_tokens: 2,
+                refill_interval: Duration::from_secs(10),
+            },
+            CrashLimitsConfig::default(),
+        );
+        assert!(svc.allow_ip("1.2.3.4").is_ok());
+        assert!(svc.allow_ip("1.2.3.4").is_ok());
+        assert!(svc.allow_ip("1.2.3.4").is_err());
+        // A different IP has its own bucket.
+        assert!(svc.allow_ip("5.6.7.8").is_ok());
+    }
+}

--- a/relay/src/crash.rs
+++ b/relay/src/crash.rs
@@ -106,7 +106,14 @@ pub fn sanitize_text(input: &str) -> String {
     let s = ipv4_re().replace_all(&s, "[redacted-ip]");
     let s = user_path_re().replace_all(&s, "$1/[redacted-path]");
     let s = long_token_re().replace_all(&s, "[redacted-token]");
-    s.into_owned()
+    // Defang GitHub markup: the sanitized text is interpolated into a public
+    // GitHub issue title/body (the allowlisted fields render outside the fenced
+    // code block). A crafted crash report could otherwise inject `@mentions`
+    // (notification-email spam) or `#123` issue refs (cross-reference spam) to
+    // arbitrary users/issues, bounded only by the 20/hr global cap. A zero-width
+    // space after `@`/`#` breaks GitHub's parser without changing the displayed
+    // text.
+    s.replace('@', "@\u{200B}").replace('#', "#\u{200B}")
 }
 
 // ---------------------------------------------------------------------------
@@ -700,6 +707,17 @@ mod tests {
         let out = sanitize_text(SAMPLE_STACK);
         assert!(out.contains("com.rousecontext.app.Foo.bar"));
         assert!(out.contains("IllegalStateException"));
+    }
+
+    #[test]
+    fn sanitize_neutralizes_github_mentions_and_refs() {
+        let out = sanitize_text("crash near @evil and ref #1337 in 1.0.3");
+        // @mention notification spam and #issue cross-ref spam are defanged
+        // with a zero-width space; the visible text is unchanged.
+        assert!(!out.contains("@evil"), "{out}");
+        assert!(out.contains("@\u{200B}evil"), "{out}");
+        assert!(!out.contains("#1337"), "{out}");
+        assert!(out.contains("#\u{200B}1337"), "{out}");
     }
 
     #[test]

--- a/relay/src/lib.rs
+++ b/relay/src/lib.rs
@@ -3,6 +3,7 @@ pub mod api;
 pub mod caa_check;
 pub mod cloudflare_dns;
 pub mod config;
+pub mod crash;
 pub mod device_ca;
 pub mod dns;
 pub mod dns_challenge;

--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -189,6 +189,12 @@ async fn main() {
     // allows a retry on the next client connection.
     let fcm_wake_throttle = Arc::new(FcmWakeThrottle::new(Duration::from_secs(10)));
 
+    // Crash-report ingestion (#464). The GitHub filer is `None` when no repo /
+    // token is configured — the endpoint then sanitizes + dedups + logs and
+    // returns 202 without filing (graceful no-op).
+    let crash_filer = rouse_relay::crash::build_filer_from_config(&config.github);
+    let crash = Arc::new(rouse_relay::crash::CrashService::with_filer(crash_filer));
+
     let app_state = Arc::new(AppState {
         relay_state: relay_state.clone(),
         session_registry: session_registry.clone(),
@@ -205,6 +211,7 @@ async fn main() {
             request_subdomain_limiter_cfg,
         ),
         fcm_wake_throttle: fcm_wake_throttle.clone(),
+        crash,
         config: config.clone(),
         device_ca,
         #[cfg(feature = "test-mode")]
@@ -490,12 +497,16 @@ async fn handle_connection(
 
 async fn handle_relay_api(
     stream: tokio::net::TcpStream,
-    _peer_addr: std::net::SocketAddr,
+    peer_addr: std::net::SocketAddr,
     tls_config: Option<Arc<rustls::ServerConfig>>,
     base_domain: &str,
     app_state: Arc<AppState>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let router = api::build_router(app_state);
+    // Source IP for per-IP rate limiting (e.g. `POST /crash`, #464). Injected
+    // as a request extension since the in-handler axum context otherwise has no
+    // access to the TCP peer address.
+    let client_ip = api::ClientIp(peer_addr.ip());
+    let router = api::build_router(app_state).layer(axum::Extension(client_ip));
 
     match tls_config {
         Some(tls_cfg) => {

--- a/relay/src/rate_limit.rs
+++ b/relay/src/rate_limit.rs
@@ -302,6 +302,7 @@ pub async fn run_rate_limit_sweep_loop(
             _ = tokio::time::sleep(interval) => {
                 app_state.rate_limiter.sweep_expired();
                 app_state.request_subdomain_rate_limiter.sweep_expired();
+                app_state.crash.sweep_expired();
                 fcm_wake_throttle.sweep_expired();
                 conn_rate_limiter.sweep_expired();
                 tracing::debug!(

--- a/relay/tests/api_status_test.rs
+++ b/relay/tests/api_status_test.rs
@@ -27,6 +27,7 @@ fn make_app(relay_state: Arc<RelayState>) -> axum::Router {
         fcm_wake_throttle: Arc::new(rouse_relay::rate_limit::FcmWakeThrottle::new(
             std::time::Duration::from_secs(10),
         )),
+        crash: Arc::new(rouse_relay::crash::CrashService::disabled()),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: None,
         #[cfg(feature = "test-mode")]

--- a/relay/tests/crash_test.rs
+++ b/relay/tests/crash_test.rs
@@ -1,0 +1,147 @@
+//! Endpoint tests for `POST /crash` (issue #464).
+//!
+//! Unit coverage for sanitization / fingerprinting / dedup / spike-cap / global
+//! cap and the per-IP limiter lives in `src/crash.rs`. Here we drive the HTTP
+//! handler end-to-end through the router to verify status-code behaviour and
+//! that a configured GitHub filer actually gets called.
+
+mod test_helpers;
+
+use async_trait::async_trait;
+use rouse_relay::api::build_router;
+use rouse_relay::crash::{CrashLimitsConfig, CrashService, GitHubError, GitHubIssueFiler};
+use rouse_relay::rate_limit::RateLimitConfig;
+use rouse_relay::state::RelayState;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use test_helpers::*;
+
+struct RecordingFiler {
+    creates: Mutex<u32>,
+}
+
+impl RecordingFiler {
+    fn new() -> Self {
+        Self {
+            creates: Mutex::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl GitHubIssueFiler for RecordingFiler {
+    async fn create_issue(
+        &self,
+        _title: &str,
+        _body: &str,
+        _labels: &[&str],
+    ) -> Result<u64, GitHubError> {
+        *self.creates.lock().unwrap() += 1;
+        Ok(42)
+    }
+    async fn comment_issue(&self, _number: u64, _body: &str) -> Result<(), GitHubError> {
+        Ok(())
+    }
+}
+
+fn make_app(crash: Arc<CrashService>) -> axum::Router {
+    let state = Arc::new(rouse_relay::api::AppState {
+        relay_state: Arc::new(RelayState::new()),
+        session_registry: Arc::new(rouse_relay::passthrough::SessionRegistry::new()),
+        firestore: Arc::new(MockFirestore::new()),
+        fcm: Arc::new(MockFcm::new()),
+        acme: Arc::new(MockAcme::new("cert")),
+        dns: Arc::new(MockDns::new()),
+        firebase_auth: Arc::new(MockFirebaseAuth::new()),
+        subdomain_generator: rouse_relay::subdomain::SubdomainGenerator::new(),
+        rate_limiter: rouse_relay::rate_limit::RateLimiter::new(RateLimitConfig::default()),
+        request_subdomain_rate_limiter: rouse_relay::rate_limit::RateLimiter::new(
+            RateLimitConfig::default(),
+        ),
+        fcm_wake_throttle: Arc::new(rouse_relay::rate_limit::FcmWakeThrottle::new(
+            Duration::from_secs(10),
+        )),
+        crash,
+        config: rouse_relay::config::RelayConfig::default(),
+        device_ca: None,
+        #[cfg(feature = "test-mode")]
+        test_metrics: None,
+    });
+    build_router(state)
+}
+
+fn post_crash(body: &str) -> axum::http::Request<axum::body::Body> {
+    axum::http::Request::builder()
+        .method("POST")
+        .uri("/crash")
+        .header("content-type", "application/json")
+        .body(axum::body::Body::from(body.to_string()))
+        .unwrap()
+}
+
+const SAMPLE: &str = r#"{"STACK_TRACE":"java.lang.IllegalStateException: boom\n\tat com.rousecontext.app.Foo.bar(Foo.kt:42)","APP_VERSION_NAME":"1.0.3"}"#;
+
+#[tokio::test]
+async fn crash_invalid_json_is_bad_request() {
+    let app = make_app(Arc::new(CrashService::disabled()));
+    let resp = tower::ServiceExt::oneshot(app, post_crash("not json"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn crash_missing_stack_trace_is_bad_request() {
+    let app = make_app(Arc::new(CrashService::disabled()));
+    let resp = tower::ServiceExt::oneshot(app, post_crash(r#"{"APP_VERSION_NAME":"1.0.3"}"#))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+#[tokio::test]
+async fn crash_without_sink_is_accepted() {
+    let app = make_app(Arc::new(CrashService::disabled()));
+    let resp = tower::ServiceExt::oneshot(app, post_crash(SAMPLE))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 202);
+}
+
+#[tokio::test]
+async fn crash_with_filer_files_issue_and_accepts() {
+    let filer = Arc::new(RecordingFiler::new());
+    let svc = CrashService::with_filer(Some(filer.clone()));
+    let app = make_app(Arc::new(svc));
+    let resp = tower::ServiceExt::oneshot(app, post_crash(SAMPLE))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 202);
+    assert_eq!(*filer.creates.lock().unwrap(), 1);
+}
+
+#[tokio::test]
+async fn crash_per_ip_rate_limit_rejects_after_burst() {
+    // Tiny bucket so the limiter trips after one request. The in-process test
+    // router shares the fallback "unknown" IP key, so the second request from
+    // the same (absent) source is rejected.
+    let svc = CrashService::new(
+        None,
+        RateLimitConfig {
+            max_tokens: 1,
+            refill_interval: Duration::from_secs(60),
+        },
+        CrashLimitsConfig::default(),
+    );
+    let app = make_app(Arc::new(svc));
+
+    let first = tower::ServiceExt::oneshot(app.clone(), post_crash(SAMPLE))
+        .await
+        .unwrap();
+    assert_eq!(first.status(), 202);
+
+    let second = tower::ServiceExt::oneshot(app, post_crash(SAMPLE))
+        .await
+        .unwrap();
+    assert_eq!(second.status(), 429);
+}

--- a/relay/tests/integration_test.rs
+++ b/relay/tests/integration_test.rs
@@ -158,6 +158,7 @@ async fn ws_upgrade_with_device_identity() {
         fcm_wake_throttle: Arc::new(rouse_relay::rate_limit::FcmWakeThrottle::new(
             std::time::Duration::from_secs(10),
         )),
+        crash: Arc::new(rouse_relay::crash::CrashService::disabled()),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: None,
         #[cfg(feature = "test-mode")]
@@ -279,6 +280,7 @@ async fn mux_frame_round_trip_through_ws() {
         fcm_wake_throttle: Arc::new(rouse_relay::rate_limit::FcmWakeThrottle::new(
             std::time::Duration::from_secs(10),
         )),
+        crash: Arc::new(rouse_relay::crash::CrashService::disabled()),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: None,
         #[cfg(feature = "test-mode")]

--- a/relay/tests/test_helpers.rs
+++ b/relay/tests/test_helpers.rs
@@ -479,6 +479,7 @@ pub fn build_test_state_with_dns(
         fcm_wake_throttle: Arc::new(rouse_relay::rate_limit::FcmWakeThrottle::new(
             std::time::Duration::from_secs(10),
         )),
+        crash: Arc::new(rouse_relay::crash::CrashService::disabled()),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: None,
         #[cfg(feature = "test-mode")]
@@ -524,6 +525,7 @@ pub fn build_test_state_with_ca(
         fcm_wake_throttle: Arc::new(rouse_relay::rate_limit::FcmWakeThrottle::new(
             std::time::Duration::from_secs(10),
         )),
+        crash: Arc::new(rouse_relay::crash::CrashService::disabled()),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: Some(ca),
         #[cfg(feature = "test-mode")]

--- a/relay/tests/valid_secrets_cache_test.rs
+++ b/relay/tests/valid_secrets_cache_test.rs
@@ -126,6 +126,7 @@ async fn rotate_secret_updates_cache_and_passthrough_accepts_new_secret() {
             },
         ),
         fcm_wake_throttle: Arc::new(FcmWakeThrottle::new(Duration::from_secs(10))),
+        crash: Arc::new(rouse_relay::crash::CrashService::disabled()),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: Some(ca),
         #[cfg(feature = "test-mode")]
@@ -235,6 +236,7 @@ async fn rotate_secret_cache_rejects_secrets_not_in_list() {
             },
         ),
         fcm_wake_throttle: Arc::new(FcmWakeThrottle::new(Duration::from_secs(10))),
+        crash: Arc::new(rouse_relay::crash::CrashService::disabled()),
         config: rouse_relay::config::RelayConfig::default(),
         device_ca: Some(ca),
         #[cfg(feature = "test-mode")]


### PR DESCRIPTION
Part of #460. Fixes #464.

The last implementation ticket of the F-Droid epic: Crashlytics-free crash reporting for the `foss` flavor, converging on GitHub issues (Crashlytics has no server-side ingestion API).

## App (foss flavor only)
- Adds **ACRA** (`ch.acra:acra-core` + `acra-http` 5.13.1) as `fossImplementation`. The `google` flavor never links it.
- Replaces the foss NoOp `CrashReporter` with **`AcraCrashReporter`** (forwards `logCaughtException`/`log`/`setCollectionEnabled` to `ACRA.errorReporter`). `google` keeps `FirebaseCrashReporter`; both sit behind the same Koin seam.
- ACRA needs `attachBaseContext` init (it forks a sender process), so `RouseApplication.attachBaseContext` now calls a flavor-specific **`CrashReporterInitializer`**: foss runs `ACRA.init(...)` with an `HttpSender` POSTing **JSON** to the relay's `POST /crash`; google is a no-op (Crashlytics self-initializes via its plugin ContentProvider).
- Respects the existing debug/release collection toggle (`RouseApplication.kt` `setCollectionEnabled(!isDebugBuild)`): ACRA collection is disabled in debug builds.

## Relay (`POST /crash` pipeline)
New `crash` module + endpoint. For each report: **sanitize** → **dedup** → **spike-cap** → **global cap** → file/append a GitHub issue labeled `crash`.
- **Sanitize**: field allowlist (only `APP_VERSION_*`, `ANDROID_VERSION`, `PHONE_MODEL`, `BRAND`, `PACKAGE_NAME` + the stack trace survive — `INSTALLATION_ID`/`DEVICE_ID`/`USER_EMAIL`/`LOGCAT`/etc. are dropped), plus regex redaction of emails / IPs / on-device paths / long opaque tokens in the stack trace.
- **Dedup**: stack-trace fingerprint (exception class + top frames, line numbers stripped, message dropped → stable across builds). Same fingerprint appends a comment instead of opening a new issue.
- **Spike-cap**: caps reports-per-fingerprint per window so one crash loop can't append forever.

## Security / abuse surface
`/crash` takes unauthenticated external POSTs and (indirectly) files GitHub issues — an abuse vector (cf. the #472 SSRF lesson). **Chosen protection: aggressive rate-limiting + capping, not device auth.** Device mTLS auth is intentionally NOT required — ACRA's `HttpSender` can't present the device client cert, and crashes must be reportable before a device is even provisioned. Instead, three in-memory layers:
1. **Per-IP token-bucket rate limit** (~10/min, burst 20) → `429` on flooding. (Plumbs the TCP peer IP into the relay-API router as a `ClientIp` extension.)
2. **Per-fingerprint spike-cap** → one crash loop ⇒ at most N touches/window.
3. **Global new-issue cap** (the real backstop) → bounds *new* issues/window even under IP/fingerprint rotation.

Responses are coarse (`202` for anything ingested, `400` no-stack-trace, `429` rate-limited, `413` too-large) so a caller can't probe dedup/cap state. Maps are swept by the existing rate-limit sweep loop (bounded memory on the $5/mo VPS).

## Ops dependency — GitHub token (Jason provisions)
Filing needs a GitHub token with `issues:write` on the repo:
```toml
[github]
crash_repo = "Monkopedia/rouse-context"
token_env  = "GITHUB_CRASH_TOKEN"   # name only; token set in /etc/rouse-relay/env
```
**If `crash_repo` is empty or the token env var is unset, the endpoint still sanitizes + dedups + logs and returns 202 — it just skips filing (graceful no-op, never crashes).** Documented in `relay/README.md` + `relay.example.toml`.

## Tests
- Relay unit (`src/crash.rs`): sanitization, fingerprint stability/divergence, allowlist drops identifying fields, dedup create→append, spike-cap, window reset, global cap, sweep eviction, per-IP rejection, filing orchestration via a fake filer.
- Relay endpoint (`tests/crash_test.rs`): invalid JSON → 400, missing stack → 400, no-sink → 202, filer-called → 202, per-IP burst → 429.
- App: `testFoss` smoke test for `AcraCrashReporter` (degrades gracefully pre-init).

## Verification
- Relay: `cargo fmt --check` clean, `cargo test` (280+ tests incl. new crash tests) green, `cargo clippy --all-targets --all-features -- -D warnings` clean.
- App: `:app:assembleFossDebug` + `:app:assembleGoogleDebug` + `:app:testGoogleDebugUnitTest` + `:app:testFossDebugUnitTest` + `ktlintCheck` + `detekt` all green.
- Confirmed `firebase-crashlytics` is absent from the foss runtime classpath (present in google). The foss CrashReporter binding resolves to the ACRA impl.

## Note (out of scope for #464)
The foss runtime classpath still pulls `firebase-auth`/`firebase-messaging` transitively via the `:work` module (`FirebaseRenewalAuthProvider`) — pre-existing, not touched here. That's the broader epic's module-decoupling concern (the #462 keypair-auth/`:work` cleanup), not crash reporting. **Crashlytty is fully removed from foss; this PR's scope is met.**