### PR TITLE
Wire real CertInspector and reach the CN-mismatch path (#495)

### DIFF
--- a/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/CertRenewalFlow.kt
+++ b/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/CertRenewalFlow.kt
@@ -1,5 +1,10 @@
 package com.rousecontext.tunnel
 
+import java.io.ByteArrayInputStream
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.time.Instant
+import javax.naming.ldap.LdapName
 import kotlinx.coroutines.delay
 
 /**
@@ -145,6 +150,9 @@ class CertRenewalFlow(
     ): RenewalResult {
         val subdomain = certificateStore.getSubdomain()
             ?: return RenewalResult.NoCertificate
+        // The current (typically expired) cert still carries a valid subject CN, so pass it
+        // into validation: the CN-mismatch safety net must fire on the expired-cert path too.
+        val currentCert = certificateStore.getCertificate()
 
         val csrResult = try {
             val keyPair = deviceKeyManager.getOrCreateKeyPair()
@@ -163,7 +171,7 @@ class CertRenewalFlow(
                 firebaseToken = credentials.token,
                 signature = credentials.signature
             )
-            handleRenewResponse(result, null)
+            handleRenewResponse(result, currentCert)
         }
     }
 
@@ -183,6 +191,9 @@ class CertRenewalFlow(
     ): RenewalResult {
         val subdomain = certificateStore.getSubdomain()
             ?: return RenewalResult.NoCertificate
+        // The current (expired) cert still carries a valid subject CN; pass it into validation
+        // so the CN-mismatch safety net runs on both the keypair and Firebase fallback branches.
+        val currentCert = certificateStore.getCertificate()
 
         val csrResult = try {
             val keyPair = deviceKeyManager.getOrCreateKeyPair()
@@ -199,7 +210,7 @@ class CertRenewalFlow(
                     csrSignature = keypair.csrSignature,
                     proof = keypair.proof
                 )
-                handleRenewResponse(result, null)
+                handleRenewResponse(result, currentCert)
             }
         }
 
@@ -213,7 +224,7 @@ class CertRenewalFlow(
                 firebaseToken = credentials.token,
                 signature = credentials.signature
             )
-            handleRenewResponse(result, null)
+            handleRenewResponse(result, currentCert)
         }
     }
 
@@ -309,10 +320,34 @@ sealed class RenewalResult {
 }
 
 /**
- * Inspects PEM certificate properties. Expect/actual or injectable for testing.
+ * Inspects PEM certificate properties (subject CN and expiry). `open` so tests can inject
+ * deterministic fakes.
+ *
+ * The default implementation parses the PEM with [CertificateFactory] into an
+ * [X509Certificate]. A malformed or unparseable input degrades safely to an empty [CertInfo]
+ * (null CN, not expired) rather than throwing inside the renewal flow — a parse failure must
+ * not abort a renewal nor be mistaken for an expiry/CN-mismatch signal.
  */
 open class CertInspector {
-    open fun inspect(pemCertificate: String): CertInfo = CertInfo()
+    open fun inspect(pemCertificate: String): CertInfo = try {
+        val cert = CertificateFactory.getInstance("X.509")
+            .generateCertificate(
+                ByteArrayInputStream(pemCertificate.toByteArray(Charsets.UTF_8))
+            ) as X509Certificate
+        CertInfo(
+            commonName = extractCommonName(cert),
+            isExpired = cert.notAfter.toInstant().isBefore(Instant.now())
+        )
+    } catch (_: Exception) {
+        CertInfo()
+    }
+
+    private fun extractCommonName(cert: X509Certificate): String? = runCatching {
+        LdapName(cert.subjectX500Principal.name).rdns
+            .firstOrNull { it.type.equals("CN", ignoreCase = true) }
+            ?.value
+            ?.toString()
+    }.getOrNull()
 }
 
 data class CertInfo(val commonName: String? = null, val isExpired: Boolean = false)

--- a/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/CertRenewalFlow.kt
+++ b/core/tunnel/src/jvmMain/kotlin/com/rousecontext/tunnel/CertRenewalFlow.kt
@@ -4,7 +4,6 @@ import java.io.ByteArrayInputStream
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 import java.time.Instant
-import javax.naming.ldap.LdapName
 import kotlinx.coroutines.delay
 
 /**
@@ -342,12 +341,59 @@ open class CertInspector {
         CertInfo()
     }
 
-    private fun extractCommonName(cert: X509Certificate): String? = runCatching {
-        LdapName(cert.subjectX500Principal.name).rdns
-            .firstOrNull { it.type.equals("CN", ignoreCase = true) }
-            ?.value
-            ?.toString()
-    }.getOrNull()
+    /**
+     * Extract the subject CN without JNDI. `javax.naming.ldap.LdapName` is part of JNDI, which is
+     * **absent from the Android runtime** — using it throws [NoClassDefFoundError] on-device, which
+     * a swallowing `runCatching` would silently turn into a permanently-null CN (issue #499). So we
+     * parse [java.security.cert.X509Certificate.getSubjectX500Principal]'s RFC 2253 string directly.
+     *
+     * The RFC 2253 form looks like `CN=test123.rousecontext.com,O=Example,C=US`: comma-separated
+     * RDNs. We split on unescaped commas (`\,` is an RFC 2253 escape) and return the value of the
+     * first `CN=` component. Returns `null` when no CN is present. Our certs only ever carry
+     * `CN=*.<subdomain>.rousecontext.com`, so escaped commas never occur, but we honour the escape
+     * anyway since it's cheap.
+     */
+    private fun extractCommonName(cert: X509Certificate): String? {
+        val subject = cert.subjectX500Principal.name
+        return splitRfc2253(subject)
+            .map { it.trim() }
+            .firstOrNull {
+                it.length > CN_PREFIX_LEN &&
+                    it.regionMatches(0, "CN=", 0, CN_PREFIX_LEN, ignoreCase = true)
+            }
+            ?.substring(CN_PREFIX_LEN)
+            ?.trim()
+    }
+
+    /** Splits an RFC 2253 distinguished name on commas that are not backslash-escaped. */
+    private fun splitRfc2253(dn: String): List<String> {
+        val parts = mutableListOf<String>()
+        val current = StringBuilder()
+        var escaped = false
+        for (ch in dn) {
+            when {
+                escaped -> {
+                    current.append(ch)
+                    escaped = false
+                }
+                ch == '\\' -> {
+                    current.append(ch)
+                    escaped = true
+                }
+                ch == ',' -> {
+                    parts.add(current.toString())
+                    current.setLength(0)
+                }
+                else -> current.append(ch)
+            }
+        }
+        parts.add(current.toString())
+        return parts
+    }
+
+    private companion object {
+        const val CN_PREFIX_LEN = 3 // length of "CN="
+    }
 }
 
 data class CertInfo(val commonName: String? = null, val isExpired: Boolean = false)

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/CertRenewalTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/CertRenewalTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -284,6 +285,87 @@ class CertRenewalTest {
         assertEquals("other-cn", result.actual)
     }
 
