### PR TITLE
FOSS #476: decouple :work from Firebase so the foss APK links zero firebase-*

### DIFF
--- a/app/src/foss/java/com/rousecontext/app/di/DistributionModule.kt
+++ b/app/src/foss/java/com/rousecontext/app/di/DistributionModule.kt
@@ -8,11 +8,13 @@ import com.rousecontext.app.auth.KeypairRenewalAuthProvider
 import com.rousecontext.app.auth.NoOpFcmTokenProvider
 import com.rousecontext.app.delivery.BackgroundDelivery
 import com.rousecontext.app.delivery.UnifiedPushBackgroundDelivery
+import com.rousecontext.app.push.NoOpConnectPushReporter
 import com.rousecontext.app.state.DeviceRegistrationStatus
 import com.rousecontext.app.support.AcraCrashReporter
 import com.rousecontext.tunnel.CertificateStore
 import com.rousecontext.tunnel.OnboardingFlow
 import com.rousecontext.tunnel.TunnelClient
+import com.rousecontext.work.ConnectPushReporter
 import com.rousecontext.work.RenewalAuthProvider
 import kotlinx.coroutines.CoroutineScope
 import org.koin.android.ext.koin.androidContext
@@ -40,6 +42,12 @@ val distributionModule = module {
     // UnifiedPush endpoint (reported via BackgroundDelivery), so the FCM-token
     // seam stays a no-op (empty token). Issue #463.
     single<FcmTokenProvider> { NoOpFcmTokenProvider() }
+
+    // Per-connect push-target sync (issue #476): no-op for foss. The UnifiedPush
+    // endpoint is reported to the relay by UnifiedPushBackgroundDelivery on
+    // endpoint delivery/rotation, not on each tunnel connect — and there is no
+    // FCM token to push, keeping firebase-messaging out of the foss build.
+    single<ConnectPushReporter> { NoOpConnectPushReporter }
 
     // Background delivery (UnifiedPush wake path). Bound as the concrete type so
     // UnifiedPushReceiver can invoke its endpoint callbacks, and exposed via the

--- a/app/src/foss/java/com/rousecontext/app/push/NoOpConnectPushReporter.kt
+++ b/app/src/foss/java/com/rousecontext/app/push/NoOpConnectPushReporter.kt
@@ -1,0 +1,15 @@
+package com.rousecontext.app.push
+
+import com.rousecontext.work.ConnectPushReporter
+
+/**
+ * `foss`-flavor [ConnectPushReporter]: a no-op. The foss build wakes via
+ * UnifiedPush, whose endpoint is reported to the relay by
+ * [com.rousecontext.app.delivery.UnifiedPushBackgroundDelivery] (on endpoint
+ * delivery / rotation), not on each tunnel connect. There is no FCM token to
+ * push, so the per-connect sync does nothing here — keeping the foss APK free
+ * of any `firebase-messaging` linkage (issue #476).
+ */
+object NoOpConnectPushReporter : ConnectPushReporter {
+    override suspend fun reportOnConnect() = Unit
+}

--- a/app/src/foss/java/com/rousecontext/app/push/UnifiedPushReceiver.kt
+++ b/app/src/foss/java/com/rousecontext/app/push/UnifiedPushReceiver.kt
@@ -12,7 +12,8 @@ import org.unifiedpush.android.connector.MessagingReceiver
 
 /**
  * UnifiedPush message receiver for the `foss` flavor (issue #463) — the
- * Firebase-free counterpart of [com.rousecontext.work.FcmReceiver].
+ * Firebase-free counterpart of the `google` flavor's
+ * `com.rousecontext.app.push.FcmReceiver`.
  *
  * - [onMessage] routes the relay's `{"type":"wake"}` / `{"type":"renew"}`
  *   payload (delivered as the POST body by the relay's UnifiedPushClient)

--- a/app/src/google/AndroidManifest.xml
+++ b/app/src/google/AndroidManifest.xml
@@ -3,13 +3,13 @@
 
     <application>
         <!--
-            FCM receiver, present only in the `google` flavor. The class lives in
-            the shared `:work` module but its manifest entry is flavor-scoped here
-            so the Firebase Cloud Messaging service is absent from the `foss`
-            build's merged manifest. See issue #461.
+            FCM receiver, present only in the `google` flavor. Both the class and
+            its manifest entry live in this `google` source set so the
+            Firebase Cloud Messaging service — and all firebase-messaging
+            bytecode — is absent from the `foss` build (issues #461, #476).
         -->
         <service
-            android:name="com.rousecontext.work.FcmReceiver"
+            android:name="com.rousecontext.app.push.FcmReceiver"
             android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />

--- a/app/src/google/java/com/rousecontext/app/auth/FirebaseRenewalAuthProvider.kt
+++ b/app/src/google/java/com/rousecontext/app/auth/FirebaseRenewalAuthProvider.kt
@@ -1,7 +1,10 @@
-package com.rousecontext.work
+package com.rousecontext.app.auth
 
 import android.util.Log
 import com.google.firebase.auth.FirebaseAuth
+import com.rousecontext.work.DeviceKeystoreSigner
+import com.rousecontext.work.FirebaseCredentials
+import com.rousecontext.work.RenewalAuthProvider
 import kotlinx.coroutines.tasks.await
 
 /**
@@ -15,6 +18,10 @@ fun interface FirebaseIdTokenSource {
 /**
  * Default [RenewalAuthProvider] implementation bridging [FirebaseAuth] (for the ID token)
  * and the Android Keystore (for the SHA256withECDSA signature over the CSR DER).
+ *
+ * `google`-flavor-only (issue #476): lives in the `:app` `google` source set so the
+ * shared `:work` module links no `firebase-auth`. The `foss` flavor binds
+ * `KeypairRenewalAuthProvider` instead.
  *
  * Returning `null` is the correct failure mode: the worker treats it as a transient
  * condition and retries on the next periodic tick. This keeps us from retry-storming when

--- a/app/src/google/java/com/rousecontext/app/di/DistributionModule.kt
+++ b/app/src/google/java/com/rousecontext/app/di/DistributionModule.kt
@@ -9,10 +9,12 @@ import com.rousecontext.app.auth.FirebaseAnonymousAuthClient
 import com.rousecontext.app.auth.FirebaseDeviceAuthTokenProvider
 import com.rousecontext.app.auth.FirebaseDeviceCredentialProvider
 import com.rousecontext.app.auth.FirebaseFcmTokenProvider
+import com.rousecontext.app.auth.FirebaseRenewalAuthProvider
 import com.rousecontext.app.delivery.BackgroundDelivery
 import com.rousecontext.app.delivery.NoOpBackgroundDelivery
+import com.rousecontext.app.push.FcmConnectPushReporter
 import com.rousecontext.app.support.FirebaseCrashReporter
-import com.rousecontext.work.FirebaseRenewalAuthProvider
+import com.rousecontext.work.ConnectPushReporter
 import com.rousecontext.work.RenewalAuthProvider
 import org.koin.dsl.module
 
@@ -37,11 +39,19 @@ val distributionModule = module {
     single<FcmTokenProvider> { FirebaseFcmTokenProvider() }
     single<DeviceAuthTokenProvider> { FirebaseDeviceAuthTokenProvider() }
 
+    // Per-connect push-target sync (issue #476): fetch the current FCM token and
+    // forward it to the relay each time the tunnel connects. The foss flavor
+    // binds a no-op since it reports a UnifiedPush endpoint instead.
+    single<ConnectPushReporter> {
+        FcmConnectPushReporter(tunnelClient = get(), tokenProvider = get())
+    }
+
     // Device-auth seam (issue #462): wraps the Firebase anon/ID-token clients.
     single<DeviceCredentialProvider> {
         FirebaseDeviceCredentialProvider(anonymousAuth = get(), deviceAuth = get())
     }
 
     // Cert-renewal auth provider (Firebase ID token + Keystore signature).
+    // Lives in the `google` source set (issue #476) so :work links no firebase-auth.
     single<RenewalAuthProvider> { FirebaseRenewalAuthProvider(signer = get()) }
 }

--- a/app/src/google/java/com/rousecontext/app/push/FcmConnectPushReporter.kt
+++ b/app/src/google/java/com/rousecontext/app/push/FcmConnectPushReporter.kt
@@ -1,0 +1,35 @@
+package com.rousecontext.app.push
+
+import android.util.Log
+import com.rousecontext.app.auth.FcmTokenProvider
+import com.rousecontext.tunnel.TunnelClient
+import com.rousecontext.work.ConnectPushReporter
+
+/**
+ * `google`-flavor [ConnectPushReporter]: fetches the current FCM registration
+ * token and forwards it to the relay on each successful tunnel connect, so the
+ * relay can deliver FCM wakeups (issue #476).
+ *
+ * The Firebase coupling sits behind the [FcmTokenProvider] seam
+ * ([FirebaseFcmTokenProvider]); this class only orchestrates the per-connect
+ * send so the shared [com.rousecontext.work.TunnelForegroundService] in `:work`
+ * stays Firebase-free.
+ */
+class FcmConnectPushReporter(
+    private val tunnelClient: TunnelClient,
+    private val tokenProvider: FcmTokenProvider
+) : ConnectPushReporter {
+
+    override suspend fun reportOnConnect() {
+        try {
+            tunnelClient.sendFcmToken(tokenProvider.currentToken())
+            Log.i(TAG, "Sent FCM token to relay")
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to send FCM token to relay", e)
+        }
+    }
+
+    private companion object {
+        const val TAG = "FcmConnectPushReporter"
+    }
+}

--- a/app/src/google/java/com/rousecontext/app/push/FcmReceiver.kt
+++ b/app/src/google/java/com/rousecontext/app/push/FcmReceiver.kt
@@ -1,9 +1,12 @@
-package com.rousecontext.work
+package com.rousecontext.app.push
 
 import android.util.Log
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.rousecontext.mcp.core.ProviderRegistry
+import com.rousecontext.work.FcmTokenRegistrar
+import com.rousecontext.work.TunnelForegroundService
+import com.rousecontext.work.WakeDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -11,17 +14,22 @@ import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 
 /**
- * Receives FCM messages (google flavor) and routes them through the shared
+ * Receives FCM messages (`google` flavor) and routes them through the shared
  * [WakeDispatcher]:
  *
  * - `type: "wake"` starts the [TunnelForegroundService] (only if integrations are enabled)
- * - `type: "renew"` enqueues a [CertRenewalWorker] via WorkManager (only if integrations are enabled)
+ * - `type: "renew"` enqueues a `CertRenewalWorker` via WorkManager (only if integrations are enabled)
  * - Unknown types are logged and ignored
  *
  * Wake and renewal requests are silently ignored when no integrations are enabled,
  * avoiding unnecessary foreground service starts and ACME cert quota usage. The
  * `foss` flavor's UnifiedPush receiver shares the same [WakeDispatcher] logic
  * (issue #463).
+ *
+ * `google`-flavor-only (issue #476): this `FirebaseMessagingService` lives in the `:app`
+ * `google` source set — alongside its flavor-scoped manifest entry — so the shared `:work`
+ * module links no `firebase-messaging`. The Firebase-free [WakeDispatcher] /
+ * [FcmTokenRegistrar] it delegates to stay in `:work`.
  */
 class FcmReceiver : FirebaseMessagingService() {
 

--- a/app/src/test/java/com/rousecontext/app/integration/ColdStartViaFcmTest.kt
+++ b/app/src/test/java/com/rousecontext/app/integration/ColdStartViaFcmTest.kt
@@ -43,8 +43,8 @@ import org.robolectric.RobolectricTestRunner
  *    is through the provisioned identity.
  * 3. An incoming FCM `type: "wake"` payload is dispatched through
  *    [FcmDispatch.resolve] and asserted to land on [FcmAction.StartService]. In
- *    production that action triggers
- *    [com.rousecontext.work.FcmReceiver.startTunnelService] which calls
+ *    production that action triggers the shared `WakeDispatcher` (invoked by the
+ *    `google` flavor's `com.rousecontext.app.push.FcmReceiver`), which calls
  *    `startForegroundService` to bring up
  *    [com.rousecontext.work.TunnelForegroundService]. (See below for what's
  *    skipped in this simulation.)

--- a/app/src/testGoogle/java/com/rousecontext/app/auth/FirebaseRenewalAuthProviderTest.kt
+++ b/app/src/testGoogle/java/com/rousecontext/app/auth/FirebaseRenewalAuthProviderTest.kt
@@ -1,5 +1,7 @@
-package com.rousecontext.work
+package com.rousecontext.app.auth
 
+import com.rousecontext.work.DeviceKeystoreSigner
+import com.rousecontext.work.FirebaseCredentials
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -10,10 +12,13 @@ import org.robolectric.RobolectricTestRunner
 /**
  * Unit tests for [FirebaseRenewalAuthProvider] using injected fakes for both the
  * Firebase token source and the Keystore signer. Real FirebaseAuth + Keystore paths are
- * covered by the thin [DefaultFirebaseIdTokenSource] / [AndroidKeystoreSigner] classes.
+ * covered by the thin [DefaultFirebaseIdTokenSource] / `AndroidKeystoreSigner` classes.
  *
  * Robolectric is used only so `android.util.Log` calls resolve to no-ops (the provider logs
  * on each non-success path). No Firebase or Keystore infrastructure is exercised here.
+ *
+ * Lives in the `testGoogle` source set (issue #476): [FirebaseRenewalAuthProvider] is a
+ * `google`-flavor class, so its test compiles only against the google variant.
  */
 @RunWith(RobolectricTestRunner::class)
 class FirebaseRenewalAuthProviderTest {

--- a/app/src/testGoogle/java/com/rousecontext/app/push/FcmReceiverTest.kt
+++ b/app/src/testGoogle/java/com/rousecontext/app/push/FcmReceiverTest.kt
@@ -1,10 +1,12 @@
-package com.rousecontext.work
+package com.rousecontext.app.push
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.firebase.messaging.RemoteMessage
 import com.rousecontext.mcp.core.McpServerProvider
 import com.rousecontext.mcp.core.ProviderRegistry
+import com.rousecontext.work.FcmTokenRegistrar
+import com.rousecontext.work.TunnelForegroundService
 import io.mockk.mockk
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -33,6 +35,9 @@ import org.robolectric.Shadows.shadowOf
  * dispatches through it. These tests exercise the dispatch path without hitting
  * Firebase Cloud Messaging itself by constructing [FcmReceiver] directly under
  * Robolectric and feeding it a synthetic [RemoteMessage].
+ *
+ * Lives in the `testGoogle` source set (issue #476): [FcmReceiver] is a `google`-flavor
+ * `FirebaseMessagingService`, so its test compiles only against the google variant.
  */
 @RunWith(RobolectricTestRunner::class)
 class FcmReceiverTest {

--- a/work/build.gradle.kts
+++ b/work/build.gradle.kts
@@ -37,9 +37,11 @@ dependencies {
     implementation(libs.datastore.preferences)
     implementation(libs.koin.android)
     implementation(libs.workmanager)
-    implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.auth)
-    implementation(libs.firebase.messaging)
+    // NOTE: no firebase-* dependencies. The Firebase-coupled classes
+    // (FirebaseRenewalAuthProvider, FcmReceiver, and the per-connect FCM-token
+    // push) live in the :app `google` source set behind the RenewalAuthProvider
+    // / ConnectPushReporter seams declared here, so :work links zero Firebase
+    // and the `foss` APK is genuinely firebase-free (issue #476).
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/work/src/main/AndroidManifest.xml
+++ b/work/src/main/AndroidManifest.xml
@@ -11,10 +11,11 @@
             android:foregroundServiceType="dataSync" />
 
         <!--
-            The FCM `FcmReceiver` service is declared in the app's `google`
-            flavor manifest (app/src/google/AndroidManifest.xml), not here. The
-            `foss` flavor has no Firebase Cloud Messaging, so the service must
-            not appear in its merged manifest. See issue #461.
+            The FCM receiver (com.rousecontext.app.push.FcmReceiver) is declared
+            in the app's `google` flavor manifest (app/src/google/AndroidManifest.xml)
+            and its class lives in that same `google` source set, so neither the
+            service nor any firebase-messaging bytecode appears in the `foss`
+            build. See issues #461, #476.
         -->
     </application>
 </manifest>

--- a/work/src/main/kotlin/com/rousecontext/work/ConnectPushReporter.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/ConnectPushReporter.kt
@@ -1,0 +1,23 @@
+package com.rousecontext.work
+
+/**
+ * Reports the device's push wake-target to the relay after each successful
+ * tunnel connect.
+ *
+ * Flavor seam (issue #476): the `google` flavor binds a Firebase-backed impl
+ * that fetches the current FCM token and forwards it with
+ * [com.rousecontext.tunnel.TunnelClient.sendFcmToken]; the `foss` flavor reports
+ * its UnifiedPush endpoint elsewhere (its `BackgroundDelivery`), so it binds a
+ * no-op. Keeping the interface in `:work` lets [TunnelForegroundService] stay
+ * flavor-agnostic and Firebase-free — the Firebase-coupled implementation lives
+ * only in the `:app` `google` source set.
+ */
+fun interface ConnectPushReporter {
+    /**
+     * Invoked on the service's lifecycle scope right after a successful connect
+     * (and after each successful reconnect). Implementations must swallow their
+     * own transient failures — a failed token push is non-fatal and the next
+     * wake re-syncs.
+     */
+    suspend fun reportOnConnect()
+}

--- a/work/src/main/kotlin/com/rousecontext/work/TunnelForegroundService.kt
+++ b/work/src/main/kotlin/com/rousecontext/work/TunnelForegroundService.kt
@@ -13,7 +13,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
-import com.google.firebase.messaging.FirebaseMessaging
 import com.rousecontext.api.CrashReporter
 import com.rousecontext.bridge.SessionHandler
 import com.rousecontext.mcp.core.McpSession
@@ -24,13 +23,10 @@ import com.rousecontext.notifications.NotificationChannels
 import com.rousecontext.notifications.SessionSummaryNotifier
 import com.rousecontext.tunnel.TunnelClient
 import com.rousecontext.tunnel.TunnelState
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
 import org.koin.android.ext.android.inject
 import org.koin.core.qualifier.named
 
@@ -58,6 +54,7 @@ class TunnelForegroundService : LifecycleService() {
     private val securityCheckPreferences: SecurityCheckPreferences by inject()
     private val relayUrl: String by inject(named("relayUrl"))
     private val crashReporter: CrashReporter by inject()
+    private val connectPushReporter: ConnectPushReporter by inject()
 
     /** Set true when idle timeout fires or user explicitly stops - suppresses reconnect. */
     @Volatile
@@ -205,7 +202,7 @@ class TunnelForegroundService : LifecycleService() {
         intentionalDisconnect = false
         try {
             tunnelClient.connect(relayUrl)
-            sendFcmToken()
+            connectPushReporter.reportOnConnect()
             triggerOpportunisticSecurityCheck()
         } catch (e: Exception) {
             Log.e(TAG, "Failed to connect to relay", e)
@@ -227,20 +224,6 @@ class TunnelForegroundService : LifecycleService() {
                 ExistingWorkPolicy.REPLACE,
                 request
             )
-        }
-    }
-
-    private suspend fun sendFcmToken() {
-        try {
-            val token = suspendCancellableCoroutine { cont ->
-                FirebaseMessaging.getInstance().token
-                    .addOnSuccessListener { cont.resume(it) }
-                    .addOnFailureListener { cont.resumeWithException(it) }
-            }
-            tunnelClient.sendFcmToken(token)
-            Log.i(TAG, "Sent FCM token to relay")
-        } catch (e: Exception) {
-            Log.w(TAG, "Failed to send FCM token to relay", e)
         }
     }
 
@@ -358,7 +341,7 @@ class TunnelForegroundService : LifecycleService() {
                 try {
                     tunnelClient.connect(relayUrl)
                     Log.i(TAG, "Reconnect succeeded")
-                    sendFcmToken()
+                    connectPushReporter.reportOnConnect()
                     return@launch
                 } catch (e: Exception) {
                     Log.w(TAG, "Reconnect attempt failed", e)

--- a/work/src/test/kotlin/com/rousecontext/work/TunnelForegroundServiceLifecycleTest.kt
+++ b/work/src/test/kotlin/com/rousecontext/work/TunnelForegroundServiceLifecycleTest.kt
@@ -98,6 +98,10 @@ class TunnelForegroundServiceLifecycleTest {
                     single { mockk<SecurityCheckPreferences>(relaxed = true) }
                     single<String>(named("relayUrl")) { "wss://test.rousecontext.com" }
                     single<CrashReporter> { CrashReporter.NoOp }
+                    // Per-connect push sync seam (issue #476). Production binds a
+                    // flavor impl (FCM token push / UnifiedPush no-op); the
+                    // lifecycle tests only need it to resolve.
+                    single<ConnectPushReporter> { ConnectPushReporter { } }
                 }
             )
         }


### PR DESCRIPTION
## What & why

The remaining blocker for a genuinely Firebase-free foss APK (discovered during #464): even after #462 (keypair identity) and #463 (UnifiedPush), the **foss runtime classpath still linked `firebase-auth` + `firebase-messaging`** transitively via the shared **`:work`** module. F-Droid scans for and rejects proprietary deps, so `:work` must link zero Firebase.

This makes `firebase-*` a **google-only** dependency by moving the Firebase-coupled classes out of `:work` into the `:app` **google** source set, leaving the Firebase-free seams/interfaces behind in `:work`.

## What moved

| Class | From | To | Seam left in `:work` |
|---|---|---|---|
| `FirebaseRenewalAuthProvider` (`firebase-auth`) | `:work` `com.rousecontext.work` | `app/src/google` `com.rousecontext.app.auth` | `RenewalAuthProvider` (foss already binds `KeypairRenewalAuthProvider`) |
| `FcmReceiver` (`FirebaseMessagingService`) | `:work` `com.rousecontext.work` | `app/src/google` `com.rousecontext.app.push` | delegates to `WakeDispatcher` / `FcmTokenRegistrar` (both stay in `:work`, Firebase-free) |
| per-connect FCM-token push (`FirebaseMessaging` in `TunnelForegroundService`) | inline in `:work` | new `FcmConnectPushReporter` in `app/src/google` | **new** `ConnectPushReporter` interface in `:work` |

Plus the matching tests moved to `app/src/testGoogle`, and the FCM service's manifest `android:name` updated to `com.rousecontext.app.push.FcmReceiver` (the manifest entry was already google-flavor-scoped from #461).

### The one new seam

`TunnelForegroundService` (shared, in `:work`) used `FirebaseMessaging.getInstance().token` directly to re-send the FCM token to the relay on every connect/reconnect — the last Firebase usage in `:work`. That now goes through a new `ConnectPushReporter` interface in `:work`:
- **google** binds `FcmConnectPushReporter`, which fetches the token via the existing `FcmTokenProvider` seam (`FirebaseFcmTokenProvider`) and calls `tunnelClient.sendFcmToken(...)` — identical behavior to before.
- **foss** binds a no-op (`NoOpConnectPushReporter`); the UnifiedPush endpoint is reported separately by `UnifiedPushBackgroundDelivery`. (Foss previously had no working per-connect sync here anyway — `FirebaseMessaging` threw with no FirebaseApp and was swallowed — so this is behavior-preserving for foss too.)

`:work`'s `build.gradle.kts` no longer declares `firebase-bom/auth/messaging`; they remain `googleImplementation` in `:app`.

## google behavior unchanged

This is a move, not a rewrite: the google flavor uses the same Firebase anonymous auth, the same FCM `FirebaseMessagingService`, and the same per-connect FCM-token push as before — the classes just live in the google source set now and are wired through the same Koin seams.

## Acceptance evidence (foss vs google runtime classpath)

```
$ ./gradlew :app:dependencies --configuration fossDebugRuntimeClasspath | grep -i firebase
(nothing)

$ ./gradlew :app:dependencies --configuration googleDebugRuntimeClasspath | grep -i firebase
+--- com.google.firebase:firebase-auth -> 24.0.1
+--- com.google.firebase:firebase-messaging -> 25.0.1
+--- com.google.firebase:firebase-crashlytics -> 20.0.5
... (transitive firebase-* present, as expected)
```

`:work` itself is now Firebase-free: `grep -rn "com.google.firebase" work/src` returns nothing.

## Verification (all green)

- `:app:assembleGoogleDebug` + `:app:assembleFossDebug`
- `:work:testDebugUnitTest`, `:app:testGoogleDebugUnitTest`, `:app:testFossDebugUnitTest`
- `:app:integrationTest` + `:app:fossIntegrationTest` (real relay binary, `--features test-mode`)
- `ktlintCheck` + `detekt`

Part of #460. Fixes #476.

🤖 Generated with [Claude Code](https://claude.com/claude-code)