### PR TITLE
#483: FOSS Home battery-opt warning + one-tap exemption dialog

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,19 @@
     -->
     <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_HISTORY" />
 
+    <!--
+      Lets the "Fix this" battery-optimization action open the one-tap
+      allow/deny dialog (ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS) instead of
+      the settings list the user has to hunt through. On the FOSS build the
+      exemption is required for background wake to fire at all (issue #483); on
+      the Google build it improves wake reliability (#453). Google Play
+      restricts this permission, but we don't ship to Play — the Google build is
+      GitHub-distributed and the FOSS build goes to F-Droid, which accepts it
+      (ntfy uses the same permission). Declared in the shared manifest because
+      the Settings "Fix this" exists on both builds.
+    -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+
     <application
         android:name=".RouseApplication"
         android:allowBackup="false"

--- a/app/src/main/java/com/rousecontext/app/di/AppModule.kt
+++ b/app/src/main/java/com/rousecontext/app/di/AppModule.kt
@@ -38,6 +38,7 @@ import com.rousecontext.app.state.ThemePreference
 import com.rousecontext.app.state.notificationPermissionFlow
 import com.rousecontext.app.support.BatteryOptimization
 import com.rousecontext.app.support.BugReportUriBuilder
+import com.rousecontext.app.support.batteryExemptFlow
 import com.rousecontext.app.token.RoomTokenStore
 import com.rousecontext.app.token.TokenDatabase
 import com.rousecontext.app.token.createUnknownClientLabeler
@@ -630,7 +631,12 @@ val appModule = module {
                 triggers = refresher.ticks
             ),
             spuriousWakesFlow = SettingsViewModel.spuriousWakeStatsFlow(get()),
-            deliveryActivation = get<BackgroundDelivery>().activation
+            deliveryActivation = get<BackgroundDelivery>().activation,
+            batteryOptimizationExempt = batteryExemptFlow(
+                context = androidContext(),
+                triggers = refresher.ticks
+            ),
+            deliveryWakeSupported = get<BackgroundDelivery>().isSupported
         )
     }
     viewModel { AddIntegrationViewModel(get(), get(), get()) }

--- a/app/src/main/java/com/rousecontext/app/support/BatteryOptimization.kt
+++ b/app/src/main/java/com/rousecontext/app/support/BatteryOptimization.kt
@@ -2,23 +2,34 @@ package com.rousecontext.app.support
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.PowerManager
 import android.provider.Settings
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 
 /**
  * Battery-optimization status and the user-facing flow to change it.
  *
- * Reliable FCM wake-ups depend on the app being exempt from Doze battery
- * optimization. We surface the current status in Settings (a warning + the
- * idle-timeout "Disable" switch both gate on it) and offer a "Fix this" button
- * that sends the user to the system screen where they can grant the exemption.
+ * Reliable background wake-ups depend on the app being exempt from Doze battery
+ * optimization. On the FOSS build this exemption is *required* — a third-party
+ * UnifiedPush distributor cannot hand our app the temporary power-allowlist that
+ * Google Play Services grants the FCM build, so without the standing exemption
+ * the background start of the tunnel foreground service is blocked and the wake
+ * is dropped (issue #483). We surface the status in Settings (#453) and, on the
+ * FOSS build, on Home, and offer a "Fix this" action.
  *
- * We deliberately use [Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS]
- * (the optimization list the user picks the app from) rather than
- * `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` (the direct allow/deny dialog):
- * the direct request needs the `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`
- * permission, which Google Play restricts to apps whose core function requires
- * it. The settings-list route needs no special permission.
+ * "Fix this" uses [Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS] — the
+ * one-tap allow/deny dialog — with a `package:` URI, instead of
+ * [Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS] (the optimization list
+ * the user has to hunt through). The dialog needs the
+ * `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` permission, which Google Play restricts
+ * to apps whose core function requires it. We don't ship to Play (the Google
+ * build is GitHub-distributed; the FOSS build goes to F-Droid, which accepts the
+ * permission — ntfy uses it), so that restriction doesn't bind and we get the
+ * better one-tap flow. This supersedes the 2026-06-02 #453 settings-list choice.
  */
 object BatteryOptimization {
 
@@ -30,8 +41,25 @@ object BatteryOptimization {
     }
 
     /**
-     * Intent that opens the system battery-optimization settings list, where the
-     * user can mark this app "Don't optimize". Launch from an Activity context.
+     * Intent that opens the system one-tap "allow ignoring battery optimization?"
+     * dialog for this app, so a single confirmation grants the exemption. Launch
+     * from an Activity context.
      */
-    fun settingsIntent(): Intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
+    fun requestExemptionIntent(context: Context): Intent =
+        Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+            data = Uri.parse("package:${context.packageName}")
+        }
 }
