### PR TITLE
Deep-link notification-listener access to our own toggle on API 30+

### DIFF
--- a/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/NotificationSetupDestination.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/NotificationSetupDestination.kt
@@ -1,6 +1,8 @@
 package com.rousecontext.app.ui.navigation.destinations
 
+import android.content.ComponentName
 import android.content.Intent
+import android.os.Build
 import android.provider.Settings
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -21,6 +23,7 @@ import com.rousecontext.app.ui.navigation.Routes
 import com.rousecontext.app.ui.screens.NotificationSetupContent
 import com.rousecontext.app.ui.screens.SetupMode
 import com.rousecontext.app.ui.viewmodels.NotificationSetupViewModel
+import com.rousecontext.integrations.notifications.NotificationCaptureService
 import org.koin.androidx.compose.koinViewModel
 
 @Suppress("LongMethod")
@@ -73,11 +76,26 @@ fun NavGraphBuilder.notificationSetupDestination(navController: NavController) {
             mode = mode,
             isDirty = isDirty,
             onGrantAccess = {
-                val intent = Intent(
-                    Settings
-                        .ACTION_NOTIFICATION_LISTENER_SETTINGS
-                )
-                navController.context.startActivity(intent)
+                val context = navController.context
+                val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    // API 30+: deep-link straight to our listener's own toggle
+                    // instead of the full list of every listener app.
+                    val component = ComponentName(
+                        context,
+                        NotificationCaptureService::class.java
+                    )
+                    Intent(
+                        Settings.ACTION_NOTIFICATION_LISTENER_DETAIL_SETTINGS
+                    ).putExtra(
+                        Settings.EXTRA_NOTIFICATION_LISTENER_COMPONENT_NAME,
+                        component.flattenToString()
+                    )
+                } else {
+                    Intent(
+                        Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS
+                    )
+                }
+                context.startActivity(intent)
             },
             onRetentionChanged = viewModel::setRetentionDays,
             onAllowActionsChanged = viewModel::setAllowActions,

--- a/docs/ux-decisions.md
+++ b/docs/ux-decisions.md
@@ -14,6 +14,34 @@ Newest entries on top.
 
 ---
 
+## 2026-06-16 — Notification-listener access deep-links to our own toggle on API 30+ (#487)
+
+**Decision:** In the notification-capture setup step, "Grant access" now deep-links
+straight to our listener's own enable toggle on API 30+ via
+`ACTION_NOTIFICATION_LISTENER_DETAIL_SETTINGS` +
+`EXTRA_NOTIFICATION_LISTENER_COMPONENT_NAME` (our `NotificationCaptureService`
+`ComponentName`). On API < 30 it falls back to the existing
+`ACTION_NOTIFICATION_LISTENER_SETTINGS` (the full list). minSdk is 24, so the
+fallback is required.
+
+**Approved by:** Jason, in-session 2026-06-16 — greenlit the audit-driven
+permission-UX improvements.
+
+**Context:** The 2026-06-16 permission-UX audit flagged that the old action drops
+the user on the full list of every notification-listener app, where they have to
+hunt for ours. The detail action lands them on our toggle directly.
+
+**Alternatives considered:** Keep the list action everywhere (rejected — extra
+hunting for no benefit on capable devices).
+
+**Trade-off accepted:** None of substance — same onboarding step, same intent
+purpose; only the deep-link target tightens (list → our toggle). Treated as a
+targeting improvement, not a flow change.
+
+**Relevant:** #487.
+
+---
+
 ## 2026-06-16 — FOSS Home battery-optimization warning; "Fix this" becomes the one-tap OS dialog (supersedes 2026-06-02 #453)
 
 **Decision:** Two parts (#483).


### PR DESCRIPTION
## What

For the notification-capture integration, the "Grant access" action opened `ACTION_NOTIFICATION_LISTENER_SETTINGS` — the full list of every notification-listener app, where the user had to find ours.

On **API 30+** this now deep-links straight to our listener's own enable toggle via `ACTION_NOTIFICATION_LISTENER_DETAIL_SETTINGS` + `EXTRA_NOTIFICATION_LISTENER_COMPONENT_NAME` (our `NotificationCaptureService` `ComponentName`). On **API < 30** it falls back to the existing list action (minSdk is 24, so the fallback is required).

The `ComponentName` is built from the `Context` (`ComponentName(context, NotificationCaptureService::class.java)`, matching the existing pattern in `NotificationSetupViewModel`), so it resolves the correct applicationId including the `.debug` suffix on debug builds. No new manifest permission.

## UX

Gray-zone per `.claude/rules/ux-changes.md`: same onboarding step, same intent purpose — only the deep-link target tightens (list -> our toggle). Surfaced in the 2026-06-16 permission-UX audit; recorded in `docs/ux-decisions.md` (newest on top) as a targeting improvement.

## Verification

- `:app:testDebugUnitTest` (foss/default) — green
- `:app:compileDebugKotlin -Pgoogle` — compiles
- `ktlintCheck detekt` — clean

The intent is built inline in the composable lambda; not unit-tested to avoid contorting code around a system intent (verified via compile + reasoning).

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)