### PR TITLE
#467: replace google/foss product flavors with a -Pgoogle build flag

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -53,7 +53,13 @@ jobs:
             -alias debug \
             -dname "CN=Debug,O=Debug,L=Debug,S=Debug,C=US"
       - name: Lint
-        run: ./gradlew ktlintCheck
+        # Distribution is a build flag, not a flavor (#467), so a single
+        # ktlintCheck only sees the selected (FOSS, default) `src` dir. Run a
+        # second pass with `-Pgoogle` so the Firebase distribution sources are
+        # linted too. (`:app` is the only module whose sources vary by flag.)
+        run: |
+          ./gradlew ktlintCheck
+          ./gradlew :app:ktlintCheck -Pgoogle
       - name: Check for zombie screen files
         run: bash scripts/check-zombie-screens.sh
       - name: Check for manual-template JSON in production code
@@ -62,14 +68,18 @@ jobs:
         # when interpolated values contain quotes, backslashes, or control
         # characters. Production code must use @Serializable + encodeToString.
         run: bash scripts/check-no-manual-json.sh
-      - name: Build (google flavor)
-        run: ./gradlew :app:assembleGoogleDebug
-      - name: Build (foss flavor, Firebase-free)
-        # Separate invocation so the foss-only build skips the Firebase Gradle
-        # plugins and proves it assembles without google-services. See #461.
-        run: ./gradlew :app:assembleFossDebug
+      - name: Build (Google distribution)
+        run: ./gradlew :app:assembleDebug -Pgoogle
+      - name: Build (FOSS distribution, Firebase-free)
+        # Bare build (no `-Pgoogle`) is the FOSS distribution: it skips the
+        # Firebase Gradle plugins and proves it assembles without
+        # google-services. See #467.
+        run: ./gradlew :app:assembleDebug
       - name: Unit tests
         timeout-minutes: 20
+        # Distribution is a build flag (#467), so `:app` unit tests run twice:
+        # bare = FOSS (ACRA / keypair seams), `-Pgoogle` = Firebase-backed. The
+        # library modules are distribution-agnostic and run once.
         run: |
           ./gradlew \
             :core:tunnel:jvmTest \
@@ -79,7 +89,8 @@ jobs:
             :notifications:testDebugUnitTest \
             :work:testDebugUnitTest \
             :integrations:testDebugUnitTest \
-            :app:testGoogleDebugUnitTest
+            :app:testDebugUnitTest
+          ./gradlew :app:testDebugUnitTest -Pgoogle
       - name: Integration tests (relay)
         if: success() || failure()
         # Raised from 10 → 15 as the integration-scenario coverage grew
@@ -88,31 +99,32 @@ jobs:
         # handshake + Robolectric Android runtime), so each scenario costs
         # several real seconds; the 10-min cap started truncating CI at
         # ~120 tests (see the #285/#287 CI failures).
-        # Three serial integration suites (:core:tunnel + :app + :app foss)
-        # share the relay binary; 15 min was sized for two, and adding the
-        # foss suite (#469) pushed the step over — bumped to 30. (A future
-        # optimization could split foss into a parallel job.)
+        # Three serial integration suites (:core:tunnel + :app FOSS + :app
+        # Google) share the relay binary; 15 min was sized for two, and adding
+        # the second :app suite (#469) pushed the step over — bumped to 30.
         timeout-minutes: 30
-        # `:app:integrationTest` boots the real AppModule Koin graph against
-        # the same `--test-mode` relay used by `:core:tunnel:integrationTest`
-        # (issue #250 scaffold; umbrella #247). `:app:fossIntegrationTest` runs
-        # the same harness under the FOSS variant so the keypair device-identity
-        # round trip (register → provision → renew, zero Firebase) is covered
-        # end-to-end against the relay (issue #469, part of #460). All three
-        # share the relay binary built above. Run together so Kover's aggregate
-        # report (`koverHtmlReport`) picks up coverage from each.
-        run: >-
-          ./gradlew
-          :core:tunnel:integrationTest
-          :app:integrationTest
-          :app:fossIntegrationTest
+        # `:app:integrationTest` boots the real AppModule Koin graph against the
+        # same `--test-mode` relay used by `:core:tunnel:integrationTest` (issue
+        # #250 scaffold; umbrella #247). With distribution as a build flag (#467)
+        # it runs once bare — FOSS, so the keypair device-identity round trip
+        # (register → provision → renew, zero Firebase) is covered (#469, part of
+        # #460) — and once with `-Pgoogle` for the Firebase-backed path. The
+        # FOSS pass (with :core:tunnel) runs first, then the Google pass; both
+        # reuse the relay binary built above. The Google pass runs last so the
+        # `koverHtmlReport` step (also `-Pgoogle`) reuses its results UP-TO-DATE.
+        run: |
+          ./gradlew :core:tunnel:integrationTest :app:integrationTest
+          ./gradlew :app:integrationTest -Pgoogle
       - name: Coverage report (Kover)
         # Runs after unit + integration tests. Kover would also trigger tests
         # on its own, but the preceding steps already ran them — Gradle will
         # reuse those results via `UP-TO-DATE`, so this step just aggregates.
