### PR TITLE
Unify MCP period parsing on local zone + sliding-from-start-of-today

### DIFF
--- a/integrations/src/main/java/com/rousecontext/integrations/health/HealthConnectMcpServer.kt
+++ b/integrations/src/main/java/com/rousecontext/integrations/health/HealthConnectMcpServer.kt
@@ -1,11 +1,11 @@
 package com.rousecontext.integrations.health
 
+import com.rousecontext.integrations.common.PeriodParser
 import com.rousecontext.mcp.core.McpServerProvider
 import com.rousecontext.mcp.tool.McpTool
 import com.rousecontext.mcp.tool.ToolResult
 import com.rousecontext.mcp.tool.registerTool
 import io.modelcontextprotocol.kotlin.sdk.server.Server
-import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
@@ -39,9 +39,6 @@ class HealthConnectMcpServer(private val repository: HealthConnectRepository) : 
     }
 
     companion object {
-        internal const val DAYS_IN_WEEK = 7L
-        internal const val DAYS_IN_MONTH = 30L
-
         /**
          * Parses an ISO 8601 datetime or date-only string to [Instant].
          * Returns null if parsing fails.
@@ -135,20 +132,17 @@ internal class GetHealthSummaryTool(private val repository: HealthConnectReposit
     override val name = "get_health_summary"
     override val description = "Health summary across permitted types for a period."
 
-    val period by stringParam("period", "today|week|month")
+    val period by stringParam("period", PeriodParser.PERIOD_DESCRIPTION)
 
     override suspend fun execute(): ToolResult {
-        val now = Instant.now()
-        val from = when (period) {
-            "today" -> LocalDate.now().atStartOfDay().toInstant(ZoneOffset.UTC)
-            "week" -> now.minus(Duration.ofDays(HealthConnectMcpServer.DAYS_IN_WEEK))
-            "month" -> now.minus(Duration.ofDays(HealthConnectMcpServer.DAYS_IN_MONTH))
-            else -> return ToolResult.Error(
+        // Delegate to the shared parser so all MCP providers agree on zone
+        // (local) and anchoring (sliding window from the start of today).
+        val range = PeriodParser.parse(period!!)
+            ?: return ToolResult.Error(
                 "Invalid period: $period. Must be today, week, or month."
             )
-        }
 
-        val summary = repository.getSummary(from, now)
+        val summary = repository.getSummary(range.start, range.end)
         return ToolResult.Success(Json.encodeToString(summary))
     }
 }

--- a/integrations/src/main/java/com/rousecontext/integrations/notifications/NotificationMcpProvider.kt
+++ b/integrations/src/main/java/com/rousecontext/integrations/notifications/NotificationMcpProvider.kt
@@ -1,6 +1,7 @@
 package com.rousecontext.integrations.notifications
 
 import android.service.notification.StatusBarNotification
+import com.rousecontext.integrations.common.PeriodParser
 import com.rousecontext.mcp.core.McpServerProvider
 import com.rousecontext.mcp.tool.McpTool
 import com.rousecontext.mcp.tool.ToolResult
@@ -10,7 +11,6 @@ import io.modelcontextprotocol.kotlin.sdk.server.Server
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
-import java.time.temporal.ChronoUnit
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
@@ -221,7 +221,10 @@ internal class GetNotificationStatsTool(private val dao: NotificationDao) : McpT
     override val name = "get_notification_stats"
     override val description = "Notification counts, top apps, and busiest hour for a period."
 
-    val period by stringParam("period", "today|week|month, default today").optional()
+    val period by stringParam(
+        "period",
+        PeriodParser.PERIOD_DESCRIPTION + " (default today)"
+    ).optional()
 
     override suspend fun execute(): ToolResult {
         val periodStr = period ?: "today"
@@ -317,14 +320,9 @@ private fun parseIsoToMillis(iso: String): Long = try {
 }
 
 private fun periodToRange(period: String): Pair<Long, Long> {
-    val now = Instant.now()
-    val zone = ZoneId.systemDefault()
-    val todayStart = LocalDate.now(zone).atStartOfDay(zone).toInstant()
-    val since = when (period) {
-        "today" -> todayStart
-        "week" -> todayStart.minus(7, ChronoUnit.DAYS)
-        "month" -> todayStart.minus(30, ChronoUnit.DAYS)
-        else -> todayStart
-    }
-    return since.toEpochMilli() to now.toEpochMilli()
+    // Delegate to the shared parser so all MCP providers agree on zone (local)
+    // and anchoring (sliding window from the start of today). Unknown values
+    // fall back to "today" (preserves prior behaviour).
+    val range = PeriodParser.parse(period) ?: PeriodParser.parse("today")!!
+    return range.startMillis to range.endMillis
 }

--- a/integrations/src/main/kotlin/com/rousecontext/integrations/common/PeriodParser.kt
+++ b/integrations/src/main/kotlin/com/rousecontext/integrations/common/PeriodParser.kt
@@ -1,0 +1,66 @@
+package com.rousecontext.integrations.common
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+/**
+ * A resolved time range for a `period` argument: `[start, end]`.
+ *
+ * Shared shape across MCP providers. Health Connect consumes [Instant]s
+ * directly; Usage and Notification providers use [startMillis] / [endMillis].
+ */
+data class PeriodRange(val start: Instant, val end: Instant) {
+    val startMillis: Long get() = start.toEpochMilli()
+    val endMillis: Long get() = end.toEpochMilli()
+}
+
+/**
+ * Single source of truth for parsing the `period` argument shared by the
+ * usage, notification, and Health Connect MCP providers.
+ *
+ * Semantics (see issue #496):
+ * - **Zone:** local ([ZoneId.systemDefault]) by default.
+ * - **Anchoring:** a sliding window ending at `now`, anchored to the start of
+ *   today in the given zone:
+ *     - `today` = `[start-of-today, now]`
+ *     - `week`  = `[start-of-today - 7 days, now]`
+ *     - `month` = `[start-of-today - 30 days, now]`
+ *
+ * `yesterday` is intentionally NOT handled here — it is a usage-only extra and
+ * is resolved at that call site before delegating.
+ */
+object PeriodParser {
+
+    const val WEEK_DAYS = 7L
+    const val MONTH_DAYS = 30L
+
+    /**
+     * Human-readable description of the unified semantics, suitable for MCP
+     * tool param docs so calling agents know the zone and anchoring.
+     */
+    const val PERIOD_DESCRIPTION =
+        "today|week|month - local time; week/month = last 7/30 days from the start of today"
+
+    /**
+     * Resolve [period] into a [PeriodRange], or null if unrecognised.
+     *
+     * @param zone the zone whose start-of-today anchors the window (default local).
+     * @param now the upper bound of the range (default [Instant.now]); the same
+     *   instant also determines which local date counts as "today".
+     */
+    fun parse(
+        period: String,
+        zone: ZoneId = ZoneId.systemDefault(),
+        now: Instant = Instant.now()
+    ): PeriodRange? {
+        val startOfToday = now.atZone(zone).toLocalDate().atStartOfDay(zone).toInstant()
+        val start = when (period) {
+            "today" -> startOfToday
+            "week" -> startOfToday.minus(WEEK_DAYS, ChronoUnit.DAYS)
+            "month" -> startOfToday.minus(MONTH_DAYS, ChronoUnit.DAYS)
+            else -> return null
+        }
+        return PeriodRange(start, now)
+    }
+}

--- a/integrations/src/main/kotlin/com/rousecontext/integrations/common/PeriodParser.kt
+++ b/integrations/src/main/kotlin/com/rousecontext/integrations/common/PeriodParser.kt
@@ -2,7 +2,6 @@ package com.rousecontext.integrations.common
 
 import java.time.Instant
 import java.time.ZoneId
-import java.time.temporal.ChronoUnit
 
 /**
  * A resolved time range for a `period` argument: `[start, end]`.
@@ -54,11 +53,12 @@ object PeriodParser {
         zone: ZoneId = ZoneId.systemDefault(),
         now: Instant = Instant.now()
     ): PeriodRange? {
-        val startOfToday = now.atZone(zone).toLocalDate().atStartOfDay(zone).toInstant()
+        val today = now.atZone(zone).toLocalDate()
+        val startOfToday = today.atStartOfDay(zone).toInstant()
         val start = when (period) {
             "today" -> startOfToday
-            "week" -> startOfToday.minus(WEEK_DAYS, ChronoUnit.DAYS)
-            "month" -> startOfToday.minus(MONTH_DAYS, ChronoUnit.DAYS)
+            "week" -> today.minusDays(WEEK_DAYS).atStartOfDay(zone).toInstant()
+            "month" -> today.minusDays(MONTH_DAYS).atStartOfDay(zone).toInstant()
             else -> return null
         }
         return PeriodRange(start, now)

--- a/integrations/src/main/kotlin/com/rousecontext/integrations/usage/UsageMcpProvider.kt
+++ b/integrations/src/main/kotlin/com/rousecontext/integrations/usage/UsageMcpProvider.kt
@@ -12,10 +12,8 @@ import com.rousecontext.mcp.tool.ToolResult
 import com.rousecontext.mcp.tool.registerTool
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import java.time.Instant
-import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
 import java.util.Calendar
 import java.util.TimeZone
 import kotlinx.serialization.encodeToString
@@ -370,14 +368,22 @@ internal fun usageError(message: String): ToolResult =
  * the start of today). `yesterday` is a usage-only extra resolved here: the
  * prior calendar day, `[start-of-yesterday, start-of-today]`.
  */
-internal fun parsePeriod(period: String): Pair<Long, Long>? {
+internal fun parsePeriod(
+    period: String,
+    zone: ZoneId = ZoneId.systemDefault(),
+    now: Instant = Instant.now()
+): Pair<Long, Long>? {
     if (period == "yesterday") {
-        val zone = ZoneId.systemDefault()
-        val startOfToday = LocalDate.now(zone).atStartOfDay(zone).toInstant()
-        val startOfYesterday = startOfToday.minus(1, ChronoUnit.DAYS)
+        // Stay in LocalDate arithmetic so the zone handles DST: the window is
+        // local-midnight to local-midnight, which is 23h on spring-forward days
+        // and 25h on fall-back days. Subtracting a flat 86_400s off an Instant
+        // would ignore DST and land an hour off (see #500 review).
+        val today = now.atZone(zone).toLocalDate()
+        val startOfYesterday = today.minusDays(1).atStartOfDay(zone).toInstant()
+        val startOfToday = today.atStartOfDay(zone).toInstant()
         return startOfYesterday.toEpochMilli() to startOfToday.toEpochMilli()
     }
-    return PeriodParser.parse(period)?.let { it.startMillis to it.endMillis }
+    return PeriodParser.parse(period, zone, now)?.let { it.startMillis to it.endMillis }
 }
 
 // ---------- Event type mapping ----------

--- a/integrations/src/main/kotlin/com/rousecontext/integrations/usage/UsageMcpProvider.kt
+++ b/integrations/src/main/kotlin/com/rousecontext/integrations/usage/UsageMcpProvider.kt
@@ -5,14 +5,17 @@ import android.app.usage.UsageStats
 import android.app.usage.UsageStatsManager
 import android.content.Context
 import android.content.pm.PackageManager
+import com.rousecontext.integrations.common.PeriodParser
 import com.rousecontext.mcp.core.McpServerProvider
 import com.rousecontext.mcp.tool.McpTool
 import com.rousecontext.mcp.tool.ToolResult
 import com.rousecontext.mcp.tool.registerTool
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import java.util.Calendar
 import java.util.TimeZone
 import kotlinx.serialization.encodeToString
@@ -42,6 +45,15 @@ class UsageMcpProvider(private val context: Context) : McpServerProvider {
         internal const val MS_PER_MIN = 60_000L
 
         /**
+         * Shared `period` description with the usage-only `yesterday` extra.
+         * Documents the unified semantics (see [PeriodParser]) so calling
+         * agents know the zone and anchoring.
+         */
+        internal const val PERIOD_DESCRIPTION =
+            "today|yesterday|week|month - local time; week/month = last 7/30 days " +
+                "from the start of today; yesterday = the prior calendar day"
+
+        /**
          * Packages filtered out by default from usage events to reduce noise.
          * Includes Rouse Context itself and Android system intelligence services.
          */
@@ -68,7 +80,7 @@ internal class GetUsageSummaryTool(private val context: Context) : McpTool() {
     override val name = "get_usage_summary"
     override val description = "Screen time totals and top apps for a period."
 
-    val period by stringParam("period", "today|yesterday|week|month")
+    val period by stringParam("period", UsageMcpProvider.PERIOD_DESCRIPTION)
     val limit by intParam("limit", "Max apps (default 10)").optional()
 
     override suspend fun execute(): ToolResult {
@@ -110,7 +122,7 @@ internal class GetAppUsageTool(private val context: Context) : McpTool() {
     override val description = "Per-day usage for one app."
 
     val packageName by stringParam("package_name", "")
-    val period by stringParam("period", "today|yesterday|week|month")
+    val period by stringParam("period", UsageMcpProvider.PERIOD_DESCRIPTION)
 
     override suspend fun execute(): ToolResult {
         val pkg = packageName!!
@@ -148,8 +160,8 @@ internal class GetUsageEventsTool(private val context: Context) : McpTool() {
     override val name = "get_usage_events"
     override val description = "Raw app foreground/background events over a range."
 
-    val since by stringParam("since", "today|yesterday|week|month")
-    val until by stringParam("until", "today|yesterday|week|month")
+    val since by stringParam("since", "Range start - " + UsageMcpProvider.PERIOD_DESCRIPTION)
+    val until by stringParam("until", "Range end - " + UsageMcpProvider.PERIOD_DESCRIPTION)
     val packageFilter by stringParam("package", "").optional()
     val includeSystem by boolParam(
         "include_system",
@@ -183,8 +195,8 @@ internal class CompareUsageTool(private val context: Context) : McpTool() {
     override val name = "compare_usage"
     override val description = "Compare screen time between two periods; biggest deltas first."
 
-    val period1 by stringParam("period1", "today|yesterday|week|month")
-    val period2 by stringParam("period2", "today|yesterday|week|month")
+    val period1 by stringParam("period1", UsageMcpProvider.PERIOD_DESCRIPTION)
+    val period2 by stringParam("period2", UsageMcpProvider.PERIOD_DESCRIPTION)
     val limit by intParam("limit", "Max apps (default 10)").optional()
 
     override suspend fun execute(): ToolResult {
@@ -352,38 +364,20 @@ internal fun usageError(message: String): ToolResult =
 /**
  * Parse a period string into a start/end epoch millis pair.
  * Returns null for unrecognised values.
+ *
+ * `today`, `week`, and `month` delegate to the shared [PeriodParser] so all
+ * three MCP providers agree on zone (local) and anchoring (sliding window from
+ * the start of today). `yesterday` is a usage-only extra resolved here: the
+ * prior calendar day, `[start-of-yesterday, start-of-today]`.
  */
 internal fun parsePeriod(period: String): Pair<Long, Long>? {
-    val now = System.currentTimeMillis()
-    val cal = Calendar.getInstance(TimeZone.getDefault())
-
-    return when (period) {
-        "today" -> {
-            cal.set(Calendar.HOUR_OF_DAY, 0)
-            cal.set(Calendar.MINUTE, 0)
-            cal.set(Calendar.SECOND, 0)
-            cal.set(Calendar.MILLISECOND, 0)
-            cal.timeInMillis to now
-        }
-        "yesterday" -> {
-            cal.set(Calendar.HOUR_OF_DAY, 0)
-            cal.set(Calendar.MINUTE, 0)
-            cal.set(Calendar.SECOND, 0)
-            cal.set(Calendar.MILLISECOND, 0)
-            val todayMidnight = cal.timeInMillis
-            cal.add(Calendar.DAY_OF_YEAR, -1)
-            cal.timeInMillis to todayMidnight
-        }
-        "week" -> {
-            cal.add(Calendar.DAY_OF_YEAR, -7)
-            cal.timeInMillis to now
-        }
-        "month" -> {
-            cal.add(Calendar.DAY_OF_YEAR, -30)
-            cal.timeInMillis to now
-        }
-        else -> null
+    if (period == "yesterday") {
+        val zone = ZoneId.systemDefault()
+        val startOfToday = LocalDate.now(zone).atStartOfDay(zone).toInstant()
+        val startOfYesterday = startOfToday.minus(1, ChronoUnit.DAYS)
+        return startOfYesterday.toEpochMilli() to startOfToday.toEpochMilli()
     }
+    return PeriodParser.parse(period)?.let { it.startMillis to it.endMillis }
 }
 
 // ---------- Event type mapping ----------

--- a/integrations/src/test/java/com/rousecontext/integrations/health/FakeHealthConnectRepository.kt
+++ b/integrations/src/test/java/com/rousecontext/integrations/health/FakeHealthConnectRepository.kt
@@ -23,6 +23,10 @@ class FakeHealthConnectRepository : HealthConnectRepository {
     /** Canned summary response. */
     var summaryResponse: JsonObject = JsonObject(emptyMap())
 
+    /** Captures the `from`/`to` passed to the most recent [getSummary] call. */
+    var lastSummaryFrom: Instant? = null
+    var lastSummaryTo: Instant? = null
+
     /** When non-null, all methods throw this exception. */
     var shouldThrow: Exception? = null
 
@@ -49,6 +53,8 @@ class FakeHealthConnectRepository : HealthConnectRepository {
 
     override suspend fun getSummary(from: Instant, to: Instant): JsonObject {
         shouldThrow?.let { throw it }
+        lastSummaryFrom = from
+        lastSummaryTo = to
         return summaryResponse
     }
 }

--- a/integrations/src/test/java/com/rousecontext/integrations/health/HealthConnectMcpServerTest.kt
+++ b/integrations/src/test/java/com/rousecontext/integrations/health/HealthConnectMcpServerTest.kt
@@ -226,6 +226,42 @@ class HealthConnectMcpServerTest {
     }
 
     @Test
+    fun `get_health_summary today anchors range to local start of today`() = runBlocking {
+        val before = java.time.Instant.now()
+        callTool("get_health_summary", buildJsonObject { put("period", "today") })
+        val after = java.time.Instant.now()
+
+        // #496: zone is local (not UTC) and the window starts at the start of
+        // today in the local zone.
+        val zone = java.time.ZoneId.systemDefault()
+        val expectedStart = java.time.LocalDate.now(zone).atStartOfDay(zone).toInstant()
+        assertEquals(expectedStart, repo.lastSummaryFrom)
+
+        val to = repo.lastSummaryTo!!
+        assertTrue("end should be ~now", !to.isBefore(before) && !to.isAfter(after))
+    }
+
+    @Test
+    fun `get_health_summary week anchors 7 days before local start of today`() = runBlocking {
+        callTool("get_health_summary", buildJsonObject { put("period", "week") })
+
+        val zone = java.time.ZoneId.systemDefault()
+        val startOfToday = java.time.LocalDate.now(zone).atStartOfDay(zone).toInstant()
+        val expectedStart = startOfToday.minus(7, java.time.temporal.ChronoUnit.DAYS)
+        assertEquals(expectedStart, repo.lastSummaryFrom)
+    }
+
+    @Test
+    fun `get_health_summary month anchors 30 days before local start of today`() = runBlocking {
+        callTool("get_health_summary", buildJsonObject { put("period", "month") })
+
+        val zone = java.time.ZoneId.systemDefault()
+        val startOfToday = java.time.LocalDate.now(zone).atStartOfDay(zone).toInstant()
+        val expectedStart = startOfToday.minus(30, java.time.temporal.ChronoUnit.DAYS)
+        assertEquals(expectedStart, repo.lastSummaryFrom)
+    }
+
+    @Test
     fun `get_health_summary returns error for invalid period`() = runBlocking {
         val result = callTool(
             "get_health_summary",

--- a/integrations/src/test/kotlin/com/rousecontext/integrations/common/PeriodParserTest.kt
+++ b/integrations/src/test/kotlin/com/rousecontext/integrations/common/PeriodParserTest.kt
@@ -77,6 +77,34 @@ class PeriodParserTest {
     }
 
     @Test
+    fun `week start is local midnight 7 days prior across a DST spring-forward`() {
+        // America/New_York springs forward on 2026-03-08 (EST UTC-5 -> EDT UTC-4).
+        // now = 2026-03-12 10:30 EDT, so today = the 12th (EDT, UTC-4) and the
+        // window starts at the 5th, which is still EST (UTC-4 vs UTC-5).
+        val zone = ZoneId.of("America/New_York")
+        val springNow = Instant.parse("2026-03-12T14:30:00Z")
+        val range = PeriodParser.parse("week", zone, springNow)!!
+
+        // Local midnight of 2026-03-05 in EST is 05:00Z; the flat 7*86400s
+        // version lands at 04:00Z (an hour off).
+        assertEquals(Instant.parse("2026-03-05T05:00:00Z"), range.start)
+        assertEquals(springNow, range.end)
+    }
+
+    @Test
+    fun `month start is local midnight 30 days prior across a DST spring-forward`() {
+        // now = 2026-03-12 10:30 EDT; 30 days prior is 2026-02-10, still EST.
+        val zone = ZoneId.of("America/New_York")
+        val springNow = Instant.parse("2026-03-12T14:30:00Z")
+        val range = PeriodParser.parse("month", zone, springNow)!!
+
+        // Local midnight of 2026-02-10 in EST is 05:00Z; the flat 30*86400s
+        // version lands at 04:00Z (an hour off).
+        assertEquals(Instant.parse("2026-02-10T05:00:00Z"), range.start)
+        assertEquals(springNow, range.end)
+    }
+
+    @Test
     fun `week is exactly 7 days before start of today`() {
         val zone = ZoneId.of("UTC")
         val range = PeriodParser.parse("week", zone, now)!!

--- a/integrations/src/test/kotlin/com/rousecontext/integrations/common/PeriodParserTest.kt
+++ b/integrations/src/test/kotlin/com/rousecontext/integrations/common/PeriodParserTest.kt
@@ -1,0 +1,87 @@
+package com.rousecontext.integrations.common
+
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class PeriodParserTest {
+
+    // A fixed "now" that is mid-afternoon UTC so day boundaries are unambiguous.
+    private val now: Instant = Instant.parse("2026-06-18T14:30:00Z")
+
+    @Test
+    fun `today range runs from start of today to now in the given zone`() {
+        val zone = ZoneId.of("UTC")
+        val range = PeriodParser.parse("today", zone, now)!!
+
+        assertEquals(Instant.parse("2026-06-18T00:00:00Z"), range.start)
+        assertEquals(now, range.end)
+    }
+
+    @Test
+    fun `week range runs from start of today minus 7 days to now`() {
+        val zone = ZoneId.of("UTC")
+        val range = PeriodParser.parse("week", zone, now)!!
+
+        assertEquals(Instant.parse("2026-06-11T00:00:00Z"), range.start)
+        assertEquals(now, range.end)
+    }
+
+    @Test
+    fun `month range runs from start of today minus 30 days to now`() {
+        val zone = ZoneId.of("UTC")
+        val range = PeriodParser.parse("month", zone, now)!!
+
+        assertEquals(Instant.parse("2026-05-19T00:00:00Z"), range.start)
+        assertEquals(now, range.end)
+    }
+
+    @Test
+    fun `start of today is anchored in the local zone not UTC`() {
+        // In New York (UTC-4 on this date) 14:30 UTC is 10:30 local, still the 18th,
+        // so start-of-today-local is 2026-06-18T04:00:00Z.
+        val zone = ZoneId.of("America/New_York")
+        val range = PeriodParser.parse("today", zone, now)!!
+
+        assertEquals(Instant.parse("2026-06-18T04:00:00Z"), range.start)
+        assertEquals(now, range.end)
+    }
+
+    @Test
+    fun `start of today respects a zone where local date is already the next day`() {
+        // In Kiritimati (UTC+14) 14:30 UTC is 04:30 on the 19th local,
+        // so start-of-today-local is 2026-06-19T00:00+14:00 == 2026-06-18T10:00:00Z.
+        val zone = ZoneId.of("Pacific/Kiritimati")
+        val range = PeriodParser.parse("today", zone, now)!!
+
+        assertEquals(Instant.parse("2026-06-18T10:00:00Z"), range.start)
+        assertEquals(now, range.end)
+    }
+
+    @Test
+    fun `unrecognised period returns null`() {
+        assertNull(PeriodParser.parse("year", ZoneId.of("UTC"), now))
+        assertNull(PeriodParser.parse("yesterday", ZoneId.of("UTC"), now))
+        assertNull(PeriodParser.parse("", ZoneId.of("UTC"), now))
+    }
+
+    @Test
+    fun `PeriodRange exposes epoch millis accessors`() {
+        val range = PeriodParser.parse("today", ZoneId.of("UTC"), now)!!
+
+        assertEquals(Instant.parse("2026-06-18T00:00:00Z").toEpochMilli(), range.startMillis)
+        assertEquals(now.toEpochMilli(), range.endMillis)
+    }
+
+    @Test
+    fun `week is exactly 7 days before start of today`() {
+        val zone = ZoneId.of("UTC")
+        val range = PeriodParser.parse("week", zone, now)!!
+        val today = PeriodParser.parse("today", zone, now)!!
+
+        assertEquals(today.start.minus(7, ChronoUnit.DAYS), range.start)
+    }
+}

--- a/integrations/src/test/kotlin/com/rousecontext/integrations/usage/ParsePeriodTest.kt
+++ b/integrations/src/test/kotlin/com/rousecontext/integrations/usage/ParsePeriodTest.kt
@@ -1,0 +1,83 @@
+package com.rousecontext.integrations.usage
+
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Tests for the usage-only `yesterday` extra in [parsePeriod].
+ *
+ * `yesterday` is NOT handled by the shared `PeriodParser` (it is a usage-only
+ * extra resolved at this call site), so its DST contract is exercised here.
+ *
+ * Contract: `yesterday` resolves to the prior calendar day in the given zone,
+ * `[local-midnight-of-yesterday, local-midnight-of-today]`. Because it uses
+ * LocalDate arithmetic, the window correctly spans 23h on spring-forward days
+ * and 25h on fall-back days — a flat 86_400s subtraction off an Instant would
+ * get this wrong (see #500 review).
+ */
+class ParsePeriodTest {
+
+    private val ny = ZoneId.of("America/New_York")
+
+    @Test
+    fun `yesterday is a 23h window on a spring-forward day`() {
+        // DST spring-forward in America/New_York is 2026-03-08 02:00 EST -> 03:00 EDT.
+        // "yesterday" relative to mid-morning on the 9th is the 8th, a 23h day.
+        val now = Instant.parse("2026-03-09T14:30:00Z") // 10:30 EDT on the 9th
+        val (start, end) = parsePeriod("yesterday", ny, now)!!
+
+        // Start of the 8th is local midnight EST (UTC-5); start of the 9th is
+        // local midnight EDT (UTC-4) because the clocks already sprang forward.
+        assertEquals(Instant.parse("2026-03-08T05:00:00Z").toEpochMilli(), start)
+        assertEquals(Instant.parse("2026-03-09T04:00:00Z").toEpochMilli(), end)
+        assertEquals(Duration.ofHours(23).toMillis(), end - start)
+    }
+
+    @Test
+    fun `yesterday is a 25h window on a fall-back day`() {
+        // DST fall-back in America/New_York is 2026-11-01 02:00 EDT -> 01:00 EST.
+        // "yesterday" relative to mid-morning on the 2nd is the 1st, a 25h day.
+        val now = Instant.parse("2026-11-02T14:30:00Z") // 09:30 EST on the 2nd
+        val (start, end) = parsePeriod("yesterday", ny, now)!!
+
+        // Start of the 1st is local midnight EDT (UTC-4); start of the 2nd is
+        // local midnight EST (UTC-5) because the clocks fell back.
+        assertEquals(Instant.parse("2026-11-01T04:00:00Z").toEpochMilli(), start)
+        assertEquals(Instant.parse("2026-11-02T05:00:00Z").toEpochMilli(), end)
+        assertEquals(Duration.ofHours(25).toMillis(), end - start)
+    }
+
+    @Test
+    fun `yesterday is a plain 24h window on a non-transition day`() {
+        val now = Instant.parse("2026-06-18T14:30:00Z") // 10:30 EDT
+        val (start, end) = parsePeriod("yesterday", ny, now)!!
+
+        assertEquals(Instant.parse("2026-06-17T04:00:00Z").toEpochMilli(), start)
+        assertEquals(Instant.parse("2026-06-18T04:00:00Z").toEpochMilli(), end)
+        assertEquals(Duration.ofHours(24).toMillis(), end - start)
+    }
+
+    @Test
+    fun `parsePeriod delegates today week month to the shared parser`() {
+        val now = Instant.parse("2026-06-18T14:30:00Z")
+        val zone = ZoneId.of("UTC")
+
+        assertEquals(
+            Instant.parse("2026-06-18T00:00:00Z").toEpochMilli() to now.toEpochMilli(),
+            parsePeriod("today", zone, now)
+        )
+        assertEquals(
+            Instant.parse("2026-06-11T00:00:00Z").toEpochMilli() to now.toEpochMilli(),
+            parsePeriod("week", zone, now)
+        )
+    }
+
+    @Test
+    fun `parsePeriod returns null for unrecognised period`() {
+        assertNull(parsePeriod("year", ny, Instant.parse("2026-06-18T14:30:00Z")))
+    }
+}


### PR DESCRIPTION
Closes #496

## What

The usage, notification, and Health Connect MCP providers each parsed the `period` argument differently. This unifies them on a single shared `PeriodParser` with the approved semantics:

- **Zone:** local (`ZoneId.systemDefault()`).
- **Anchoring:** sliding window ending at `now`, anchored to the start of today:
  - `today` = `[start-of-today, now]`
  - `week` = `[start-of-today - 7d, now]`
  - `month` = `[start-of-today - 30d, now]`
- **Enum:** `today|week|month` aligned across all three; `yesterday` kept as a usage-only extra (resolved locally before delegating).

## Behavior change (intended)

Health Connect previously stamped local-date-midnight as UTC (shifting "today" for non-UTC users) and anchored week/month to `now`. It now matches the others (local zone, start-of-today anchoring).

## Consumer-facing

The MCP tool `period` param descriptions now document the zone + anchoring so calling agents can reason about the window.

## Tests

- New `PeriodParserTest` covering zone (local + non-UTC zones incl. next-day-local), each period's boundaries, and the millis accessors.
- `FakeHealthConnectRepository` now captures the range passed to `getSummary`; new `HealthConnectMcpServerTest` cases assert the new local/start-of-today ranges for today/week/month.
- Existing provider tests pass unchanged (they assert relative behavior / period echo, not absolute ranges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)