+    // --- Real (production) CertInspector tests (issue #495) ---
+
+    @Test
+    fun `real CertInspector parses CN and reports non-expired`() {
+        val info = CertInspector().inspect(REAL_CERT_TEST123)
+        assertEquals("test123.rousecontext.com", info.commonName)
+        assertFalse(info.isExpired, "fixture cert is valid until 2036")
+    }
+
+    @Test
+    fun `real CertInspector flags an expired cert`() {
+        val info = CertInspector().inspect(REAL_CERT_EXPIRED)
+        assertEquals("test123.rousecontext.com", info.commonName)
+        assertTrue(info.isExpired, "fixture cert expired in 2021")
+    }
+
+    @Test
+    fun `real CertInspector degrades to empty CertInfo on a malformed cert`() {
+        val info = CertInspector().inspect("not a real certificate")
+        assertNull(info.commonName)
+        assertFalse(info.isExpired)
+    }
+
+    @Test
+    fun `mTLS CN mismatch fires end-to-end with the real inspector`(): Unit = runBlocking {
+        store.storeCertificate(REAL_CERT_TEST123)
+        store.storeSubdomain("test123")
+        val flow = createFlow(inspector = CertInspector())
+
+        mockServer.renewHandler = { _ ->
+            MockRenewResponse(
+                status = 200,
+                body = RenewResponse(
+                    serverCert = REAL_CERT_OTHER,
+                    clientCert = MockRelayServer.MOCK_CLIENT_CERT_PEM,
+                    relayCaCert = MockRelayServer.MOCK_RELAY_CA_PEM
+                )
+            )
+        }
+
+        val result = flow.renewWithMtls(signature = "sig")
+        assertTrue(result is RenewalResult.CnMismatch, "expected CnMismatch, got $result")
+        assertEquals("test123.rousecontext.com", result.expected)
+        assertEquals("other-cn.rousecontext.com", result.actual)
+    }
+
+    @Test
+    fun `Firebase path CN mismatch fires end-to-end with the real inspector`(): Unit = runBlocking {
+        // Guards the firebase-path wiring: the current cert must be passed into
+        // handleRenewResponse so the CN-mismatch safety net runs on this path too.
+        store.storeCertificate(REAL_CERT_TEST123)
+        store.storeSubdomain("test123")
+        val flow = createFlow(inspector = CertInspector())
+
+        mockServer.renewHandler = { _ ->
+            MockRenewResponse(
+                status = 200,
+                body = RenewResponse(
+                    serverCert = REAL_CERT_OTHER,
+                    clientCert = MockRelayServer.MOCK_CLIENT_CERT_PEM,
+                    relayCaCert = MockRelayServer.MOCK_RELAY_CA_PEM
+                )
+            )
+        }
+
+        val result = flow.renewWithFirebase(firebaseToken = "t", signature = "s")
+        assertTrue(result is RenewalResult.CnMismatch, "expected CnMismatch, got $result")
+        assertEquals("test123.rousecontext.com", result.expected)
+        assertEquals("other-cn.rousecontext.com", result.actual)
+    }
+
+    @Test
+    fun `expired current cert returns CertExpired with the real inspector`(): Unit = runBlocking {
+        store.storeCertificate(REAL_CERT_EXPIRED)
+        store.storeSubdomain("test123")
+        val flow = createFlow(inspector = CertInspector())
+
+        val result = flow.renewWithMtls(signature = "unused")
+        assertTrue(result is RenewalResult.CertExpired, "expected CertExpired, got $result")
+    }
+
     @Test
     fun `rate limited schedules retry`(): Unit = runBlocking {
         store.storeCertificate(MockRelayServer.MOCK_CERT_PEM)
@@ -418,5 +500,49 @@ class CertRenewalTest {
 
     private companion object {
         val lenientJson = Json { ignoreUnknownKeys = true }
+
+        // Real self-signed ECDSA P-256 certs (openssl) used to exercise the production
+        // CertInspector. Unlike the hand-built MockRelayServer PEMs, these parse via
+        // CertificateFactory so CN + expiry extraction is real (issue #495).
+
+        // CN=test123.rousecontext.com, valid until 2036-06-15.
+        const val REAL_CERT_TEST123 = """-----BEGIN CERTIFICATE-----
+MIIBmzCCAUGgAwIBAgIUMZZKurrSJOfzTdyw1djx+MBhlhMwCgYIKoZIzj0EAwIw
+IzEhMB8GA1UEAwwYdGVzdDEyMy5yb3VzZWNvbnRleHQuY29tMB4XDTI2MDYxODE5
+NTgwOFoXDTM2MDYxNTE5NTgwOFowIzEhMB8GA1UEAwwYdGVzdDEyMy5yb3VzZWNv
+bnRleHQuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAErYaEDbL/A/2zsnJD
+arWcJJPqvV6KZdqn+7Vj4UkgJihvNzUJ9CzfKevOg2+fc+5rvTUV+8MP7mVJiCW9
+gg1lvaNTMFEwHQYDVR0OBBYEFAhAgnv2Gl1r5H1Rg4spGlmmrLrEMB8GA1UdIwQY
+MBaAFAhAgnv2Gl1r5H1Rg4spGlmmrLrEMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZI
+zj0EAwIDSAAwRQIgALN5eRW0AqhfU/Qrk9UiYFxfGBY7pO6bis/aC/32By8CIQDj
+AgNLz8OO6pAjGBI6UOCPjMVrHxqo7nwHj+dSw0BT6A==
+-----END CERTIFICATE-----"""
+
+        // CN=other-cn.rousecontext.com, valid until 2036-06-15. Different subject CN
+        // than REAL_CERT_TEST123 to trigger the CN-mismatch safety net.
+        const val REAL_CERT_OTHER = """-----BEGIN CERTIFICATE-----
+MIIBnTCCAUOgAwIBAgIUO51XPyr4cBUmtS/NUQfLFQDXQZkwCgYIKoZIzj0EAwIw
+JDEiMCAGA1UEAwwZb3RoZXItY24ucm91c2Vjb250ZXh0LmNvbTAeFw0yNjA2MTgx
+OTU4MDhaFw0zNjA2MTUxOTU4MDhaMCQxIjAgBgNVBAMMGW90aGVyLWNuLnJvdXNl
+Y29udGV4dC5jb20wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATXmnFgOPwXF6Ds
+4JkhLZWQG5nxWh4ZFac48uS6lIGdSkPGJX9geC/yKUsAeH55KdzrHnu7IvMDUfqh
+BwIwTFbPo1MwUTAdBgNVHQ4EFgQUQtRk1OzPkFDxyKTjlWr1sEwQigQwHwYDVR0j
+BBgwFoAUQtRk1OzPkFDxyKTjlWr1sEwQigQwDwYDVR0TAQH/BAUwAwEB/zAKBggq
+hkjOPQQDAgNIADBFAiBeH3eUvuWUIxNH1wk3OFRGFfmudXSn7MMQfrHwYVh67QIh
+ALRZfL7MdyG1WYqTbWCLCfJrm4+Bfp0mebM5afDJo2uB
+-----END CERTIFICATE-----"""
+
+        // CN=test123.rousecontext.com, expired (2020-01-01 .. 2021-01-01).
+        const val REAL_CERT_EXPIRED = """-----BEGIN CERTIFICATE-----
+MIIBmzCCAUGgAwIBAgIUCj2Eei46jccndtKjced6sLBEHr0wCgYIKoZIzj0EAwIw
+IzEhMB8GA1UEAwwYdGVzdDEyMy5yb3VzZWNvbnRleHQuY29tMB4XDTIwMDEwMTAw
+MDAwMFoXDTIxMDEwMTAwMDAwMFowIzEhMB8GA1UEAwwYdGVzdDEyMy5yb3VzZWNv
+bnRleHQuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEy95XyDTAqJXo3swZ
+CgEoipmVqx4LmxQpHdWtfsKOtAe6tVXZukwjC/1JKMAC7OiWRPkp3X2GZiWCAkft
+RGvL+6NTMFEwHQYDVR0OBBYEFIgBC5XzzINobe/UBwXJTZ3SVmu3MB8GA1UdIwQY
+MBaAFIgBC5XzzINobe/UBwXJTZ3SVmu3MA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZI
+zj0EAwIDSAAwRQIhANcXWPuTCGFPopswAwEH6Ts7kHkl17QuUuu71Cz6wrz0AiAw
+0DZ+vyzoHioE5Rmi23+PUoNGu6o7dUvuym03n7FEQg==
+-----END CERTIFICATE-----"""
     }
 }

--- a/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/CertRenewalTest.kt
+++ b/core/tunnel/src/jvmTest/kotlin/com/rousecontext/tunnel/CertRenewalTest.kt
@@ -295,6 +295,21 @@ class CertRenewalTest {
     }
 
     @Test
+    fun `real CertInspector extracts CN via the JNDI-free X500Principal path`() {
+        // Guards issue #499: CN extraction must parse the X500Principal RFC 2253 string directly,
+        // not via javax.naming.ldap.LdapName (JNDI is absent from the Android runtime). Both
+        // fixtures must yield their real subject CN through CertificateFactory + the new parser.
+        assertEquals(
+            "test123.rousecontext.com",
+            CertInspector().inspect(REAL_CERT_TEST123).commonName
+        )
+        assertEquals(
+            "other-cn.rousecontext.com",
+            CertInspector().inspect(REAL_CERT_OTHER).commonName
+        )
+    }
+
+    @Test
     fun `real CertInspector flags an expired cert`() {
         val info = CertInspector().inspect(REAL_CERT_EXPIRED)
         assertEquals("test123.rousecontext.com", info.commonName)


### PR DESCRIPTION
Closes #495

## What
The certificate-renewal CN-mismatch safety net and the expiry guard in `CertRenewalFlow` were both inert in production:
- `CertInspector` was a no-op `open class` stub returning an empty `CertInfo()`, so `isExpired` was always `false` and the old-vs-new CN comparison was always `null == null`.
- As a result the whole downstream banner chain (`RenewalResult.CnMismatch` -> `CertRenewalWorker.handleCnMismatch` -> `CertRenewalBannerFlow` -> dashboard banner) could never fire, even though it is fully built and tested.

## Changes
1. **Real `CertInspector.inspect(pem)`** — parses the PEM with `CertificateFactory` into an `X509Certificate`, populating `commonName` (subject CN via `LdapName`) and `isExpired` (`notAfter < now`). The class stays `open` so existing test fakes still override it. A malformed/unparseable cert degrades safely to an empty `CertInfo()` rather than throwing inside the renewal flow.
2. **CN-mismatch path made reachable on every renewal path** — `renewWithFirebase` and `renewExpired` (keypair + Firebase fallback branches) now pass the current stored cert into `handleRenewResponse` instead of `null`. The mTLS path already passed it. The expired current cert still carries a valid subject CN, so the comparison is meaningful there too.

No production wiring change at the injection site is needed: `AppModule` already constructs `CertRenewalFlow` with the default `CertInspector`, which is now real.

## Tests
Extended `CertRenewalTest` with real openssl-generated self-signed fixtures (so CN + expiry extraction runs against the production code path):
- real `CertInspector` parses CN + reports non-expired for a valid cert
- real `CertInspector` flags an expired cert
- real `CertInspector` degrades to empty `CertInfo` on malformed input
- mTLS CN-mismatch fires end-to-end with the real inspector
- Firebase-path CN-mismatch fires end-to-end (guards the new currentCert wiring)
- expired current cert returns `CertExpired` with the real inspector

All 5 were red before the implementation and green after. Existing tests (including the override-based CN-mismatch test) are unchanged.

## Verification
- `:core:tunnel:jvmTest` green
- `:app:testDebugUnitTest` (foss/default) green
- `:app:compileDebugKotlin -Pgoogle` compiles
- `:core:tunnel:ktlintCheck` + whole-tree `detekt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)