+        # `-Pgoogle` so the `:app` coverage tracks the shipping Firebase
+        # distribution (matching the pre-#467 google-flavor-only coverage); its
+        # Google unit + integration runs above are reused UP-TO-DATE.
         if: success() || failure()
         timeout-minutes: 10
-        run: ./gradlew koverHtmlReport koverXmlReport
+        run: ./gradlew koverHtmlReport koverXmlReport -Pgoogle
       - name: Per-module coverage summary
         if: success() || failure()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,15 @@ jobs:
             -alias debug \
             -dname "CN=Debug,O=Debug,L=Debug,S=Debug,C=US"
       - name: ktlint
-        run: ./gradlew ktlintCheck
+        # Distribution is a build flag, not a flavor (#467): a single ktlintCheck
+        # only lints the selected (FOSS, default) `src` dir, so a second
+        # `-Pgoogle` pass lints the Firebase distribution sources (`:app` only).
+        run: |
+          ./gradlew ktlintCheck
+          ./gradlew :app:ktlintCheck -Pgoogle
       - name: detekt
+        # detekt's source set is the raw `src` glob across modules, so it already
+        # scans both the FOSS and Google distribution dirs in one pass (#467).
         run: ./gradlew detekt
       - name: Block production runBlocking (issue #136)
         run: |
@@ -131,16 +138,22 @@ jobs:
             -keyalg RSA -keysize 2048 -validity 10000 \
             -alias debug \
             -dname "CN=Debug,O=Debug,L=Debug,S=Debug,C=US"
-      - name: Build (google flavor)
-        run: ./gradlew :app:assembleGoogleDebug
-      - name: Build (foss flavor, Firebase-free)
-        # Separate invocation so the foss-only build skips the Firebase Gradle
-        # plugins and proves it assembles without google-services. See #461.
-        run: ./gradlew :app:assembleFossDebug
+      - name: Build (Google distribution)
+        run: ./gradlew :app:assembleDebug -Pgoogle
+      - name: Build (FOSS distribution, Firebase-free)
+        # Bare build (no `-Pgoogle`) is the FOSS distribution: it skips the
+        # Firebase Gradle plugins and proves it assembles without
+        # google-services. See #467.
+        run: ./gradlew :app:assembleDebug
       - name: Unit tests
-        # :app is flavored (#461) so its unit-test task is per-flavor; the
-        # library modules keep the plain `testDebugUnitTest` task name.
-        run: ./gradlew :app:testGoogleDebugUnitTest testDebugUnitTest :core:tunnel:jvmTest :core:mcp:jvmTest :core:bridge:jvmTest
+        # Distribution is a build flag (#467): `:app` unit tests run once bare
+        # (FOSS) and once with `-Pgoogle` (Firebase). `testDebugUnitTest`
+        # (unqualified) covers the library modules' `:app` foss run plus the
+        # distribution-agnostic modules; the `-Pgoogle` pass covers the Firebase
+        # distribution.
+        run: |
+          ./gradlew testDebugUnitTest :core:tunnel:jvmTest :core:mcp:jvmTest :core:bridge:jvmTest
+          ./gradlew :app:testDebugUnitTest -Pgoogle
       - name: Upload test results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,21 +40,22 @@ jobs:
           mkdir -p .signing
           echo "${{ secrets.RELEASE_KEYSTORE }}" | base64 -d > .signing/release.keystore
 
-      - name: Build release APK + AAB (google flavor)
+      - name: Build release APK + AAB (Google distribution)
         env:
           ROUSE_RELEASE_STORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
           ROUSE_RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
-        # #461 introduced google/foss flavors. The release pipeline ships the
-        # `google` flavor only (current behaviour, Firebase included). A
-        # dual-flavor FOSS release is a later ticket (#465).
+        # Distribution is a build flag (#467). The release pipeline ships the
+        # Google distribution (Firebase included) via `-Pgoogle`. A FOSS release
+        # (bare build) is a later ticket (#465). Without a flavor, the outputs
+        # land under the un-prefixed `release/` paths.
         run: |
-          ./gradlew :app:assembleGoogleRelease :app:bundleGoogleRelease
+          ./gradlew :app:assembleRelease :app:bundleRelease -Pgoogle
 
       - name: Extract version from APK
         id: version
         run: |
           # Pull versionName from the build output metadata
-          VERSION=$(grep -oP '"versionName"\s*:\s*"\K[^"]+' app/build/outputs/apk/google/release/output-metadata.json || echo "unknown")
+          VERSION=$(grep -oP '"versionName"\s*:\s*"\K[^"]+' app/build/outputs/apk/release/output-metadata.json || echo "unknown")
           echo "name=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=${GITHUB_REF_NAME:-${{ github.event.inputs.version || format('v{0}', env.VERSION) }}}" >> "$GITHUB_OUTPUT"
 
@@ -62,13 +63,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: release-apk
-          path: app/build/outputs/apk/google/release/app-google-release.apk
+          path: app/build/outputs/apk/release/app-release.apk
 
       - name: Upload AAB artifact (for Play Console)
         uses: actions/upload-artifact@v4
         with:
           name: release-aab
-          path: app/build/outputs/bundle/googleRelease/app-google-release.aab
+          path: app/build/outputs/bundle/release/app-release.aab
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
@@ -77,5 +78,5 @@ jobs:
           name: Rouse Context ${{ steps.version.outputs.name }}
           generate_release_notes: true
           files: |
-            app/build/outputs/apk/google/release/app-google-release.apk
-            app/build/outputs/bundle/googleRelease/app-google-release.aab
+            app/build/outputs/apk/release/app-release.apk
+            app/build/outputs/bundle/release/app-release.aab

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,21 +11,22 @@ plugins {
     alias(libs.plugins.test.retry)
 }
 
+// Distribution is selected by a build flag, not a product flavor (issue #467).
+// A bare build is the FOSS distribution (no secrets, buildable by anyone /
+// F-Droid); `-Pgoogle` opts into the credentialed Firebase build. This encodes
+// the real relationship — FOSS is the universal base, Google a credentialed
+// superset — instead of the symmetric flavor framing that made the safe build
+// non-default and forced task-name sniffing to re-derive "is this credentialed?".
+val googleBuild = project.hasProperty("google")
+
 // The Firebase Gradle plugins (`google-services`, `firebase-crashlytics`) are
-// applied only when the `google` product flavor is part of the build. A
-// foss-only build skips them entirely so that:
-//   * `google-services.json` is NOT required to assemble the foss variant, and
-//   * no Play-Services / Firebase Gradle processing runs for foss.
-// Detection is by requested task name (CI invokes the flavored tasks directly,
-// e.g. `assembleFossDebug` / `assembleGoogleDebug`). A build that mentions
-// neither flavor (e.g. `ktlintCheck`, bare `assemble`) keeps the plugins, which
-// matches the pre-flavor behaviour. See issue #461.
-val requestedTaskNames = gradle.startParameter.taskNames
-val isFossOnlyBuild = requestedTaskNames.isNotEmpty() &&
-    requestedTaskNames.any { it.contains("Foss", ignoreCase = true) } &&
-    requestedTaskNames.none { it.contains("Google", ignoreCase = true) }
-val applyFirebasePlugins = !isFossOnlyBuild
-if (applyFirebasePlugins) {
+// applied only for the Google build. The FOSS build skips them entirely so that:
+//   * `google-services.json` is NOT required to assemble it, and
+//   * no Play-Services / Firebase Gradle processing runs.
+// Keeping the plugins behind the flag preserves the google-services plugin's
+// hard-fail-on-missing-credentials — a `-Pgoogle` build with no
+// `google-services.json` fails loudly rather than producing a broken APK.
+if (googleBuild) {
     apply(plugin = "com.google.gms.google-services")
     apply(plugin = "com.google.firebase.crashlytics")
 }
@@ -75,12 +76,9 @@ android {
     // and `packageReleaseUnitTestForUnitTest`) don't spuriously require the keys.
     gradle.taskGraph.whenReady {
         val releaseSigningTasks = setOf(
-            "assembleGoogleRelease",
-            "packageGoogleRelease",
-            "bundleGoogleRelease",
-            "assembleFossRelease",
-            "packageFossRelease",
-            "bundleFossRelease"
+            "assembleRelease",
+            "packageRelease",
+            "bundleRelease"
         )
         val needsReleaseSigning = allTasks.any { task ->
             task.project == project && task.name in releaseSigningTasks
@@ -121,32 +119,34 @@ android {
         buildConfigField("String", "RELAY_SCHEME", "\"$relayScheme\"")
     }
 
-    // Distribution flavor split (issue #461). `google` is the unchanged
-    // Firebase/FCM/Crashlytics build; `foss` compiles with no Firebase /
-    // google-services / Play-Services dependencies. Both flavors ship the same
-    // `applicationId` (com.rousecontext) — the foss build is the same app,
-    // Firebase-free, not a separate package.
-    flavorDimensions += "distribution"
-    productFlavors {
-        create("google") {
-            dimension = "distribution"
-        }
-        create("foss") {
-            dimension = "distribution"
-        }
-    }
+    // Distribution code is selected by the `-Pgoogle` flag (issue #467) instead
+    // of product-flavor source sets. The FOSS sources are the default; `-Pgoogle`
+    // swaps in the Firebase-backed sources. The directories themselves are
+    // unchanged from the former `google`/`foss` flavor source sets — they are
+    // just no longer registered as flavor source sets. Both distributions ship
+    // the same `applicationId` (com.rousecontext); the FOSS build is the same
+    // app, Firebase-free, not a separate package.
+    //
+    // The matching `test{Google,Foss}` source sets carry the distribution's
+    // unit tests (Firebase-backed vs ACRA/keypair), selected the same way so the
+    // tests only compile/run against the classpath that has their deps.
+    sourceSets["main"].java.srcDir(
+        if (googleBuild) "src/google/java" else "src/foss/java"
+    )
+    sourceSets["test"].java.srcDir(
+        if (googleBuild) "src/testGoogle/java" else "src/testFoss/java"
+    )
 
     buildTypes {
         debug {
             signingConfig = signingConfigs.getByName("debug")
             applicationIdSuffix = ".debug"
             // No mapping upload in debug — the Crashlytics plugin runs even here
-            // (for the `google` flavor) because the library is linked in that
-            // variant. We still skip the slow symbol upload work to keep debug
-            // assembly fast for iteration. Guarded so foss-only builds, which
-            // never apply the Crashlytics plugin, don't reference a missing
-            // extension.
-            if (applyFirebasePlugins) {
+            // (under `-Pgoogle`) because the library is linked in that build. We
+            // still skip the slow symbol upload work to keep debug assembly fast
+            // for iteration. Guarded so FOSS builds, which never apply the
+            // Crashlytics plugin, don't reference a missing extension.
+            if (googleBuild) {
                 configure<com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension> {
                     mappingFileUploadEnabled = false
                     nativeSymbolUploadEnabled = false
@@ -162,8 +162,8 @@ android {
             )
             // Release builds ship R8-obfuscated code; upload the mapping so
             // Crashlytics deobfuscates stacks. We have no NDK code, so native
-            // symbol upload stays off. Guarded as above for foss-only builds.
-            if (applyFirebasePlugins) {
+            // symbol upload stays off. Guarded as above for FOSS builds.
+            if (googleBuild) {
                 configure<com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension> {
                     mappingFileUploadEnabled = true
                     nativeSymbolUploadEnabled = false
@@ -206,6 +206,19 @@ android {
     }
 }
 
+// Overlay the distribution-specific manifest (FcmReceiver for Google,
+// UnifiedPushReceiver for FOSS) by flag, using AGP's Variant Sources API
+// (issue #467). `addStaticManifestFile` feeds the overlay into the standard
+// manifest merger as a highest-priority source — no module split, no
+// duplication of the shared manifest body. Path is relative to the :app dir.
+androidComponents {
+    onVariants(selector().all()) { variant ->
+        variant.sources.manifests.addStaticManifestFile(
+            if (googleBuild) "src/google/AndroidManifest.xml" else "src/foss/AndroidManifest.xml"
+        )
+    }
+}
+
 dependencies {
     implementation(project(":core:tunnel"))
     implementation(project(":core:mcp"))
@@ -239,29 +252,23 @@ dependencies {
     implementation(libs.room.ktx)
     ksp(libs.room.compiler)
 
-    // Firebase — scoped to the `google` flavor only (issue #461). The `foss`
-    // flavor compiles with zero firebase-* dependencies; its Koin seams bind
-    // NoOp/stub implementations instead (see app/src/foss).
-    "googleImplementation"(platform(libs.firebase.bom))
-    "googleImplementation"(libs.firebase.auth)
-    "googleImplementation"(libs.firebase.messaging)
-    "googleImplementation"(libs.firebase.crashlytics)
-
-    // UnifiedPush — scoped to the `foss` flavor only (issue #463). The foss
-    // build wakes via a UnifiedPush distributor instead of FCM; this library
-    // provides the MessagingReceiver base + distributor registration API. The
-    // google flavor never links it — all UnifiedPush calls sit behind the
-    // flavor-agnostic BackgroundDelivery seam.
-    "fossImplementation"(libs.unifiedpush.connector)
-
-    // ACRA — scoped to the `foss` flavor only (issue #464). Crashlytics is not
-    // FOSS, so the foss flavor reports crashes via ACRA's HttpSender, which
-    // POSTs JSON crash reports to the relay's `POST /crash` endpoint. The relay
-    // sanitizes/dedups them into GitHub issues (mirroring the Crashlytics→issue
-    // convention). The google flavor never links ACRA — it keeps Crashlytics
-    // behind the same flavor-agnostic CrashReporter seam.
-    "fossImplementation"(libs.acra.core)
-    "fossImplementation"(libs.acra.http)
+    // Distribution-specific dependencies, selected by the `-Pgoogle` flag
+    // (issue #467). The Google build links Firebase (FCM wake + Crashlytics);
+    // the FOSS build links UnifiedPush (distributor-based wake) + ACRA (crash
+    // reporting via the relay's `POST /crash`) and zero firebase-* artifacts.
+    // Both distributions sit behind the same distribution-agnostic Koin seams
+    // (BackgroundDelivery, CrashReporter, device-identity providers — see
+    // app/src/{google,foss}).
+    if (googleBuild) {
+        implementation(platform(libs.firebase.bom))
+        implementation(libs.firebase.auth)
+        implementation(libs.firebase.messaging)
+        implementation(libs.firebase.crashlytics)
+    } else {
+        implementation(libs.unifiedpush.connector)
+        implementation(libs.acra.core)
+        implementation(libs.acra.http)
+    }
 
     // Health Connect (for HealthConnectIntegration availability check)
     implementation(libs.health.connect)
@@ -329,11 +336,14 @@ dependencies {
 // and depend on `relay/target/debug/rouse-relay` being built with
 // `--features test-mode`.
 //
-// They are excluded from the default `testGoogleDebugUnitTest` run (CI's "unit
+// They are excluded from the default `testDebugUnitTest` run (CI's "unit
 // tests" step stays fast) and fronted by a dedicated `:app:integrationTest`
 // task so CI can gate them separately. Both tasks are Android `Test` tasks
 // on the debug variant, so Kover's auto-discovery picks them up for the
-// aggregated coverage report (issue #248).
+// aggregated coverage report (issue #248). With the distribution flag (issue
+// #467) `integrationTest` covers whichever distribution is selected — CI runs
+// it once bare (FOSS, incl. the keypair round-trip from src/testFoss) and once
+// with `-Pgoogle` (Firebase-backed), so both are exercised end-to-end.
 private val integrationPackage = "com.rousecontext.app.integration"
 
 tasks.withType<Test>().configureEach {
@@ -347,10 +357,9 @@ tasks.withType<Test>().configureEach {
         maxRetries.set(2)
         failOnPassedAfterRetry.set(false)
     }
-    // Per-flavor debug unit-test tasks (testGoogleDebugUnitTest /
-    // testFossDebugUnitTest) keep the fast unit-test run lean by excluding the
-    // slow relay-backed integration scenarios, which run via `integrationTest`.
-    if (name == "testGoogleDebugUnitTest" || name == "testFossDebugUnitTest") {
+    // The fast `testDebugUnitTest` run stays lean by excluding the slow
+    // relay-backed integration scenarios, which run via `integrationTest`.
+    if (name == "testDebugUnitTest") {
         filter {
             excludeTestsMatching("$integrationPackage.*")
             isFailOnNoMatchingTests = false
@@ -364,11 +373,13 @@ tasks.register<Test>("integrationTest") {
         "Runs `$integrationPackage.*` tests against the real relay binary. " +
         "Requires `cd relay && cargo build --features test-mode` first."
 
-    // Reuse everything about `testGoogleDebugUnitTest` (Robolectric runtime,
-    // compiled test classes, android resources, JVM args) — we just want a
-    // different filter applied to the same test task classpath. The integration
-    // scenarios exercise the Firebase-backed `google` variant.
-    val source = tasks.named<Test>("testGoogleDebugUnitTest").get()
+    // Reuse everything about `testDebugUnitTest` (Robolectric runtime, compiled
+    // test classes, android resources, JVM args) — we just want a different
+    // filter applied to the same test task classpath. The selected distribution
+    // (issue #467) determines which `DistributionModule` and distribution test
+    // source set are live: bare = FOSS (keypair device identity, zero Firebase,
+    // incl. the keypair round-trip from src/testFoss); `-Pgoogle` = Firebase.
+    val source = tasks.named<Test>("testDebugUnitTest").get()
     testClassesDirs = source.testClassesDirs
     classpath = source.classpath
     systemProperty("repo.root", rootProject.projectDir.absolutePath)
@@ -384,36 +395,5 @@ tasks.register<Test>("integrationTest") {
 
     // Integration tests are I/O-heavy (relay subprocess + real TLS + cert
     // generation) so fail if something hangs instead of wedging CI.
-    timeout.set(Duration.ofMinutes(10L))
-}
-
-tasks.register<Test>("fossIntegrationTest") {
-    group = "verification"
-    description =
-        "Runs `$integrationPackage.*` tests against the real relay binary under the " +
-        "FOSS variant (keypair device identity, zero Firebase). " +
-        "Requires `cd relay && cargo build --features test-mode` first."
-
-    // Mirror `integrationTest`, but reuse `testFossDebugUnitTest` so the FOSS
-    // `distributionModule` (KeypairDeviceCredentialProvider /
-    // KeypairRenewalAuthProvider) is the flavor module live in the harness
-    // (issue #469). The keypair round-trip scenario lives in the
-    // `app/src/testFoss` source set so it only compiles/runs under this
-    // classpath, never under the google `integrationTest` above.
-    val source = tasks.named<Test>("testFossDebugUnitTest").get()
-    testClassesDirs = source.testClassesDirs
-    classpath = source.classpath
-    systemProperty("repo.root", rootProject.projectDir.absolutePath)
-    // Mirror Robolectric graphics config from `testOptions.unitTests.all`.
-    systemProperty("robolectric.graphicsMode", "NATIVE")
-
-    filter {
-        includeTestsMatching("$integrationPackage.*")
-        isFailOnNoMatchingTests = false
-    }
-
-    useJUnit()
-
-    // Same hang-guard as `integrationTest`.
     timeout.set(Duration.ofMinutes(10L))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,18 +59,12 @@ subprojects {
             currentProject {
                 instrumentation {
                     // Release-variant unit tests have never been configured to
-                    // work (e.g. Roborazzi screenshot tests). Library modules
-                    // expose `testReleaseUnitTest`; the flavored `:app` (#461)
-                    // exposes per-flavor release tasks instead.
+                    // work (e.g. Roborazzi screenshot tests). Every module —
+                    // including `:app`, now that distribution is a flag rather
+                    // than a flavor (#467) — exposes the plain
+                    // `testReleaseUnitTest` task again, so a single exclusion
+                    // covers them all.
                     disabledForTestTasks.add("testReleaseUnitTest")
-                    disabledForTestTasks.add("testGoogleReleaseUnitTest")
-                    disabledForTestTasks.add("testFossReleaseUnitTest")
-                    // Coverage tracks the shipping `google` flavor only. The
-                    // `foss` flavor's seams are temporary NoOp/stub placeholders
-                    // (#461; real impls land in #462–#464) and its unit-test
-                    // variant intentionally omits the Firebase-backed tests, so
-                    // exclude it from the aggregated Kover report.
-                    disabledForTestTasks.add("testFossDebugUnitTest")
                 }
             }
         }

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -76,21 +76,22 @@ Source-of-truth for the module list is `settings.gradle.kts:25-35`.
 All Gradle commands need `JAVA_HOME=/usr/lib/jvm/java-21-openjdk`.
 
 ```bash
-# Build a debug APK. `:app` is split into google/foss flavors (#461):
-#   google = current build (Firebase/FCM/Crashlytics)
-#   foss   = Firebase-free (no google-services.json required)
-./gradlew :app:assembleGoogleDebug
-# → app/build/outputs/apk/google/debug/app-google-debug.apk
-./gradlew :app:assembleFossDebug
-# → app/build/outputs/apk/foss/debug/app-foss-debug.apk
+# Build a debug APK. Distribution is a build flag, not a flavor (#467):
+#   bare      = FOSS (Firebase-free; no google-services.json required)
+#   -Pgoogle  = Firebase/FCM/Crashlytics (needs app/google-services.json)
+./gradlew :app:assembleDebug
+# → app/build/outputs/apk/debug/app-debug.apk  (FOSS)
+./gradlew :app:assembleDebug -Pgoogle
+# → app/build/outputs/apk/debug/app-debug.apk  (Google; overwrites the above)
 
-# Build a release APK (shipping build is the google flavor)
-./gradlew :app:assembleGoogleRelease
-# → app/build/outputs/apk/google/release/app-google-release.apk
+# Build a release APK (shipping build is the Google distribution)
+./gradlew :app:assembleRelease -Pgoogle
+# → app/build/outputs/apk/release/app-release.apk
 
 # Unit tests for one module
 ./gradlew :core:mcp:jvmTest                       # KMP/JVM
-./gradlew :app:testGoogleDebugUnitTest            # Android-only (flavored)
+./gradlew :app:testDebugUnitTest                  # Android-only (FOSS)
+./gradlew :app:testDebugUnitTest -Pgoogle         # Android-only (Google)
 ./gradlew :integrations:testDebugUnitTest         # Android-only
 
 # Tunnel integration tests (against real relay binary)

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -108,11 +108,12 @@ because the debug keystore is not a secret.
 All hostnames derive from a single Gradle property, `-Pdomain`:
 
 ```bash
-./gradlew :app:assembleGoogleDebug -Pdomain=coolapp.example
+./gradlew :app:assembleDebug -Pdomain=coolapp.example
 ```
 
-(`:app` has `google`/`foss` flavors — see #461. Use `:app:assembleFossDebug`
-for a Firebase-free build.)
+(A bare build is the Firebase-free FOSS distribution; add `-Pgoogle` for the
+Firebase build, which needs `app/google-services.json`. Distribution is a build
+flag, not a product flavor — see #467.)
 
 The app's `BuildConfig` will have:
 
@@ -122,10 +123,10 @@ The app's `BuildConfig` will have:
 Test the override wired correctly:
 
 ```bash
-./gradlew -Pdomain=coolapp.example :app:compileGoogleDebugKotlin
+./gradlew -Pdomain=coolapp.example :app:compileDebugKotlin
 ```
 
-For production/release builds, use the same flag with `:app:assembleGoogleRelease` and your release keystore.
+For production/release builds, use the same flag with `:app:assembleRelease` (add `-Pgoogle` for the Firebase build) and your release keystore.
 
 ### Package name
 

--- a/docs/test-coverage-audit.md
+++ b/docs/test-coverage-audit.md
@@ -957,12 +957,12 @@ fun `all screens use material design 3 colors from theme`() {
 # MCP tests
 ./gradlew :core:mcp:jvmTest
 
-# App UI tests
-./gradlew :app:testGoogleDebugUnitTest --tests "*.MainDashboardViewModelTest"
+# App UI tests (distribution-agnostic; add -Pgoogle for the Firebase build)
+./gradlew :app:testDebugUnitTest --tests "*.MainDashboardViewModelTest"
 
 # Screenshot tests (requires graphics)
 JAVA_HOME=/usr/lib/jvm/java-21-openjdk \
-  ./gradlew :app:testGoogleDebugUnitTest --tests "*.ScreenScreenshotTest"
+  ./gradlew :app:testDebugUnitTest --tests "*.ScreenScreenshotTest"
 
 # Relay tests
 cd relay && cargo test


### PR DESCRIPTION
## What & why

`Closes #467.`

Replaces the `google`/`foss` **product flavors** with a **`-Pgoogle` build flag** (approved design, Jason in-session 2026-06-15).

FOSS and Google are not symmetric peers: FOSS is the universal, secret-free base build (buildable by anyone / F-Droid); Google is a credentialed *superset* requiring our private `google-services.json`. Product flavors forced a symmetric frame — bare `assemble` built both, `google-services.json` was required by default, and task-name sniffing (`isFossOnlyBuild`) was needed to re-derive "is this the credentialed build?". A flag encodes the real relationship: **bare build = FOSS; `-Pgoogle` = Firebase opt-in.** The safe build becomes the default, and keeping the google-services plugin behind the flag preserves its hard-fail-on-missing-credentials guard.

## The inversion (`app/build.gradle.kts`)

- `val googleBuild = project.hasProperty("google")`.
- Removed `flavorDimensions` / `productFlavors`. Distribution sources selected by flag: `sourceSets["main"]/["test"].java.srcDir(if (googleBuild) "src/google/java"/"src/testGoogle/java" else "src/foss/java"/"src/testFoss/java")`. The `src/{google,foss}` and `src/test{Google,Foss}` directories are unchanged.
- **Manifest overlay** by flag via AGP 8.13.2 Variant Sources API — `androidComponents.onVariants { variant.sources.manifests.addStaticManifestFile(...) }` — feeding `src/{google,foss}/AndroidManifest.xml` into the standard merger as the highest-priority source. No module split, no shared-body duplication.
- Firebase deps + the `google-services`/`firebase-crashlytics` plugins + the Crashlytics `buildTypes` config all gated on `googleBuild` (replacing the task-name sniff). `google-services.json` required **only** under `-Pgoogle`, still hard-failing loudly if absent.
- FOSS deps (`unifiedpush.connector`, `acra.core`, `acra.http`) on the `else` branch.
- Collapsed `fossIntegrationTest` into a single flag-selected `integrationTest`; fixed the release-signing task set (`assembleRelease`/`packageRelease`/`bundleRelease`) and the root `build.gradle.kts` Kover disabled-task list, both of which named the now-gone per-flavor tasks.

## CI two-pass migration

Per-flavor tasks (`testGoogleDebugUnitTest`, `assembleFossDebug`, `fossIntegrationTest`, …) no longer exist, so both distributions are covered by running twice per flag:

- **android-ci.yml / ci.yml** — `assembleDebug` (FOSS) + `assembleDebug -Pgoogle`; `:app:testDebugUnitTest` (FOSS) + `-Pgoogle`; ktlint runs both passes (`-Pgoogle` lints the Firebase sources); detekt stays single-pass (its `src` glob already scans both dirs).
- **android-ci.yml integration** — `:core:tunnel:integrationTest :app:integrationTest` (FOSS, incl. the keypair round-trip) then `:app:integrationTest -Pgoogle`; Kover runs `-Pgoogle` to keep `:app` coverage on the shipping Firebase distribution (reused UP-TO-DATE).
- **release.yml** — `assembleRelease`/`bundleRelease -Pgoogle`, with the un-prefixed `app/build/outputs/{apk,bundle}/release/app-release.*` paths.
- Docs (`agent-quickstart`, `self-hosting`, `test-coverage-audit`) updated to the flag form.

## Verification (local, JDK 21)

- **FOSS** `:app:assembleDebug` ✅ — merged manifest registers `UnifiedPushReceiver`, **no** `FcmReceiver`/`MESSAGING_EVENT` component; `debugRuntimeClasspath` has **zero** `firebase-*` artifacts and links `unifiedpush` + `acra`.
- **Google** `:app:assembleDebug -Pgoogle` ✅ — merged manifest registers `FcmReceiver` (`MESSAGING_EVENT`), **no** `UnifiedPushReceiver`; classpath has 62 firebase artifacts and **zero** unifiedpush/acra. (Proves `addStaticManifestFile` works both ways.)
- **Both unit-test passes green:** `:app:testDebugUnitTest` (ran `AcraCrashReporterTest`) and `-Pgoogle` (ran `FirebaseRenewalAuthProviderTest`, `FcmReceiverTest`, `FirebaseCrashReporterTest`).
- **Lint green** both passes: `ktlintCheck` + `:app:ktlintCheck -Pgoogle`; `detekt`.
- **Loud-fail guard confirmed:** with `app/google-services.json` temporarily moved, `:app:processDebugGoogleServices -Pgoogle` fails with `File google-services.json is missing.`; the bare FOSS build never invokes that plugin. (File restored.)
- `:app:integrationTest` task wiring resolves under both flags (dry-run).

## Notes / unsure

- `google-services.json` is checked in (`app/google-services.json`; API keys aren't secret), so `-Pgoogle` builds succeed in CI and locally — the loud-fail path is only hit when it's genuinely absent.
- Full relay-backed `integrationTest` suites were not run locally (need the `--features test-mode` relay binary); CI runs them both passes. Task graph validated via dry-run.
- Kover now tracks `:app` coverage under `-Pgoogle` to match the prior google-flavor-only coverage intent; FOSS-only seams (ACRA/keypair) are exercised by tests but not aggregated into the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
