### PR TITLE
relay: drop stale InMemoryFirestore TODO

### DIFF
--- a/relay/src/main.rs
+++ b/relay/src/main.rs
@@ -811,7 +811,8 @@ fn build_firestore_client(
 
 /// In-memory Firestore implementation for development/testing.
 /// Persists data for the relay's lifetime but not across restarts.
-/// TODO: Replace with RealFirestoreClient backed by Firestore REST API.
+/// Deliberate fallback when no service account is configured; the default is
+/// `RealFirestoreClient` (see `build_firestore_client`).
 struct InMemoryFirestore {
     devices:
         std::sync::Mutex<std::collections::HashMap<String, rouse_relay::firestore::DeviceRecord>>,


### PR DESCRIPTION
Removes the stale `TODO: Replace with RealFirestoreClient` on `InMemoryFirestore`. That client already exists and is the default when a service account is configured; `InMemoryFirestore` is the deliberate no-service-account fallback. Comment-only/hygiene change, no behavior change.

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)