+
+/**
+ * Maps a trigger flow (emit anything to re-check) into a flow of "is this app
+ * exempt from battery optimization". An initial value is emitted immediately on
+ * collection. Mirrors
+ * [com.rousecontext.app.state.notificationPermissionFlow]: callers drive
+ * [triggers] from lifecycle events (ON_RESUME) so the Home battery-optimization
+ * banner reflects the current state after the user returns from the OS dialog.
+ */
+fun batteryExemptFlow(context: Context, triggers: Flow<Unit>): Flow<Boolean> = triggers
+    .onStart { emit(Unit) }
+    .map { BatteryOptimization.isExempt(context) }
+    .distinctUntilChanged()

--- a/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/MainDashboardDestination.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/MainDashboardDestination.kt
@@ -20,6 +20,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.rousecontext.app.R
 import com.rousecontext.app.state.NotificationPermissionRefresher
+import com.rousecontext.app.support.BatteryOptimization
 import com.rousecontext.app.ui.navigation.ConfigureNavBar
 import com.rousecontext.app.ui.navigation.Routes
 import com.rousecontext.app.ui.navigation.TAB_INDEX
@@ -130,6 +131,15 @@ fun NavGraphBuilder.mainDashboardDestination(navController: NavController) {
                 // foss-only: the degraded-wake banner is the only caller and it
                 // never renders on google. Opens the "Background delivery" picker.
                 navController.navigate(Routes.BACKGROUND_DELIVERY_BASE)
+            },
+            onFixBatteryOptimization = {
+                // foss-only battery banner: open the one-tap OS allow dialog
+                // (#483). The ON_RESUME refresh above re-reads the exemption so
+                // the banner clears when the user returns from the dialog.
+                startActivitySafely(
+                    context,
+                    BatteryOptimization.requestExemptionIntent(context)
+                )
             },
             onRetry = { viewModel.retry() }
         )

