### PR TITLE
Decouple foss wake-activation from cert provisioning (#486)

### DIFF
--- a/app/src/foss/java/com/rousecontext/app/delivery/UnifiedPushBackgroundDelivery.kt
+++ b/app/src/foss/java/com/rousecontext/app/delivery/UnifiedPushBackgroundDelivery.kt
@@ -152,23 +152,29 @@ class UnifiedPushBackgroundDelivery(
             Log.e(TAG, "Couldn't obtain device credential for deferred registration", e)
             null
         } ?: return
-        when (
-            val result = onboardingFlow.execute(
-                credential,
-                fcmToken = "",
-                pushEndpoint = endpoint
-            )
-        ) {
-            is OnboardingResult.Success -> {
-                registrationStatus.markComplete()
-                _activation.value = DeliveryActivation.Active
-                Log.i(TAG, "Deferred foss registration complete; on-demand wake active")
-            }
-            else -> {
-                Log.w(TAG, "Deferred foss registration did not complete: $result")
-                _activation.value = DeliveryActivation.NeedsSetup
-            }
+        val result = onboardingFlow.execute(
+            credential,
+            fcmToken = "",
+            pushEndpoint = endpoint
+        )
+        if (result is OnboardingResult.Success) {
+            registrationStatus.markComplete()
         }
+        // Wake-activation tracks "is there a registered push wake target?", which
+        // is exactly "did we persist a subdomain?" — NOT "did the whole flow incl.
+        // certs succeed" (#486). `execute` registers + persists the subdomain
+        // before chaining ACME cert provisioning (#389), so a cert-stage failure
+        // (Cert*) returns non-Success while the device is already registered with
+        // its endpoint reported. Keying off the persisted subdomain (mirroring the
+        // init seeding and refreshEndpoint) keeps the delivery banner Active in
+        // that case; cert problems are surfaced separately by the cert-renewal
+        // banner. Only pre-subdomain failures leave wake needing setup.
+        _activation.value = if (certificateStore.getSubdomain() != null) {
+            DeliveryActivation.Active
+        } else {
+            DeliveryActivation.NeedsSetup
+        }
+        Log.i(TAG, "Deferred foss registration result=$result; activation=${_activation.value}")
     }
 
     private suspend fun refreshEndpoint(endpoint: String) {

--- a/app/src/testFoss/java/com/rousecontext/app/delivery/UnifiedPushBackgroundDeliveryTest.kt
+++ b/app/src/testFoss/java/com/rousecontext/app/delivery/UnifiedPushBackgroundDeliveryTest.kt
@@ -1,0 +1,151 @@
+package com.rousecontext.app.delivery
+
+import androidx.test.core.app.ApplicationProvider
+import com.rousecontext.app.auth.DeviceCredentialProvider
+import com.rousecontext.app.state.DeviceRegistrationStatus
+import com.rousecontext.tunnel.CertificateStore
+import com.rousecontext.tunnel.DeviceCredential
+import com.rousecontext.tunnel.OnboardingFlow
+import com.rousecontext.tunnel.OnboardingResult
+import com.rousecontext.tunnel.TunnelClient
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Direct unit tests for the deferred-registration activation logic in
+ * [UnifiedPushBackgroundDelivery] (issue #486).
+ *
+ * Onboarding ([OnboardingFlow.execute]) registers + persists the subdomain
+ * FIRST and only then chains ACME cert provisioning (#389). A cert-stage
+ * failure therefore returns a `Cert*` result while the device is already
+ * registered with its push endpoint reported. Wake-activation (the Home
+ * delivery banner) must key off the persisted subdomain — "do we have a push
+ * wake target?" — not off whether the cert hop also succeeded. Cert problems
+ * are surfaced separately by the dashboard cert-renewal banner.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class UnifiedPushBackgroundDeliveryTest {
+
+    private val credentialProvider = mockk<DeviceCredentialProvider> {
+        coEvery { forRegistration() } returns DeviceCredential.Firebase("test-token")
+    }
+    private val registrationStatus = DeviceRegistrationStatus(initiallyRegistered = false)
+    private val tunnelClient = mockk<TunnelClient>(relaxed = true)
+
+    /**
+     * In-memory [CertificateStore] whose subdomain is mutated by the faked
+     * [OnboardingFlow] (mirroring `registerAndPersist`, which persists the
+     * subdomain before the cert hop runs). Only [getSubdomain]/[storeSubdomain]
+     * matter here; the rest are relaxed no-ops.
+     */
+    private val certificateStore = mockk<CertificateStore>(relaxed = true)
+    private var persistedSubdomain: String? = null
+
+    init {
+        coEvery { certificateStore.getSubdomain() } answers { persistedSubdomain }
+    }
+
+    /**
+     * Builds an [OnboardingFlow] whose `execute` persists [subdomainOnRegister]
+     * (when non-null, modelling the register-before-certs ordering) and then
+     * returns [result].
+     */
+    private fun onboardingFlowReturning(
+        result: OnboardingResult,
+        subdomainOnRegister: String?
+    ): OnboardingFlow = mockk {
+        coEvery { execute(any(), any(), any()) } coAnswers {
+            if (subdomainOnRegister != null) {
+                persistedSubdomain = subdomainOnRegister
+            }
+            result
+        }
+    }
+
+    private fun delivery(onboardingFlow: OnboardingFlow, scope: kotlinx.coroutines.CoroutineScope) =
+        UnifiedPushBackgroundDelivery(
+            appContext = ApplicationProvider.getApplicationContext(),
+            onboardingFlow = onboardingFlow,
+            credentialProvider = credentialProvider,
+            certificateStore = certificateStore,
+            registrationStatus = registrationStatus,
+            tunnelClient = tunnelClient,
+            appScope = scope
+        )
+
+    @Test
+    fun `cert failure with persisted subdomain activates wake`() = runTest {
+        // Subdomain persisted, but the chained cert hop rate-limited (#389).
+        val flow = onboardingFlowReturning(
+            result = OnboardingResult.CertRateLimited(
+                retryAfterSeconds = 60,
+                subdomain = "abc.example"
+            ),
+            subdomainOnRegister = "abc.example"
+        )
+        val delivery = delivery(flow, this)
+
+        delivery.onEndpoint("https://push.example/endpoint")
+        advanceUntilIdle()
+
+        // Cert stumbled but the device is registered with a wake target -> Active.
+        assertEquals(DeliveryActivation.Active, delivery.activation.value)
+    }
+
+    @Test
+    fun `cert relay error with persisted subdomain activates wake`() = runTest {
+        val flow = onboardingFlowReturning(
+            result = OnboardingResult.CertRelayError(
+                statusCode = 500,
+                message = "boom",
+                subdomain = "abc.example"
+            ),
+            subdomainOnRegister = "abc.example"
+        )
+        val delivery = delivery(flow, this)
+
+        delivery.onEndpoint("https://push.example/endpoint")
+        advanceUntilIdle()
+
+        assertEquals(DeliveryActivation.Active, delivery.activation.value)
+    }
+
+    @Test
+    fun `pre-subdomain failure leaves wake needing setup`() = runTest {
+        // Registration itself failed -> no subdomain persisted.
+        val flow = onboardingFlowReturning(
+            result = OnboardingResult.RateLimited(retryAfterSeconds = 60),
+            subdomainOnRegister = null
+        )
+        val delivery = delivery(flow, this)
+
+        delivery.onEndpoint("https://push.example/endpoint")
+        advanceUntilIdle()
+
+        assertEquals(DeliveryActivation.NeedsSetup, delivery.activation.value)
+    }
+
+    @Test
+    fun `success activates wake and marks registration complete`() = runTest {
+        val flow = onboardingFlowReturning(
+            result = OnboardingResult.Success(subdomain = "abc.example"),
+            subdomainOnRegister = "abc.example"
+        )
+        val delivery = delivery(flow, this)
+
+        delivery.onEndpoint("https://push.example/endpoint")
+        advanceUntilIdle()
+
+        assertEquals(DeliveryActivation.Active, delivery.activation.value)
+        assertTrue(registrationStatus.complete.value)
+    }
+}


### PR DESCRIPTION
## Problem

On a fresh foss onboard, `UnifiedPushBackgroundDelivery.registerWithEndpoint` latched `DeliveryActivation.NeedsSetup` for ANY non-`Success` result of `OnboardingFlow.execute`. But `execute` registers + persists the subdomain FIRST, then chains ACME cert provisioning (#389). A cert-stage failure (`CertRateLimited` / `CertRelayError` / `CertNetworkError` / `CertKeyGenerationFailed` / `CertStorageFailed`) returns non-`Success` while the device is **already registered with its push endpoint reported**.

Those results hit the `else` branch and wrongly latched `NeedsSetup`, so Home showed "On-demand wake is off / set up a delivery app" even though wake was fully configured and only the cert hop stumbled. (A redo cleared it because the new endpoint routed through `refreshEndpoint`, which sets `Active` unconditionally.) Cert problems are already surfaced + retried independently via the dashboard cert-renewal banner, so they must not flip the delivery banner.

## Fix

Key wake-activation off the persisted subdomain (mirroring the `init` seeding and `refreshEndpoint`) rather than full-flow success:
- `Active` when `certificateStore.getSubdomain() != null` (registered with a wake target),
- `NeedsSetup` only for pre-subdomain failures (no subdomain persisted),
- still `registrationStatus.markComplete()` on `Success`.

foss-only; no change to the cert-renewal banner, ViewModel, or Home.

## Tests

Adds the first direct unit test for `UnifiedPushBackgroundDelivery` (`app/src/testFoss/.../UnifiedPushBackgroundDeliveryTest.kt`):
- `Cert*` failure with a persisted subdomain -> `Active` (red against old code, green now),
- pre-subdomain failure (no subdomain) -> `NeedsSetup`,
- `Success` -> `Active` + `markComplete()`.

## Verification

- `:app:testDebugUnitTest` (foss/default) green
- `:app:compileDebugKotlin -Pgoogle` compiles
- `ktlintCheck` + `detekt` clean

Closes #486