### PR TITLE
Redirect unregistered FOSS Add-integration to delivery picker (#474)

### DIFF
--- a/app/src/main/java/com/rousecontext/app/di/AppModule.kt
+++ b/app/src/main/java/com/rousecontext/app/di/AppModule.kt
@@ -31,6 +31,7 @@ import com.rousecontext.app.state.DeviceRegistrationStatus
 import com.rousecontext.app.state.IntegrationSettingsStore
 import com.rousecontext.app.state.NotificationPermissionRefresher
 import com.rousecontext.app.state.OAuthHostnameProvider
+import com.rousecontext.app.state.PendingIntegrationSetup
 import com.rousecontext.app.state.PreferencesSnapshotHolder
 import com.rousecontext.app.state.SecurityAlertGate
 import com.rousecontext.app.state.ThemePreference
@@ -175,6 +176,9 @@ val appModule = module {
 
     // --- Notification permission refresher ---
     single { NotificationPermissionRefresher() }
+
+    // --- Pending-integration carry across the Background delivery detour (#474) ---
+    single { PendingIntegrationSetup() }
 
     // --- Bug report URI builder ---
     single { BugReportUriBuilder(androidContext()) }

--- a/app/src/main/java/com/rousecontext/app/state/PendingIntegrationSetup.kt
+++ b/app/src/main/java/com/rousecontext/app/state/PendingIntegrationSetup.kt
@@ -1,0 +1,58 @@
+package com.rousecontext.app.state
+
+import com.rousecontext.app.delivery.DeliveryActivation
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Carries the id of the integration a user was adding across a Background
+ * delivery picker detour (issue #474, Option A).
+ *
+ * On a not-yet-registered foss device (one that tapped "Skip for now" on
+ * Background delivery), tapping "Add integration" used to silently block in
+ * [com.rousecontext.app.ui.viewmodels.IntegrationSetupViewModel]
+ * `.awaitRegistrationIfNeeded` — it read like a hang. Instead the add-integration
+ * destination now [remember]s the chosen integration and redirects to the
+ * picker. Once a distributor is selected, the picker [consume]s the id and
+ * navigates straight into that integration's setup flow (auto-resume), rather
+ * than dropping the user back at Home.
+ *
+ * A single pending id is held (the user can only be adding one integration at a
+ * time); [remember] overwrites any prior value. Provided as a Koin singleton so
+ * the two destinations share the same instance across the round-trip.
+ */
+class PendingIntegrationSetup {
+
+    private val _pendingId = MutableStateFlow<String?>(null)
+
+    /** Currently-pending integration id, or null. Drives the picker's strip. */
+    val pendingId: StateFlow<String?> = _pendingId.asStateFlow()
+
+    /** Record the integration the user is adding before redirecting to the picker. */
+    fun remember(id: String) {
+        _pendingId.value = id
+    }
+
+    /**
+     * Return and clear the pending id (the auto-resume path). Returns null when
+     * the picker was reached for any other reason (onboarding, Settings).
+     */
+    fun consume(): String? = _pendingId.value.also { _pendingId.value = null }
+
+    /** Drop the pending id without resuming (e.g. the user skipped the picker). */
+    fun clear() {
+        _pendingId.value = null
+    }
+}
+
+/**
+ * Whether tapping "Add integration" must first route the user through the
+ * Background delivery picker. True only for the foss "skipped delivery, not yet
+ * registered" state ([DeliveryActivation.NeedsSetup]); a registered foss device
+ * ([DeliveryActivation.Active]) and google/FCM
+ * ([DeliveryActivation.NotApplicable]) proceed straight into setup, so this is a
+ * no-op there.
+ */
+fun deliveryNeedsSetupBeforeIntegration(activation: DeliveryActivation): Boolean =
+    activation == DeliveryActivation.NeedsSetup

--- a/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/AddIntegrationDestination.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/AddIntegrationDestination.kt
@@ -8,15 +8,13 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.rousecontext.app.R
 import com.rousecontext.app.auth.DeviceCredentialProvider
+import com.rousecontext.app.delivery.BackgroundDelivery
+import com.rousecontext.app.state.PendingIntegrationSetup
+import com.rousecontext.app.state.deliveryNeedsSetupBeforeIntegration
 import com.rousecontext.app.ui.navigation.ConfigureNavBar
 import com.rousecontext.app.ui.navigation.Routes
 import com.rousecontext.app.ui.screens.AddIntegrationPickerContent
-import com.rousecontext.app.ui.screens.SetupMode
 import com.rousecontext.app.ui.viewmodels.AddIntegrationViewModel
-import com.rousecontext.app.ui.viewmodels.HealthConnectSetupViewModel
-import com.rousecontext.app.ui.viewmodels.NotificationSetupViewModel
-import com.rousecontext.app.ui.viewmodels.OutreachSetupViewModel
-import com.rousecontext.app.ui.viewmodels.UsageSetupViewModel
 import com.rousecontext.tunnel.CertProvisioningFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -38,52 +36,36 @@ fun NavGraphBuilder.addIntegrationDestination(navController: NavController) {
         val certProvisioningFlow: CertProvisioningFlow = koinInject()
         val credentialProvider: DeviceCredentialProvider = koinInject()
         val appScope: CoroutineScope = koinInject(named("appScope"))
+        val delivery: BackgroundDelivery = koinInject()
+        val pendingSetup: PendingIntegrationSetup = koinInject()
+        val activation by delivery.activation.collectAsState()
         AddIntegrationPickerContent(
             integrations = integrations,
             onSetUp = { id ->
-                // Kick off cert provisioning in the background while
-                // user configures the integration. Survives navigation
-                // since it uses the app-scoped coroutine scope.
-                appScope.launch {
-                    try {
-                        val credential = credentialProvider.forProvisioning()
-                        if (credential != null) {
-                            certProvisioningFlow.execute(credential)
+                // #474: a foss device that skipped Background delivery has no
+                // push endpoint and isn't registered yet, so setup would block
+                // silently in IntegrationSetupViewModel.awaitRegistrationIfNeeded.
+                // Remember the integration and redirect to the picker; the
+                // picker auto-resumes here once a distributor is chosen. On
+                // google/registered foss this is a no-op (NotApplicable/Active).
+                if (deliveryNeedsSetupBeforeIntegration(activation)) {
+                    pendingSetup.remember(id)
+                    navController.navigate(Routes.BACKGROUND_DELIVERY_BASE)
+                } else {
+                    // Kick off cert provisioning in the background while the
+                    // user configures the integration. Survives navigation
+                    // since it uses the app-scoped coroutine scope.
+                    appScope.launch {
+                        try {
+                            val credential = credentialProvider.forProvisioning()
+                            if (credential != null) {
+                                certProvisioningFlow.execute(credential)
+                            }
+                        } catch (_: Exception) {
+                            // Best-effort; integrationSetup will retry
                         }
-                    } catch (_: Exception) {
-                        // Best-effort; integrationSetup will retry
                     }
-                }
-                when (id) {
-                    HealthConnectSetupViewModel
-                        .HEALTH_INTEGRATION_ID ->
-                        navController.navigate(
-                            Routes.healthConnectSetup(
-                                SetupMode.SETUP
-                            )
-                        )
-                    NotificationSetupViewModel.INTEGRATION_ID ->
-                        navController.navigate(
-                            Routes.notificationSetup(
-                                SetupMode.SETUP
-                            )
-                        )
-                    OutreachSetupViewModel.INTEGRATION_ID ->
-                        navController.navigate(
-                            Routes.outreachSetup(
-                                SetupMode.SETUP
-                            )
-                        )
-                    UsageSetupViewModel.INTEGRATION_ID ->
-                        navController.navigate(
-                            Routes.usageSetup(
-                                SetupMode.SETUP
-                            )
-                        )
-                    else ->
-                        navController.navigate(
-                            Routes.integrationSetup(id)
-                        )
+                    navController.navigate(setupRouteForIntegration(id))
                 }
             }
         )

--- a/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/BackgroundDeliveryDestination.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/BackgroundDeliveryDestination.kt
@@ -16,6 +16,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.rousecontext.app.delivery.BackgroundDelivery
 import com.rousecontext.app.delivery.DistributorOption
+import com.rousecontext.app.state.PendingIntegrationSetup
 import com.rousecontext.app.ui.navigation.ConfigureNavBar
 import com.rousecontext.app.ui.navigation.Routes
 import com.rousecontext.app.ui.screens.BackgroundDeliveryScreen
@@ -62,8 +63,12 @@ private fun BackgroundDeliveryDestinationContent(
 ) {
     val viewModel: BackgroundDeliveryViewModel = koinViewModel()
     val delivery: BackgroundDelivery = koinInject()
+    val pendingSetup: PendingIntegrationSetup = koinInject()
     val context = LocalContext.current
     val rows by viewModel.rows.collectAsState()
+    // #474: non-null when the picker was reached from "Add integration" on a
+    // not-yet-registered foss device. Drives the contextual strip + auto-resume.
+    val pendingIntegration by pendingSetup.pendingId.collectAsState()
 
     // Re-scan installed distributors when the user returns (e.g. after
     // installing one from the store the "install" rows deep-link to).
@@ -78,8 +83,29 @@ private fun BackgroundDeliveryDestinationContent(
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
-    val advance = {
-        if (settingsMode) {
+    // A distributor was chosen. #474: if we got here from Add integration,
+    // auto-resume straight into that integration's setup (popping the picker so
+    // back lands on Add integration). Otherwise keep the onboarding/Settings
+    // behaviour (advance to notification preferences / pop).
+    val onChosen = {
+        val pending = pendingSetup.consume()
+        if (pending != null) {
+            navController.navigate(setupRouteForIntegration(pending)) {
+                popUpTo(Routes.BACKGROUND_DELIVERY_BASE) { inclusive = true }
+            }
+        } else if (settingsMode) {
+            navController.popBackStack()
+        } else {
+            navController.navigate(Routes.NOTIFICATION_PREFERENCES)
+        }
+        Unit
+    }
+
+    // "Skip for now". When redirected here from Add integration there is
+    // nothing to resume into, so drop the pending integration and pop back to
+    // Add integration. Otherwise keep the onboarding skip behaviour.
+    val onSkip = {
+        if (pendingSetup.consume() != null) {
             navController.popBackStack()
         } else {
             navController.navigate(Routes.NOTIFICATION_PREFERENCES)
@@ -95,7 +121,7 @@ private fun BackgroundDeliveryDestinationContent(
                 DistributorOption.Kind.INSTALLED,
                 DistributorOption.Kind.ACTIVE -> {
                     viewModel.select(option.id)
-                    advance()
+                    onChosen()
                 }
                 DistributorOption.Kind.INSTALL_NTFY,
                 DistributorOption.Kind.INSTALL_OTHER -> {
@@ -109,7 +135,10 @@ private fun BackgroundDeliveryDestinationContent(
                 }
             }
         },
-        onSkip = advance,
-        onBack = { navController.popBackStack() }
+        onSkip = onSkip,
+        onBack = { navController.popBackStack() },
+        contextNote = pendingIntegration?.let {
+            "Set up a delivery app to finish adding integrations."
+        }
     )
 }

--- a/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/IntegrationSetupRoutes.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/IntegrationSetupRoutes.kt
@@ -1,0 +1,29 @@
+package com.rousecontext.app.ui.navigation.destinations
+
+import com.rousecontext.app.ui.navigation.Routes
+import com.rousecontext.app.ui.screens.SetupMode
+import com.rousecontext.app.ui.viewmodels.HealthConnectSetupViewModel
+import com.rousecontext.app.ui.viewmodels.NotificationSetupViewModel
+import com.rousecontext.app.ui.viewmodels.OutreachSetupViewModel
+import com.rousecontext.app.ui.viewmodels.UsageSetupViewModel
+
+/**
+ * Resolves the setup route for an integration id. Integrations that need a
+ * dedicated permission/credential step get their own screen; everything else
+ * uses the generic [Routes.integrationSetup].
+ *
+ * Shared by the add-integration picker and the #474 auto-resume path so both
+ * land on the same screen when entering an integration's setup flow.
+ */
+internal fun setupRouteForIntegration(id: String): String = when (id) {
+    HealthConnectSetupViewModel.HEALTH_INTEGRATION_ID ->
+        Routes.healthConnectSetup(SetupMode.SETUP)
+    NotificationSetupViewModel.INTEGRATION_ID ->
+        Routes.notificationSetup(SetupMode.SETUP)
+    OutreachSetupViewModel.INTEGRATION_ID ->
+        Routes.outreachSetup(SetupMode.SETUP)
+    UsageSetupViewModel.INTEGRATION_ID ->
+        Routes.usageSetup(SetupMode.SETUP)
+    else ->
+        Routes.integrationSetup(id)
+}

--- a/app/src/main/java/com/rousecontext/app/ui/screens/BackgroundDeliveryScreen.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/screens/BackgroundDeliveryScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -44,6 +45,11 @@ import com.rousecontext.app.ui.theme.SuccessGreen
  * don't block). Reached from Settings ([settingsMode] = true) it shows a back
  * arrow and marks the active distributor.
  *
+ * [contextNote], when non-null, renders a contextual strip above the picker.
+ * #474 uses it when the user was redirected here mid "Add integration" on a
+ * not-yet-registered foss device ("Set up a delivery app to finish adding
+ * integrations.").
+ *
  * Pure/state-driven so it renders in Roborazzi without UnifiedPush or Koin.
  */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -53,7 +59,8 @@ fun BackgroundDeliveryScreen(
     settingsMode: Boolean,
     onSelect: (DistributorOption) -> Unit,
     onSkip: () -> Unit,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    contextNote: String? = null
 ) {
     Scaffold(
         topBar = {
@@ -80,6 +87,10 @@ fun BackgroundDeliveryScreen(
                 .padding(horizontal = 24.dp)
         ) {
             Spacer(Modifier.height(20.dp))
+            if (contextNote != null) {
+                ContextNoteStrip(contextNote)
+                Spacer(Modifier.height(16.dp))
+            }
             Text(
                 text = "Pick an app to wake your phone when an AI client connects.",
                 style = MaterialTheme.typography.bodyLarge
@@ -98,6 +109,27 @@ fun BackgroundDeliveryScreen(
                 }
                 Spacer(Modifier.height(16.dp))
             }
+        }
+    }
+}
+
+@Composable
+private fun ContextNoteStrip(note: String) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.Info,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary
+            )
+            Spacer(Modifier.width(16.dp))
+            Text(
+                text = note,
+                style = MaterialTheme.typography.bodyMedium
+            )
         }
     }
 }

--- a/app/src/test/java/com/rousecontext/app/state/PendingIntegrationSetupTest.kt
+++ b/app/src/test/java/com/rousecontext/app/state/PendingIntegrationSetupTest.kt
@@ -1,0 +1,61 @@
+package com.rousecontext.app.state
+
+import com.rousecontext.app.delivery.DeliveryActivation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the pending-integration carry + the redirect decision behind #474
+ * (Option A: redirect a not-yet-registered foss device to the Background
+ * delivery picker when it taps "Add integration", then auto-resume into the
+ * integration it was adding once a distributor is chosen).
+ */
+class PendingIntegrationSetupTest {
+
+    @Test
+    fun `remember then consume returns the id exactly once`() {
+        val pending = PendingIntegrationSetup()
+
+        pending.remember("health")
+        assertEquals("health", pending.pendingId.value)
+
+        // Auto-resume consumes the carried id and clears it so a later picker
+        // visit (onboarding/Settings) does not re-trigger the resume.
+        assertEquals("health", pending.consume())
+        assertNull("consume must clear the pending id", pending.consume())
+        assertNull(pending.pendingId.value)
+    }
+
+    @Test
+    fun `clear drops a remembered id without returning it`() {
+        val pending = PendingIntegrationSetup()
+
+        pending.remember("notifications")
+        pending.clear()
+
+        assertNull(pending.pendingId.value)
+        assertNull(pending.consume())
+    }
+
+    @Test
+    fun `remember overwrites a previously pending id`() {
+        val pending = PendingIntegrationSetup()
+
+        pending.remember("health")
+        pending.remember("usage")
+
+        assertEquals("usage", pending.consume())
+    }
+
+    @Test
+    fun `redirect fires only for the foss not-yet-registered delivery state`() {
+        // NeedsSetup == foss device that skipped Background delivery: redirect.
+        assertTrue(deliveryNeedsSetupBeforeIntegration(DeliveryActivation.NeedsSetup))
+        // Active == foss registered; NotApplicable == google/FCM. Neither redirects.
+        assertFalse(deliveryNeedsSetupBeforeIntegration(DeliveryActivation.Active))
+        assertFalse(deliveryNeedsSetupBeforeIntegration(DeliveryActivation.NotApplicable))
+    }
+}

--- a/app/src/test/java/com/rousecontext/app/ui/navigation/BackStackFlowTest.kt
+++ b/app/src/test/java/com/rousecontext/app/ui/navigation/BackStackFlowTest.kt
@@ -381,6 +381,67 @@ class BackStackFlowTest {
         )
     }
 
+    // ---------- #474 redirect + auto-resume ----------
+
+    /**
+     * #474: a not-yet-registered foss device (skipped Background delivery)
+     * taps an integration on Add integration. Instead of silently blocking in
+     * IntegrationSetupViewModel.awaitRegistrationIfNeeded, it is redirected to
+     * the Background delivery picker. Once a distributor is chosen, it
+     * auto-resumes straight into the integration's setup flow — popping the
+     * picker so back from setup lands on Add integration, not the picker.
+     */
+    @Test
+    fun `unregistered add-integration redirects to picker then resumes into setup`() {
+        val stack = FakeBackStack(Routes.HOME)
+
+        // HOME -> ADD_INTEGRATION
+        stack.navigate(Routes.ADD_INTEGRATION)
+        // Tap an integration while unregistered -> redirect to the picker
+        // (instead of navigating to the integration's setup route).
+        stack.navigate(Routes.BACKGROUND_DELIVERY_BASE)
+        assertEquals(
+            listOf(Routes.HOME, Routes.ADD_INTEGRATION, Routes.BACKGROUND_DELIVERY_BASE),
+            stack.asList
+        )
+
+        // Distributor chosen -> auto-resume into the pending integration's
+        // setup, popping the picker inclusive.
+        stack.navigate(
+            route = Routes.INTEGRATION_SETUP,
+            popTarget = Routes.BACKGROUND_DELIVERY_BASE,
+            inclusive = true
+        )
+
+        // Lands on setup (NOT back on HOME); the picker is gone from the stack.
+        assertEquals(
+            listOf(Routes.HOME, Routes.ADD_INTEGRATION, Routes.INTEGRATION_SETUP),
+            stack.asList
+        )
+        assertEquals(Routes.INTEGRATION_SETUP, stack.current)
+    }
+
+    /**
+     * #474: if the redirected user taps "Skip for now" on the picker rather
+     * than choosing a distributor, there is nothing to resume into — drop the
+     * pending integration and pop back to Add integration.
+     */
+    @Test
+    fun `unregistered add-integration redirect then skip returns to add integration`() {
+        val stack = FakeBackStack(Routes.HOME)
+
+        stack.navigate(Routes.ADD_INTEGRATION)
+        stack.navigate(Routes.BACKGROUND_DELIVERY_BASE)
+
+        // "Skip for now" with a pending integration -> popBackStack.
+        stack.popBackStack()
+
+        assertEquals(
+            listOf(Routes.HOME, Routes.ADD_INTEGRATION),
+            stack.asList
+        )
+    }
+
     // ---------- IntegrationManage back behaviour ----------
 
     /**

--- a/app/src/test/java/com/rousecontext/app/ui/navigation/destinations/IntegrationSetupRoutesTest.kt
+++ b/app/src/test/java/com/rousecontext/app/ui/navigation/destinations/IntegrationSetupRoutesTest.kt
@@ -1,0 +1,47 @@
+package com.rousecontext.app.ui.navigation.destinations
+
+import com.rousecontext.app.ui.navigation.Routes
+import com.rousecontext.app.ui.screens.SetupMode
+import com.rousecontext.app.ui.viewmodels.HealthConnectSetupViewModel
+import com.rousecontext.app.ui.viewmodels.NotificationSetupViewModel
+import com.rousecontext.app.ui.viewmodels.OutreachSetupViewModel
+import com.rousecontext.app.ui.viewmodels.UsageSetupViewModel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Locks in the integration-id -> setup-route mapping shared by the add-integration
+ * picker and the #474 auto-resume path. Both must resolve the same dedicated
+ * setup screens (Health Connect, notifications, outreach, usage) so resuming
+ * after the Background delivery detour lands on the right flow.
+ */
+class IntegrationSetupRoutesTest {
+
+    @Test
+    fun `maps specialized integrations to their dedicated setup routes`() {
+        assertEquals(
+            Routes.healthConnectSetup(SetupMode.SETUP),
+            setupRouteForIntegration(HealthConnectSetupViewModel.HEALTH_INTEGRATION_ID)
+        )
+        assertEquals(
+            Routes.notificationSetup(SetupMode.SETUP),
+            setupRouteForIntegration(NotificationSetupViewModel.INTEGRATION_ID)
+        )
+        assertEquals(
+            Routes.outreachSetup(SetupMode.SETUP),
+            setupRouteForIntegration(OutreachSetupViewModel.INTEGRATION_ID)
+        )
+        assertEquals(
+            Routes.usageSetup(SetupMode.SETUP),
+            setupRouteForIntegration(UsageSetupViewModel.INTEGRATION_ID)
+        )
+    }
+
+    @Test
+    fun `maps an unknown integration to the generic setup route`() {
+        assertEquals(
+            Routes.integrationSetup("custom"),
+            setupRouteForIntegration("custom")
+        )
+    }
+}

--- a/docs/ux-decisions.md
+++ b/docs/ux-decisions.md
@@ -14,6 +14,57 @@ Newest entries on top.
 
 ---
 
+## 2026-06-16 — Add integration on an unregistered FOSS device redirects to the delivery picker (auto-resume)
+
+**Decision:** Option A — auto-redirect + auto-resume. On a not-yet-registered
+FOSS device (one that tapped "Skip for now" on Background delivery, so it sits on
+a degraded Home with no push endpoint), tapping **Add integration** no longer
+silently blocks in `IntegrationSetupViewModel.awaitRegistrationIfNeeded` (which
+read like a hang). Instead:
+- It **redirects to the existing Background delivery picker** (#463), topped with
+  a contextual strip: **"Set up a delivery app to finish adding integrations."**
+- It **remembers the integration the user was adding** (a single pending-integration
+  id carried across the picker round-trip).
+- **Auto-resume:** once a distributor is chosen, the user drops straight back into
+  that integration's setup flow (not back to Home). The setup screen's existing
+  "Registering" indicator covers the brief deferred-registration wait, so the
+  hand-off is legitimate rather than a silent block.
+- If the user instead taps "Skip for now" on the picker, the pending integration
+  is dropped and they return to Add integration (nothing to resume into).
+- **Gated on the delivery-not-set-up state** (`DeliveryActivation.NeedsSetup`), so
+  it is a no-op on `google` (FCM, `NotApplicable`) and on already-registered FOSS
+  devices (`Active`), which proceed straight into setup as before.
+
+**Approved by:** Jason, in-session 2026-06-15 — reviewed rendered Roborazzi mocks of
+four candidate shapes (silent-hang baseline, A auto-redirect, B explanatory dialog,
+C inline banner) and picked **Option A + auto-resume**.
+
+**Context:** The FOSS deferred-activation model (2026-06-13 entry) lets a user skip
+Background delivery and reach a degraded Home. But the integration-setup flow waits
+for registration to complete before provisioning, and on a skipped device that
+registration never starts — so "Add integration" appeared to hang with no
+explanation and no way forward.
+
+**Alternatives considered:**
+- **B — explanatory dialog** before routing onward. Adds the most net-new UI for
+  the least payoff; the picker itself already explains what's needed.
+- **C — inline banner on a dead-end screen.** Leaves the user parked on a screen
+  they have to back out of, rather than moving them toward the fix.
+- **Return to Home after registration** (instead of auto-resume). Rejected: it
+  breaks the "finish what you started" flow the strip copy promises and forces the
+  user to re-find and re-tap the integration.
+- A is the most faithful to the existing flow (it *is* the real #463 picker),
+  the lowest-risk build, and the smallest new surface.
+
+**Trade-off accepted:** "Add integration" can now detour through a second screen
+before setup, and the carried pending-integration id is process-scoped (not
+persisted) — if the process dies mid-detour, the user simply re-taps the
+integration. We accept that over a heavier persisted-resume mechanism.
+
+**Relevant:** #474 (this change), #463 (the picker), #460 (the FOSS flavor).
+
+---
+
 ## 2026-06-13 — FOSS flavor adds a "Background delivery" picker (deferred activation)
 
 **Decision:** The fully-FOSS build flavor (`foss`, for F-Droid — see #460) replaces


### PR DESCRIPTION
Closes #474

## What changed

On a not-yet-registered FOSS device (one that tapped "Skip for now" on Background delivery and sits on a degraded Home), tapping **Add integration** used to silently block in `IntegrationSetupViewModel.awaitRegistrationIfNeeded` waiting for a registration that never starts — it read like a hang.

This implements the approved **Option A + auto-resume**:

1. **Detect + redirect.** At add-integration time, if `BackgroundDelivery.activation == NeedsSetup` (the foss skipped/unregistered state), redirect to the existing #463 Background delivery picker instead of blocking.
2. **Contextual strip.** When the picker is reached this way it shows: *"Set up a delivery app to finish adding integrations."*
3. **Auto-resume.** A new `PendingIntegrationSetup` singleton carries the integration id across the picker round-trip. Once a distributor is chosen, the user drops straight back into that integration's setup flow (the setup screen's existing "Registering" indicator covers the brief deferred-registration wait). Tapping "Skip for now" instead drops the pending id and returns to Add integration.

Gated on `NeedsSetup`, so it is a **no-op on google** (FCM → `NotApplicable`) and on already-registered FOSS devices (`Active`), which proceed straight into setup as before.

The integration-id → setup-route mapping was extracted into a shared `setupRouteForIntegration` helper so the picker and the add-integration screen resolve the same dedicated setup screens (Health Connect, notifications, outreach, usage).

## UX decision log

Per `.claude/rules/ux-changes.md`, this PR adds a `docs/ux-decisions.md` entry (newest on top): Decision = Option A redirect + auto-resume; Approved by Jason in-session 2026-06-15 (reviewed Roborazzi mocks of baseline/A/B/C); records the B/dialog, C/inline-banner, and return-to-home alternatives and the trade-off. Relevant: #474, #463, #460.

## Tests / verification

- New `PendingIntegrationSetupTest`: remember/consume/clear carry semantics + the redirect decision fires only for `NeedsSetup` (not `Active`/`NotApplicable`).
- New `IntegrationSetupRoutesTest`: shared route mapping resolves each specialized + generic setup route.
- `BackStackFlowTest`: two new cases — redirect then resume lands on integration setup (not Home, picker popped); redirect then skip returns to Add integration.
- `./gradlew :app:testDebugUnitTest` green; `./gradlew ktlintCheck detekt` green.
- google variant compiles (`:app:compileDebugKotlin -Pgoogle`). `:app:assembleDebug` fails only at `validateSigningDebug` in this worktree (keystore/env), identically for foss and google — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)