--- a/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/SettingsDestination.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/SettingsDestination.kt
@@ -99,7 +99,10 @@ private fun SettingsDestinationContent(onOpenBackgroundDelivery: () -> Unit) {
         onIdleTimeoutChanged = viewModel::setIdleTimeout,
         onDisableTimeoutToggled = viewModel::setDisableTimeout,
         onFixBatteryOptimization = {
-            startActivitySafely(settingsContext, BatteryOptimization.settingsIntent())
+            startActivitySafely(
+                settingsContext,
+                BatteryOptimization.requestExemptionIntent(settingsContext)
+            )
         },
         onPostSessionModeChanged = viewModel::setPostSessionMode,
         onShowAllMcpMessagesChanged = viewModel::setShowAllMcpMessages,
@@ -136,9 +139,9 @@ private fun openUriSafely(context: Context, uri: Uri) {
 /**
  * Launch an arbitrary system [Intent], swallowing [ActivityNotFoundException]
  * for the rare device/ROM that doesn't expose the target screen. Used for the
- * battery-optimization settings deep-link behind "Fix this".
+ * battery-optimization request dialog behind "Fix this".
  */
-private fun startActivitySafely(context: Context, intent: Intent) {
+internal fun startActivitySafely(context: Context, intent: Intent) {
     try {
         context.startActivity(intent.apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) })
     } catch (_: ActivityNotFoundException) {

--- a/app/src/main/java/com/rousecontext/app/ui/screens/MainDashboardScreen.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/screens/MainDashboardScreen.kt
@@ -122,6 +122,18 @@ data class SpuriousWakeBanner(val rolling24hCount: Int)
  */
 data object DeliveryBanner
 
+/**
+ * Shown on the foss flavor when the app is NOT exempt from Doze battery
+ * optimization (issue #483). On foss that exemption is required for background
+ * wake to fire at all: a UnifiedPush distributor can't grant our app the
+ * temporary power-allowlist that Play Services hands the FCM build, so without
+ * the standing exemption the background start of the tunnel foreground service
+ * is blocked and the wake is dropped. Tapping "Fix this" opens the one-tap OS
+ * allow dialog. Distinct from [DeliveryBanner] (no distributor chosen) and can
+ * co-exist with it. Never shown on the google flavor, which wakes via FCM.
+ */
+data object BatteryOptimizationBanner
+
 private const val MAX_RECENT_ITEMS = 5
 
 @Immutable
@@ -132,6 +144,7 @@ data class DashboardState(
     val recentActivity: List<AuditHistoryEntry> = emptyList(),
     val certBanner: CertBanner? = null,
     val deliveryBanner: DeliveryBanner? = null,
+    val batteryOptimizationBanner: BatteryOptimizationBanner? = null,
     val notificationBanner: NotificationBanner? = null,
     val spuriousWakeBanner: SpuriousWakeBanner? = null,
     val hasMoreIntegrationsToAdd: Boolean = true,
@@ -153,6 +166,7 @@ fun HomeDashboardContent(
     onOpenNotificationSettings: () -> Unit = {},
     onOpenSettings: () -> Unit = {},
     onSetUpDelivery: () -> Unit = {},
+    onFixBatteryOptimization: () -> Unit = {},
     onRetry: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
@@ -178,7 +192,8 @@ fun HomeDashboardContent(
             onRetryRenewal = onRetryRenewal,
             onOpenNotificationSettings = onOpenNotificationSettings,
             onOpenSettings = onOpenSettings,
-            onSetUpDelivery = onSetUpDelivery
+            onSetUpDelivery = onSetUpDelivery,
+            onFixBatteryOptimization = onFixBatteryOptimization
         )
 
         // Integrations header
@@ -446,12 +461,52 @@ private fun DeliveryBannerCard(onSetUp: () -> Unit) {
     }
 }
 
+@Composable
+private fun BatteryOptimizationBannerCard(onFix: () -> Unit) {
+    val ext = com.rousecontext.app.ui.theme.LocalExtendedColors.current
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = ext.warningContainer)
+    ) {
+        Row(
+            modifier = Modifier.padding(dimensionResource(R.dimen.spacing_lg)),
+            verticalAlignment = Alignment.Top
+        ) {
+            Icon(
+                imageVector = Icons.Default.Warning,
+                contentDescription = null,
+                modifier = Modifier.size(dimensionResource(R.dimen.icon_size_sm)),
+                tint = ext.onWarningContainer
+            )
+            Spacer(modifier = Modifier.width(dimensionResource(R.dimen.spacing_md)))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.screen_dashboard_battery_off_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = ext.onWarningContainer
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.screen_dashboard_battery_off_subtitle),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = ext.onWarningContainer
+                )
+                Spacer(modifier = Modifier.height(10.dp))
+                OutlinedButton(onClick = onFix) {
+                    Text(stringResource(R.string.screen_dashboard_battery_off_action))
+                }
+            }
+        }
+    }
+}
+
 private fun LazyListScope.dashboardBannerItems(
     state: DashboardState,
     onRetryRenewal: () -> Unit,
     onOpenNotificationSettings: () -> Unit,
     onOpenSettings: () -> Unit,
-    onSetUpDelivery: () -> Unit
+    onSetUpDelivery: () -> Unit,
+    onFixBatteryOptimization: () -> Unit
 ) {
     // Cert banner (most urgent — show first).
     state.certBanner?.let { banner ->
@@ -470,6 +525,19 @@ private fun LazyListScope.dashboardBannerItems(
                 Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_lg)))
             }
             DeliveryBannerCard(onSetUp = onSetUpDelivery)
