### PR TITLE
Re-register distributor after opening it from the #480 nudge

### DIFF
--- a/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/BackgroundDeliveryDestination.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/navigation/destinations/BackgroundDeliveryDestination.kt
@@ -73,12 +73,14 @@ private fun BackgroundDeliveryDestinationContent(
     val pendingIntegration by pendingSetup.pendingId.collectAsState()
 
     // Re-scan installed distributors when the user returns (e.g. after
-    // installing one from the store the "install" rows deep-link to).
+    // installing one from the store the "install" rows deep-link to). #493: also
+    // re-register a selected-but-unacked distributor, in case the user opened it
+    // from the nudge and lingered there past the VM's re-register delay.
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner.lifecycle) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                viewModel.rescan()
+                viewModel.onResume()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -153,6 +155,10 @@ private fun BackgroundDeliveryDestinationContent(
             delivery.launchIntent(distributorNudge.distributorId)?.let { intent ->
                 try {
                     context.startActivity(intent)
+                    // #493: launching alone won't register — the original REGISTER
+                    // was dropped while the distributor was stopped. Re-issue it
+                    // once the distributor has had a moment to come up.
+                    viewModel.onDistributorOpened(distributorNudge.distributorId)
                 } catch (_: ActivityNotFoundException) {
                     // Distributor has no launchable entry; leave the nudge up.
                 }

--- a/app/src/main/java/com/rousecontext/app/ui/viewmodels/BackgroundDeliveryViewModel.kt
+++ b/app/src/main/java/com/rousecontext/app/ui/viewmodels/BackgroundDeliveryViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.rousecontext.app.delivery.BackgroundDelivery
 import com.rousecontext.app.delivery.DistributorOption
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -32,6 +33,15 @@ import kotlinx.coroutines.withTimeoutOrNull
  * clears the stopped state). When the endpoint finally arrives the nudge clears
  * and the picker advances via [proceed]. If the endpoint arrives promptly there
  * is no nudge and the picker advances immediately.
+ *
+ * ## Re-register after opening (issue #493)
+ *
+ * Launching the distributor is not enough on its own: the `REGISTER` from
+ * [select] was already dropped while the distributor was stopped, and UnifiedPush
+ * never redelivers it, so the now-running distributor has nothing to act on. The
+ * nudge's "Open" action therefore re-issues registration shortly after launch
+ * ([onDistributorOpened]), and the destination's `ON_RESUME` ([onResume]) does
+ * the same if the user returns with a selected-but-unacked distributor.
  */
 class BackgroundDeliveryViewModel(private val delivery: BackgroundDelivery) : ViewModel() {
 
@@ -49,10 +59,51 @@ class BackgroundDeliveryViewModel(private val delivery: BackgroundDelivery) : Vi
     val proceed: SharedFlow<Unit> = _proceed.asSharedFlow()
 
     private var selectionJob: Job? = null
+    private var reregisterJob: Job? = null
+
+    /** The last distributor the user selected, awaiting its endpoint (#493). */
+    private var selectedId: String? = null
 
     /** Re-enumerate installed distributors (e.g. after returning from a store). */
     fun rescan() {
         _rows.value = delivery.distributorOptions()
+    }
+
+    /**
+     * Destination `ON_RESUME`: re-scan installed distributors, and — if a
+     * distributor was selected but no endpoint has arrived yet — re-issue its
+     * registration (#493). This is the belt-and-suspenders companion to
+     * [onDistributorOpened] for when the user lingers in the distributor app past
+     * the [onDistributorOpened] delay and only returns later: by then the
+     * distributor has left Android's stopped state, so the re-issued `REGISTER`
+     * is no longer dropped. No-op once the endpoint is in hand.
+     */
+    fun onResume() {
+        rescan()
+        val id = selectedId
+        if (id != null && !delivery.endpointArrived.value) {
+            delivery.selectDistributor(id)
+        }
+    }
+
+    /**
+     * Nudge "Open" tapped (#493): the destination has just launched the chosen
+     * distributor. The original `REGISTER` from [select] was dropped because the
+     * distributor was in Android's stopped state, and UnifiedPush does not
+     * redeliver it — so launching alone never mints an endpoint. Give the
+     * distributor a moment to leave the stopped state, then re-issue registration
+     * via the same path [select] uses (re-selecting the row is the known-good
+     * recovery). The in-flight [selectionJob] is still awaiting the endpoint, so
+     * once it arrives the nudge clears and [proceed] fires. If it still doesn't
+     * arrive the nudge stays up, so the user can retry — it never gets stuck.
+     */
+    fun onDistributorOpened(id: String) {
+        selectedId = id
+        reregisterJob?.cancel()
+        reregisterJob = viewModelScope.launch {
+            delay(REREGISTER_DELAY_MS)
+            delivery.selectDistributor(id)
+        }
     }
 
     /**
@@ -63,6 +114,7 @@ class BackgroundDeliveryViewModel(private val delivery: BackgroundDelivery) : Vi
      */
     fun select(id: String) {
         val name = _rows.value.firstOrNull { it.id == id }?.name ?: id
+        selectedId = id
         delivery.selectDistributor(id)
         rescan()
         selectionJob?.cancel()
@@ -93,6 +145,15 @@ class BackgroundDeliveryViewModel(private val delivery: BackgroundDelivery) : Vi
          * few seconds; past this we assume the stopped-state silent degrade.
          */
         private const val NUDGE_TIMEOUT_MS = 6_000L
+
+        /**
+         * Pause after launching the distributor before re-issuing registration
+         * (#493). Long enough for the just-launched distributor to leave Android's
+         * stopped state and start receiving broadcasts, short enough to feel
+         * immediate. The `ON_RESUME` re-register ([onResume]) covers the case
+         * where the user lingers longer than this.
+         */
+        private const val REREGISTER_DELAY_MS = 1_500L
     }
 }
 

--- a/app/src/test/java/com/rousecontext/app/ui/viewmodels/BackgroundDeliveryViewModelTest.kt
+++ b/app/src/test/java/com/rousecontext/app/ui/viewmodels/BackgroundDeliveryViewModelTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -139,6 +140,78 @@ class BackgroundDeliveryViewModelTest {
     }
 
     @Test
+    fun `opening the distributor re-registers so a dropped REGISTER is re-issued`() =
+        runTest(dispatcher) {
+            val delivery = FakeDelivery()
+            delivery.options = listOf(installed("ntfy", "io.heckel.ntfy"))
+            // The distributor is in Android's stopped state: the first REGISTER is
+            // dropped (no endpoint); only the second one — issued after the user
+            // opens it — mints an endpoint.
+            delivery.deliverEndpointOnSelectCall = 2
+            val vm = BackgroundDeliveryViewModel(delivery)
+            val proceeded = CompletableDeferred<Unit>()
+            val collector = launch { vm.proceed.first().also { proceeded.complete(Unit) } }
+
+            vm.select("io.heckel.ntfy")
+            advanceUntilIdle()
+            // First REGISTER dropped -> nudge shown, no endpoint, no proceed.
+            assertNotNull(vm.nudge.value)
+            assertFalse(proceeded.isCompleted)
+
+            // User taps "Open"; the destination launches the distributor and tells
+            // the VM, which re-issues registration after a short delay.
+            vm.onDistributorOpened("io.heckel.ntfy")
+            advanceUntilIdle()
+
+            assertEquals(2, delivery.selected.size)
+            assertNull(vm.nudge.value)
+            assertTrue(proceeded.isCompleted)
+            collector.cancel()
+        }
+
+    @Test
+    fun `ON_RESUME re-registers a selected distributor that has no endpoint yet`() =
+        runTest(dispatcher) {
+            val delivery = FakeDelivery()
+            delivery.options = listOf(installed("ntfy", "io.heckel.ntfy"))
+            delivery.deliverEndpointOnSelectCall = 2
+            val vm = BackgroundDeliveryViewModel(delivery)
+            val proceeded = CompletableDeferred<Unit>()
+            val collector = launch { vm.proceed.first().also { proceeded.complete(Unit) } }
+
+            vm.select("io.heckel.ntfy")
+            advanceUntilIdle()
+            assertNotNull(vm.nudge.value)
+
+            // User lingered in the distributor app, then returned -> ON_RESUME
+            // re-registers the now-running distributor.
+            vm.onResume()
+            advanceUntilIdle()
+
+            assertEquals(2, delivery.selected.size)
+            assertNull(vm.nudge.value)
+            assertTrue(proceeded.isCompleted)
+            collector.cancel()
+        }
+
+    @Test
+    fun `ON_RESUME does not re-register once the endpoint has arrived`() = runTest(dispatcher) {
+        val delivery = FakeDelivery()
+        delivery.options = listOf(installed("ntfy", "io.heckel.ntfy"))
+        val vm = BackgroundDeliveryViewModel(delivery)
+
+        vm.select("io.heckel.ntfy")
+        delivery.endpoint.value = true
+        advanceUntilIdle()
+        assertEquals(1, delivery.selected.size)
+
+        // Endpoint already in hand: returning to the picker only rescans.
+        vm.onResume()
+        advanceUntilIdle()
+        assertEquals(1, delivery.selected.size)
+    }
+
+    @Test
     fun `dismissNudge hides the nudge`() = runTest(dispatcher) {
         val delivery = FakeDelivery()
         delivery.options = listOf(installed("ntfy", "io.heckel.ntfy"))
@@ -170,6 +243,14 @@ class BackgroundDeliveryViewModelTest {
         var options: List<DistributorOption> = emptyList()
         val selected = mutableListOf<String>()
         val endpoint = MutableStateFlow(false)
+
+        /**
+         * Which `selectDistributor` call delivers an endpoint, mirroring the
+         * stopped-state bug: a value of 2 drops the first REGISTER (stopped
+         * distributor) and only mints the endpoint on the re-register. Default is
+         * "never via select" so tests that flip [endpoint] manually are unaffected.
+         */
+        var deliverEndpointOnSelectCall = Int.MAX_VALUE
         override val isSupported = true
         override val activation: StateFlow<DeliveryActivation> =
             MutableStateFlow(DeliveryActivation.NeedsSetup)
@@ -177,6 +258,9 @@ class BackgroundDeliveryViewModelTest {
         override fun distributorOptions(): List<DistributorOption> = options
         override fun selectDistributor(id: String) {
             selected += id
+            if (selected.size >= deliverEndpointOnSelectCall) {
+                endpoint.value = true
+            }
         }
         override fun installIntent(option: DistributorOption): Intent? = null
         override fun activeDistributorName(): String? = null


### PR DESCRIPTION
Closes #493

## Problem
The #480 "Open {distributor} to enable" nudge appeared and launched the distributor, but never cleared and no endpoint ever arrived. `select()` issues a single UnifiedPush `REGISTER`, which Android drops while the freshly-installed distributor is in its stopped state; UnifiedPush does not redeliver it. The nudge's "Open" action only launched the distributor — it never re-issued `REGISTER` — so the now-running distributor had nothing to act on. `ON_RESUME` only called `rescan()`. Net result: no endpoint, `endpointArrived` never flipped, the nudge stuck forever (only a manual re-select recovered).

## Fix
Re-issue registration once the distributor has come up, reusing the known-good `selectDistributor` path (manual re-select already worked):

- `BackgroundDeliveryViewModel.onDistributorOpened(id)` — launched by the nudge's "Open" action after the destination starts the distributor. Waits a short, cancellable `~1.5s` (`REREGISTER_DELAY_MS`) for the distributor to leave the stopped state, then re-registers. Runs in `viewModelScope`; a `reregisterJob` is cancelled/replaced on repeat taps. The in-flight `selectionJob` is still awaiting `endpointArrived`, so when the endpoint arrives the nudge clears and `proceed` fires.
- `BackgroundDeliveryViewModel.onResume()` — destination `ON_RESUME` now calls this (was `rescan()`). Re-scans and, if a distributor was selected but no endpoint has arrived yet, re-registers — belt-and-suspenders for users who linger in the distributor app past the delay. No-op once the endpoint is in hand.
- Nudge remains a non-permanent fallback: if the endpoint still doesn't arrive, the nudge stays up so the user can retry; it never gets stuck.

No new interface surface — both paths reuse `BackgroundDelivery.selectDistributor`, which is exactly what manual re-selection does.

## Tests
Extended `BackgroundDeliveryViewModelTest` with a fake whose `selectDistributor` only delivers an endpoint on the **second** call (simulating the dropped-while-stopped first REGISTER):
- `opening the distributor re-registers so a dropped REGISTER is re-issued` — nudge shown after first (dropped) register; `onDistributorOpened` re-registers, endpoint arrives, nudge clears, `proceed` fires.
- `ON_RESUME re-registers a selected distributor that has no endpoint yet` — same via `onResume()`.
- `ON_RESUME does not re-register once the endpoint has arrived` — guard verified (no extra register).

Both new "re-register" tests fail against the pre-fix code (nudge never clears) and pass after.

## Verification
- `:app:testDebugUnitTest` (foss/default) green
- `:app:compileDebugKotlin -Pgoogle` compiles
- `ktlintCheck detekt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)