+            Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_lg)))
+        }
+    }
+
+    // Battery-optimization banner (foss: background wake can't fire while the
+    // app is still battery-optimized). Distinct from the delivery banner; both
+    // can show at once.
+    if (state.batteryOptimizationBanner != null) {
+        item {
+            if (state.certBanner == null && state.deliveryBanner == null) {
+                Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_lg)))
+            }
+            BatteryOptimizationBannerCard(onFix = onFixBatteryOptimization)
             Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_lg)))
         }
     }

--- a/app/src/main/java/com/rousecontext/app/ui/viewmodels/MainDashboardViewModel.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/viewmodels/MainDashboardViewModel.kt
@@ -8,6 +8,7 @@ import com.rousecontext.api.McpIntegration
 import com.rousecontext.api.deriveIntegrationState
 import com.rousecontext.app.McpUrlProvider
 import com.rousecontext.app.delivery.DeliveryActivation
+import com.rousecontext.app.ui.screens.BatteryOptimizationBanner
 import com.rousecontext.app.ui.screens.CertBanner
 import com.rousecontext.app.ui.screens.ConnectionStatus
 import com.rousecontext.app.ui.screens.DashboardState
@@ -68,6 +69,23 @@ class MainDashboardViewModel(
      */
     deliveryActivation: Flow<DeliveryActivation> = flowOf(DeliveryActivation.NotApplicable),
     /**
+     * Whether this app is currently exempt from Doze battery optimization
+     * (issue #483). Re-read on each ON_RESUME tick (see
+     * [com.rousecontext.app.support.batteryExemptFlow]) so returning from the
+     * OS allow dialog clears the banner. Combined with [deliveryWakeSupported]
+     * to drive the foss-only battery-optimization Home banner. Defaults to
+     * `true` (no banner) for tests and the google flavor.
+     */
+    batteryOptimizationExempt: Flow<Boolean> = flowOf(true),
+    /**
+     * Whether this distribution wakes via a UnifiedPush distributor (foss),
+     * i.e. [com.rousecontext.app.delivery.BackgroundDelivery.isSupported]. Only
+     * then is the battery-optimization exemption load-bearing for background
+     * wake, so the battery banner is gated on it — the google/FCM build (where
+     * this is `false`) never shows it. Issue #483.
+     */
+    private val deliveryWakeSupported: Boolean = false,
+    /**
      * Ticker driving the rolling-24h "Recent Activity" cutoff. Each emission
      * is a fresh wall-clock timestamp that `flatMapLatest` uses to restart
      * the DAO query with a moved-forward lower bound. Fixes #370: the
@@ -101,6 +119,7 @@ class MainDashboardViewModel(
     }
     private val deliveryActivationStarted =
         deliveryActivation.onStart { emit(DeliveryActivation.NotApplicable) }
+    private val batteryExemptStarted = batteryOptimizationExempt.onStart { emit(true) }
 
     val state: StateFlow<DashboardState> = combine(
         combine(
@@ -113,8 +132,9 @@ class MainDashboardViewModel(
             BannerInputs(tunnelState, recentEntries, certBanner, notifsEnabled)
         },
         spuriousWakesFlowStarted,
-        deliveryActivationStarted
-    ) { inputs, spurious, deliveryState ->
+        deliveryActivationStarted,
+        batteryExemptStarted
+    ) { inputs, spurious, deliveryState, batteryExempt ->
         val tunnelState = inputs.tunnelState
         val recentEntries = inputs.recentEntries
         val certBanner = inputs.certBanner
@@ -169,6 +189,11 @@ class MainDashboardViewModel(
             certBanner = certBanner,
             deliveryBanner = if (deliveryState == DeliveryActivation.NeedsSetup) {
                 DeliveryBanner
+            } else {
+                null
+            },
+            batteryOptimizationBanner = if (deliveryWakeSupported && !batteryExempt) {
+                BatteryOptimizationBanner
             } else {
                 null
             },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -255,6 +255,9 @@
     <string name="screen_dashboard_delivery_off_title">On-demand wake is off</string>
     <string name="screen_dashboard_delivery_off_subtitle">Set up a delivery app so AI clients can reach your phone while it\'s asleep.</string>
     <string name="screen_dashboard_delivery_off_action">Set up</string>
+    <string name="screen_dashboard_battery_off_title">Battery optimization is on</string>
+    <string name="screen_dashboard_battery_off_subtitle">Allow this app to ignore battery optimization, or AI clients can\'t wake your phone while it\'s asleep. Your delivery app may need the same.</string>
+    <string name="screen_dashboard_battery_off_action">Fix this</string>
     <string name="screen_dashboard_spurious_wake_title">Background activity higher than expected</string>
     <string name="screen_dashboard_spurious_wake_subtitle">The relay may be sending spurious wakes (%1$d in the last 24h). Tap for details.</string>
     <string name="screen_dashboard_cert_renewing_title">Provisioning your certificate...</string>

--- a/app/src/test/java/com/rousecontext/app/support/BatteryOptimizationTest.kt
+++ b/app/src/test/java/com/rousecontext/app/support/BatteryOptimizationTest.kt
@@ -30,8 +30,9 @@ class BatteryOptimizationTest {
     }
 
     @Test
-    fun `settingsIntent targets the battery-optimization settings screen`() {
-        val intent = BatteryOptimization.settingsIntent()
-        assertEquals(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS, intent.action)
+    fun `requestExemptionIntent targets the one-tap allow dialog for this package`() {
+        val intent = BatteryOptimization.requestExemptionIntent(context)
+        assertEquals(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS, intent.action)
+        assertEquals("package:${context.packageName}", intent.data.toString())
     }
 }

--- a/app/src/test/java/com/rousecontext/app/ui/viewmodels/MainDashboardViewModelTest.kt
+++ b/app/src/test/java/com/rousecontext/app/ui/viewmodels/MainDashboardViewModelTest.kt
@@ -426,6 +426,73 @@ class MainDashboardViewModelTest {
     }
 
     @Test
+    fun `battery banner appears on foss when not exempt`() = runTest(testDispatcher) {
+        val vm = createViewModel(
+            deliveryWakeSupported = true,
+            batteryExemptFlow = flowOf(false)
+        )
+        vm.state.test {
+            var state = awaitItem()
+            while (state.isLoading || state.batteryOptimizationBanner == null) {
+                state = awaitItem()
+            }
+            assertNotNull(state.batteryOptimizationBanner)
+        }
+    }
+
+    @Test
+    fun `battery banner absent on foss when exempt`() = runTest(testDispatcher) {
+        val vm = createViewModel(
+            deliveryWakeSupported = true,
+            batteryExemptFlow = flowOf(true)
+        )
+        vm.state.test {
+            var state = awaitItem()
+            while (state.isLoading) {
+                state = awaitItem()
+            }
+            assertNull(state.batteryOptimizationBanner)
+        }
+    }
+
+    @Test
+    fun `battery banner absent on google flavor even when not exempt`() = runTest(testDispatcher) {
+        val vm = createViewModel(
+            deliveryWakeSupported = false,
+            batteryExemptFlow = flowOf(false)
+        )
+        vm.state.test {
+            var state = awaitItem()
+            while (state.isLoading) {
+                state = awaitItem()
+            }
+            assertNull(state.batteryOptimizationBanner)
+        }
+    }
+
+    @Test
+    fun `battery banner clears reactively when exemption is granted`() = runTest(testDispatcher) {
+        val exemptFlow = MutableStateFlow(false)
+        val vm = createViewModel(
+            deliveryWakeSupported = true,
+            batteryExemptFlow = exemptFlow
+        )
+        vm.state.test {
+            var state = awaitItem()
+            while (state.isLoading || state.batteryOptimizationBanner == null) {
+                state = awaitItem()
+            }
+            assertNotNull(state.batteryOptimizationBanner)
+
+            // User grants the exemption via the OS dialog; an ON_RESUME re-read
+            // flips the flow.
+            exemptFlow.value = true
+            state = awaitItem()
+            assertNull(state.batteryOptimizationBanner)
+        }
+    }
+
+    @Test
     fun `connection status reflects tunnel state`() = runTest(testDispatcher) {
         val vm = createViewModel()
         vm.state.test {
@@ -514,7 +581,9 @@ class MainDashboardViewModelTest {
         certRenewalFlow: kotlinx.coroutines.flow.Flow<CertBanner?> = flowOf(null),
         notificationsEnabledFlow: kotlinx.coroutines.flow.Flow<Boolean> = flowOf(true),
         spuriousWakesFlow: kotlinx.coroutines.flow.Flow<SpuriousWakeStats> =
-            flowOf(SpuriousWakeStats.EMPTY)
+            flowOf(SpuriousWakeStats.EMPTY),
+        batteryExemptFlow: kotlinx.coroutines.flow.Flow<Boolean> = flowOf(true),
+        deliveryWakeSupported: Boolean = false
     ): MainDashboardViewModel {
         val auditDao = mockk<AuditDao> {
             coEvery { queryByDateRange(any(), any(), any()) } returns emptyList()
@@ -537,7 +606,9 @@ class MainDashboardViewModelTest {
             tunnelClient = fakeTunnelClient,
             certRenewalBanner = certRenewalFlow,
             notificationsEnabled = notificationsEnabledFlow,
-            spuriousWakesFlow = spuriousWakesFlow
+            spuriousWakesFlow = spuriousWakesFlow,
+            batteryOptimizationExempt = batteryExemptFlow,
+            deliveryWakeSupported = deliveryWakeSupported
         )
     }
 

--- a/docs/ux-decisions.md
+++ b/docs/ux-decisions.md
@@ -14,6 +14,67 @@ Newest entries on top.
 
 ---
 
+## 2026-06-16 — FOSS Home battery-optimization warning; "Fix this" becomes the one-tap OS dialog (supersedes 2026-06-02 #453)
+
+**Decision:** Two parts (#483).
+1. **New FOSS-only Home banner.** On the FOSS build, Home shows a persistent
+   warning banner ("Battery optimization is on") whenever the app is NOT on the
+   battery-optimization allowlist. On FOSS that exemption is required for
+   background wake to fire at all — a UnifiedPush distributor can't grant our app
+   the temporary power-allowlist that Play Services hands the FCM build, so
+   without the standing exemption the background start of the tunnel foreground
+   service is blocked and the wake is dropped. The banner mirrors how ntfy
+   surfaces its own battery warning, and sits alongside (and can co-exist with)
+   the existing "On-demand wake is off" delivery banner — a distinct condition
+   (that one = no distributor chosen; this one = distributor set up but the app
+   can't start the FGS from background without the exemption). Never shown on the
+   google/FCM build, which gets the temporary allowlist automatically.
+2. **"Fix this" now opens the one-tap OS dialog.** Both the new Home banner's
+   action AND the existing #453 Connection-settings "Fix this" now launch
+   `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` (the one-tap allow/deny dialog,
+   with a `package:` URI) instead of `ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS`
+   (the settings list the user hunts through). This declares the
+   `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` permission. **This supersedes the
+   2026-06-02 #453 decision** ("Fix this opens battery-optimization settings").
+
+**Approved by:** Jason, in-session 2026-06-16 — picked the detect-and-warn option
+and, in a follow-up amendment, the one-tap dialog mechanism for both surfaces.
+
+**Context:** Found during the 2026-06-16 FCM-vs-ntfy wake benchmark (#483): the
+FOSS ntfy wake path didn't fire at all until the app was battery-exempt. The
+#453 "Fix this" deliberately used the settings-list action solely to dodge the
+Google Play policy restriction on `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`. We
+don't ship to Play — the Google build is GitHub-distributed and the FOSS build
+goes to F-Droid, which accepts the permission (ntfy itself uses it and ships on
+F-Droid) — so that constraint no longer binds, and the better one-tap flow is
+available.
+
+**Alternatives considered:**
+- **Request the exemption up front during FOSS delivery setup** (option (a) on
+  #483) — most reliable, but adds an onboarding permission surface. Rejected in
+  favor of degrade-and-warn, consistent with the delivery banner's "degrade,
+  don't block" model.
+- **Document-only** (option (c)) — weakest; leaves wake quietly unreliable.
+- **Keep the settings-list action for "Fix this"** — no Play risk, but a multi-tap
+  hunt-for-the-app flow when a one-tap dialog is available and policy no longer
+  blocks it.
+
+**Trade-off accepted:** The app now declares a Play-restricted permission, so it
+could not ship to Google Play as-is — acceptable because we never do (Google
+build is GitHub-distributed, FOSS goes to F-Droid). The Home banner is one more
+warning surface FOSS users may see, but it is the only signal that an otherwise
+silent background-wake failure is fixable.
+
+**Relevant:**
+- #483 (this change); part of epic #460 (the FOSS distribution).
+- Supersedes the 2026-06-02 #453 "Fix this opens battery-optimization settings"
+  decision below.
+- Battery-opt status + intent shared via `BatteryOptimization`; foss-gated at
+  runtime via `BackgroundDelivery.isSupported` (the same seam the delivery banner
+  uses). Exemption re-read on ON_RESUME via `batteryExemptFlow`.
+
+---
+
 ## 2026-06-16 — Add integration on an unregistered FOSS device redirects to the delivery picker (auto-resume)
 
 **Decision:** Option A — auto-redirect + auto-resume. On a not-yet-registered


### PR DESCRIPTION
Closes #483

## What & why
On the FOSS build, on-demand wake silently fails from the background unless the app is on the battery-optimization allowlist. A third-party UnifiedPush distributor can't grant our app the temporary power-allowlist that Play Services hands the FCM build, so the background start of the tunnel foreground service is blocked and the wake is dropped. Nothing surfaced this fixable condition.

### Part 1 — FOSS-only Home battery-optimization warning
- New persistent Home banner ("Battery optimization is on") shown when the app is **not** battery-exempt.
- **Foss-gated at runtime** via `BackgroundDelivery.isSupported` — the same seam the existing "On-demand wake is off" delivery banner uses (`NoOpBackgroundDelivery.isSupported == false` on google/FCM, so it never shows there). No new BuildConfig field needed.
- Exemption is re-read on `ON_RESUME` via a new `batteryExemptFlow(context, triggers)` that mirrors `notificationPermissionFlow`, reusing the dashboard's existing `NotificationPermissionRefresher` ticks, so the banner clears when the user returns from the OS dialog.
- Sits alongside (and can co-exist with) the delivery banner — distinct condition: delivery banner = no distributor chosen; battery banner = distributor set up but the app can't start the FGS from background without the exemption.

### Part 2 — "Fix this" becomes the one-tap OS dialog
- Both the new Home banner action and the **existing #453 Connection-settings "Fix this"** now launch `ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` (one-tap allow/deny dialog) + `package:` URI, instead of `ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS` (the list).
- Declares `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` in the **shared** manifest (the Settings "Fix this" exists on both builds). #453 used the list solely to dodge the Google Play restriction on that permission; we don't ship to Play (Google build is GitHub-distributed, FOSS goes to F-Droid, which accepts it — ntfy uses it), so that no longer binds.

### UX decision log
`docs/ux-decisions.md` gets a new 2026-06-16 entry recording both parts and explicitly **superseding the 2026-06-02 #453** "Fix this opens battery-optimization settings" decision.

## Tests
- `BatteryOptimizationTest` updated: asserts the dialog action + `package:` data URI.
- `MainDashboardViewModelTest`: banner shows on foss when not exempt; absent when exempt; absent on google even when not exempt; clears reactively when exemption is granted.

## Verification
- `./gradlew :app:testDebugUnitTest` (foss/default) — green (full suite).
- Affected tests also green under `-Pgoogle`.
- `./gradlew :app:compileDebugKotlin -Pgoogle` — compiles (warning stays foss-gated).
- `./gradlew :app:ktlintCheck detekt` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)